### PR TITLE
Fix bookmark view routing and add TypeScript type checking to test pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: tests build run mcp-server migrate backend-lint unit_tests pen_tests frontend-install frontend-build frontend-dev frontend-tests frontend-lint
+.PHONY: tests build run mcp-server migrate backend-lint unit_tests pen_tests frontend-install frontend-build frontend-dev frontend-tests frontend-lint frontend-typecheck
 
 -include .env
 export
@@ -35,6 +35,9 @@ frontend-build:  ## Build frontend for production
 
 frontend-lint:  ## Run frontend linter
 	cd frontend && npm run lint
+
+frontend-typecheck:  ## Run TypeScript type checking
+	cd frontend && npx tsc --noEmit
 
 frontend-tests:  ## Run frontend tests
 	cd frontend && npm run test:run
@@ -73,7 +76,7 @@ backend-tests:  ## Run backend unit tests with coverage
 
 lint: backend-lint frontend-lint  ## Run all linters
 
-tests: backend-lint backend-tests frontend-lint frontend-tests ## Run linting + all tests
+tests: backend-lint backend-tests frontend-lint frontend-typecheck frontend-tests ## Run linting + all tests
 
 pen_tests:  ## Run live penetration tests (requires SECURITY_TEST_USER_A_PAT and SECURITY_TEST_USER_B_PAT in .env)
 	uv run pytest backend/tests/security/test_live_penetration.py -v

--- a/frontend/src/hooks/useBookmarkView.ts
+++ b/frontend/src/hooks/useBookmarkView.ts
@@ -3,10 +3,10 @@
  *
  * Replaces useTabNavigation for route-based navigation.
  * Routes:
- * - /bookmarks → view: 'active', listId: undefined
- * - /bookmarks/archived → view: 'archived', listId: undefined
- * - /bookmarks/trash → view: 'deleted', listId: undefined
- * - /bookmarks/lists/:listId → view: 'active', listId: number
+ * - /app/bookmarks → view: 'active', listId: undefined
+ * - /app/bookmarks/archived → view: 'archived', listId: undefined
+ * - /app/bookmarks/trash → view: 'deleted', listId: undefined
+ * - /app/bookmarks/lists/:listId → view: 'active', listId: number
  */
 import { useMemo } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
@@ -38,15 +38,15 @@ export function useBookmarkView(): UseBookmarkViewReturn {
   const { currentView, currentListId } = useMemo(() => {
     const path = location.pathname
 
-    if (path === '/bookmarks/archived') {
+    if (path === '/app/bookmarks/archived') {
       return { currentView: 'archived' as BookmarkView, currentListId: undefined }
     }
 
-    if (path === '/bookmarks/trash') {
+    if (path === '/app/bookmarks/trash') {
       return { currentView: 'deleted' as BookmarkView, currentListId: undefined }
     }
 
-    if (path.startsWith('/bookmarks/lists/') && params.listId) {
+    if (path.startsWith('/app/bookmarks/lists/') && params.listId) {
       const listId = parseInt(params.listId, 10)
       return {
         currentView: 'active' as BookmarkView,
@@ -54,7 +54,7 @@ export function useBookmarkView(): UseBookmarkViewReturn {
       }
     }
 
-    // Default: /bookmarks
+    // Default: /app/bookmarks
     return { currentView: 'active' as BookmarkView, currentListId: undefined }
   }, [location.pathname, params.listId])
 


### PR DESCRIPTION
# Summary

Fixes a bug where archived, trash, and custom list bookmark views weren't working due to incorrect route path matching. Also fixes TypeScript build errors that were caught in production but not locally, and adds TypeScript type checking to make tests to prevent similar issues.

## Changes

- Fixed route matching in useBookmarkView.ts: Updated paths from /bookmarks/* to /app/bookmarks/* to match actual route configuration (archived, trash, and list views were broken)
- Fixed TypeScript errors in api.test.ts: Added missing mock properties (consent, currentPrivacyVersion, currentTermsVersion, error) and proper type casting for axios interceptor internals
- Added frontend-typecheck to Makefile: New target runs tsc --noEmit and is included in the tests target to catch type errors before deployment

## Testing

- All frontend tests pass (348 tests)
- npm run build succeeds (runs tsc -b which performs type checking)
- make frontend-typecheck runs successfully

# Impact

- Root cause: Tests passed locally because Vitest uses esbuild (skips type checking), but Railway build runs tsc -b first
- Prevention: make tests now includes TypeScript type checking, so similar issues will be caught before pushing
- No breaking changes