### PR TITLE
Misc fixes: shortcuts dialog, list wrap, editor, nav, limits

### DIFF
--- a/backend/src/core/tier_limits.py
+++ b/backend/src/core/tier_limits.py
@@ -83,7 +83,7 @@ _FIELD_LENGTHS = {
     "max_url_length": 2048,
     "max_prompt_name_length": 100,
     "max_argument_name_length": 100,
-    "max_argument_description_length": 500,
+    "max_argument_description_length": 1000,
 }
 
 TIER_LIMITS: dict[Tier, TierLimits] = {

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -273,7 +273,7 @@ If you need scripted access to these, authenticate with an Auth0 session.
 - `Alt+L`: Toggle line numbers.
 - `Alt+M`: Toggle monospace font.
 - `Alt+T`: Toggle table of contents sidebar (navigable list of headings).
-- Standard formatting: `Cmd+B` (bold), `Cmd+I` (italic), `Cmd+E` (inline code), `Cmd+K` (link), `Cmd+Shift+E` (code block), `Cmd+Shift+8` (bullet list), `Cmd+Shift+7` (numbered list), `Cmd+Shift+9` (task list).
+- Standard formatting: `Cmd+B` (bold), `Cmd+I` (italic), `Cmd+E` (inline code), `Cmd+K` (link), `Cmd+Shift+E` (code block), `Cmd+Shift+7` (bullet list), `Cmd+Shift+8` (numbered list), `Cmd+Shift+9` (checklist).
 
 ## Platform
 

--- a/frontend/src/components/CodeMirrorEditor.tsx
+++ b/frontend/src/components/CodeMirrorEditor.tsx
@@ -31,7 +31,7 @@ import {
   LinkIcon,
   BulletListIcon,
   OrderedListIcon,
-  TaskListIcon,
+  ChecklistIcon,
   BlockquoteIcon,
   HorizontalRuleIcon,
   HeadingIcon,
@@ -75,7 +75,7 @@ const LINE_PREFIXES = {
   blockquote: '> ',
   bulletList: '- ',
   numberedList: '1. ',
-  taskList: '- [ ] ',
+  checklist: '- [ ] ',
 } as const
 
 interface CodeMirrorEditorProps {
@@ -165,10 +165,10 @@ function createMarkdownKeyBindings(): KeyBinding[] {
     // Code
     { key: 'Mod-e', run: ifWritable((view) => toggleWrapMarkers(view, MARKERS.inlineCode.before, MARKERS.inlineCode.after)) },
     { key: 'Mod-Shift-e', run: ifWritable((view) => insertCodeBlock(view)) },
-    // Lists (Notion convention: 7=numbered, 8=bullet, 9=task)
-    { key: 'Mod-Shift-7', run: ifWritable((view) => toggleLinePrefix(view, LINE_PREFIXES.numberedList)) },
-    { key: 'Mod-Shift-8', run: ifWritable((view) => toggleLinePrefix(view, LINE_PREFIXES.bulletList)) },
-    { key: 'Mod-Shift-9', run: ifWritable((view) => toggleLinePrefix(view, LINE_PREFIXES.taskList)) },
+    // Lists (matches toolbar/menu order: 7=bullet, 8=numbered, 9=checklist)
+    { key: 'Mod-Shift-7', run: ifWritable((view) => toggleLinePrefix(view, LINE_PREFIXES.bulletList)) },
+    { key: 'Mod-Shift-8', run: ifWritable((view) => toggleLinePrefix(view, LINE_PREFIXES.numberedList)) },
+    { key: 'Mod-Shift-9', run: ifWritable((view) => toggleLinePrefix(view, LINE_PREFIXES.checklist)) },
     // Links and other
     { key: 'Mod-k', run: ifWritable((view) => insertLink(view)) },
     { key: 'Mod-Shift--', run: ifWritable((view) => insertHorizontalRule(view)) },
@@ -418,7 +418,7 @@ export function CodeMirrorEditor({
       link: () => <LinkIcon />,
       bulletList: () => <BulletListIcon />,
       orderedList: () => <OrderedListIcon />,
-      taskList: () => <TaskListIcon />,
+      checklist: () => <ChecklistIcon />,
       blockquote: () => <BlockquoteIcon />,
       horizontalRule: () => <HorizontalRuleIcon />,
       heading1: () => <HeadingIcon level={1} />,
@@ -630,14 +630,14 @@ export function CodeMirrorEditor({
           <ToolbarSeparator />
 
           {/* Lists */}
-          <ToolbarButton onClick={() => runAction((v) => toggleLinePrefix(v, LINE_PREFIXES.bulletList))} title="Bullet List (⌘⇧8)">
+          <ToolbarButton onClick={() => runAction((v) => toggleLinePrefix(v, LINE_PREFIXES.bulletList))} title="Bullet List (⌘⇧7)">
             <BulletListIcon />
           </ToolbarButton>
-          <ToolbarButton onClick={() => runAction((v) => toggleLinePrefix(v, LINE_PREFIXES.numberedList))} title="Numbered List (⌘⇧7)">
+          <ToolbarButton onClick={() => runAction((v) => toggleLinePrefix(v, LINE_PREFIXES.numberedList))} title="Numbered List (⌘⇧8)">
             <OrderedListIcon />
           </ToolbarButton>
-          <ToolbarButton onClick={() => runAction((v) => toggleLinePrefix(v, LINE_PREFIXES.taskList))} title="Task List (⌘⇧9)">
-            <TaskListIcon />
+          <ToolbarButton onClick={() => runAction((v) => toggleLinePrefix(v, LINE_PREFIXES.checklist))} title="Checklist (⌘⇧9)">
+            <ChecklistIcon />
           </ToolbarButton>
 
           <ToolbarSeparator />

--- a/frontend/src/components/MilkdownEditor.tsx
+++ b/frontend/src/components/MilkdownEditor.tsx
@@ -129,7 +129,7 @@ import {
   LinkIcon,
   BulletListIcon,
   OrderedListIcon,
-  TaskListIcon,
+  ChecklistIcon,
   BlockquoteIcon,
   HorizontalRuleIcon,
   JinjaVariableIcon,
@@ -198,13 +198,13 @@ interface EditorToolbarProps {
   onCodeBlockToggle: () => void
   onBulletListClick: () => void
   onOrderedListClick: () => void
-  onTaskListClick: () => void
+  onChecklistClick: () => void
   showJinjaTools?: boolean
   /** Content to copy (for always-visible copy button) */
   copyContent?: string
 }
 
-function EditorToolbar({ getEditor, onLinkClick, onCodeBlockToggle, onBulletListClick, onOrderedListClick, onTaskListClick, showJinjaTools = false, copyContent }: EditorToolbarProps): ReactNode {
+function EditorToolbar({ getEditor, onLinkClick, onCodeBlockToggle, onBulletListClick, onOrderedListClick, onChecklistClick, showJinjaTools = false, copyContent }: EditorToolbarProps): ReactNode {
   const runCommand = useCallback(
     (command: Parameters<typeof callCommand>[0]) => {
       const editor = getEditor()
@@ -280,8 +280,8 @@ function EditorToolbar({ getEditor, onLinkClick, onCodeBlockToggle, onBulletList
         <ToolbarButton onAction={onOrderedListClick} title="Numbered List (⌘⇧8)">
           <OrderedListIcon />
         </ToolbarButton>
-        <ToolbarButton onAction={onTaskListClick} title="Task List (⌘⇧9)">
-          <TaskListIcon />
+        <ToolbarButton onAction={onChecklistClick} title="Checklist (⌘⇧9)">
+          <ChecklistIcon />
         </ToolbarButton>
 
         <ToolbarSeparator />
@@ -320,7 +320,7 @@ function EditorToolbar({ getEditor, onLinkClick, onCodeBlockToggle, onBulletList
 }
 
 /**
- * Width of the clickable area for task list checkboxes (in pixels).
+ * Width of the clickable area for checklist checkboxes (in pixels).
  * This matches the checkbox pseudo-element which is 16px wide (w-4) in index.css.
  * Only clicks directly on the checkbox should toggle it, not clicks in the gap.
  */
@@ -1026,7 +1026,11 @@ function MilkdownEditorInner({
 
   /**
    * Get the current list context for the selection.
-   * Returns { listType, listItemDepth, listDepth, isTask } or null if not in a list.
+   * Returns { listType, listItemDepth, listDepth, isChecklist } or null if not in a list.
+   *
+   * Note: list_item.attrs.checked is part of Milkdown's GFM schema — a non-null
+   * value (true/false) marks the item as a checklist entry; null means a plain
+   * bullet/numbered item.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getListContext = useCallback((view: any) => {
@@ -1055,11 +1059,10 @@ function MilkdownEditorInner({
       }
     }
 
-    // Check if it's a task list item
     const listItem = $from.node(listItemDepth)
-    const isTask = listItem.attrs.checked !== null
+    const isChecklist = listItem.attrs.checked !== null
 
-    return { listType, listItemDepth, listDepth, isTask }
+    return { listType, listItemDepth, listDepth, isChecklist }
   }, [])
 
   // Handle toolbar bullet list button click - toggle behavior
@@ -1077,19 +1080,19 @@ function MilkdownEditorInner({
       return
     }
 
-    const { listType, listItemDepth, isTask } = ctx
+    const { listType, listItemDepth, isChecklist } = ctx
 
-    if (listType === 'bullet_list' && !isTask) {
-      // Already in bullet list (not task) - lift out
+    if (listType === 'bullet_list' && !isChecklist) {
+      // Already in plain bullet list (not a checklist) - lift out
       const listItemNodeType = view.state.schema.nodes.list_item
       liftListItem(listItemNodeType)(view.state, view.dispatch)
       view.focus()
       return
     }
 
-    // In ordered list or task list - convert to bullet list
-    // First, if it's a task, remove the checked attribute
-    if (isTask) {
+    // In ordered list or checklist - convert to bullet list.
+    // If it's a checklist, clear the GFM `checked` attribute first.
+    if (isChecklist) {
       const { $from } = view.state.selection
       const listItem = $from.node(listItemDepth)
       const listItemPos = $from.before(listItemDepth)
@@ -1127,7 +1130,7 @@ function MilkdownEditorInner({
       return
     }
 
-    const { listType, listItemDepth, isTask } = ctx
+    const { listType, listItemDepth, isChecklist } = ctx
 
     if (listType === 'ordered_list') {
       // Already in ordered list - lift out
@@ -1137,9 +1140,9 @@ function MilkdownEditorInner({
       return
     }
 
-    // In bullet list or task list - convert to ordered list
-    // First, if it's a task, remove the checked attribute
-    if (isTask) {
+    // In bullet list or checklist - convert to ordered list.
+    // If it's a checklist, clear the GFM `checked` attribute first.
+    if (isChecklist) {
       const { $from } = view.state.selection
       const listItem = $from.node(listItemDepth)
       const listItemPos = $from.before(listItemDepth)
@@ -1162,8 +1165,8 @@ function MilkdownEditorInner({
     view.focus()
   }, [get, getListContext])
 
-  // Handle toolbar task list button click
-  const handleTaskListClick = useCallback(() => {
+  // Handle toolbar checklist button click
+  const handleChecklistClick = useCallback(() => {
     const editor = get()
     if (!editor) return
 
@@ -1171,10 +1174,10 @@ function MilkdownEditorInner({
     const ctx = getListContext(view)
 
     if (!ctx) {
-      // Not in a list - first create a bullet list, then convert to task
+      // Not in a list - first create a bullet list, then convert to a checklist
       editor.action(callCommand(wrapInBulletListCommand.key))
-      // After creating bullet list, find and convert the list item to task
-      // Need to get fresh state after the command
+      // After creating bullet list, find and set the GFM `checked` attribute
+      // on the list item. Need to get fresh state after the command.
       setTimeout(() => {
         if (!isMountedRef.current) return
         try {
@@ -1201,18 +1204,18 @@ function MilkdownEditorInner({
       return
     }
 
-    const { isTask } = ctx
+    const { isChecklist } = ctx
 
-    if (isTask) {
-      // Already a task - lift out of list entirely (consistent with bullet/ordered list toggle)
+    if (isChecklist) {
+      // Already a checklist - lift out of list entirely (consistent with bullet/ordered list toggle)
       const listItemNodeType = view.state.schema.nodes.list_item
       liftListItem(listItemNodeType)(view.state, view.dispatch)
       view.focus()
       return
     }
 
-    // In a list but not a task - convert to task
-    // If in ordered list, first convert to bullet list
+    // In a list but not a checklist - convert to a checklist.
+    // If in ordered list, first convert to bullet list.
     if (ctx.listType === 'ordered_list') {
       const { $from } = view.state.selection
       const listPos = $from.before(ctx.listDepth)
@@ -1314,24 +1317,24 @@ function MilkdownEditorInner({
         return
       }
 
-      // Cmd+Shift+7 - Bullet list
+      // Cmd+Shift+7 - Bullet list (matches toolbar/menu order: 7=bullet, 8=numbered, 9=checklist)
       if (isMod && e.shiftKey && e.key === '7') {
         e.preventDefault()
         handleBulletListClick()
         return
       }
 
-      // Cmd+Shift+8 - Ordered list
+      // Cmd+Shift+8 - Numbered list
       if (isMod && e.shiftKey && e.key === '8') {
         e.preventDefault()
         handleOrderedListClick()
         return
       }
 
-      // Cmd+Shift+9 - Task list
+      // Cmd+Shift+9 - Checklist
       if (isMod && e.shiftKey && e.key === '9') {
         e.preventDefault()
-        handleTaskListClick()
+        handleChecklistClick()
         return
       }
 
@@ -1350,7 +1353,7 @@ function MilkdownEditorInner({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [get, runCommand, handleCodeBlockToggle, handleBulletListClick, handleOrderedListClick, handleTaskListClick, handleToolbarLinkClick]
+    [get, runCommand, handleCodeBlockToggle, handleBulletListClick, handleOrderedListClick, handleChecklistClick, handleToolbarLinkClick]
   )
 
   // Handle mouse down - checkbox toggle and focus on empty space
@@ -1362,11 +1365,14 @@ function MilkdownEditorInner({
       // Don't interfere with clicks on any content elements (let ProseMirror handle them)
       const isContentClick = target.closest('p, li, h1, h2, h3, h4, h5, h6, blockquote, pre, code, a, ul, ol, table, td, th, tr')
 
-      const taskListItem = target.closest('li[data-item-type="task"]') as HTMLElement | null
+      // Note: Milkdown's GFM plugin tags checklist items with
+      // `data-item-type="task"` — that attribute name is owned upstream and
+      // can't be renamed. We surface it as "Checklist" everywhere in our UI.
+      const checklistItem = target.closest('li[data-item-type="task"]') as HTMLElement | null
 
-      if (taskListItem) {
+      if (checklistItem) {
         // Check if click was on the checkbox area (left side of the item)
-        const rect = taskListItem.getBoundingClientRect()
+        const rect = checklistItem.getBoundingClientRect()
         const clickX = e.clientX - rect.left
 
         if (clickX < CHECKBOX_CLICK_AREA_WIDTH) {
@@ -1375,7 +1381,7 @@ function MilkdownEditorInner({
             const view = editor.ctx.get(editorViewCtx)
 
             // Find the position of this list item in the ProseMirror document
-            const pos = view.posAtDOM(taskListItem, 0)
+            const pos = view.posAtDOM(checklistItem, 0)
             if (pos === null || pos === undefined) return
 
             // Find the node at this position
@@ -1430,7 +1436,7 @@ function MilkdownEditorInner({
 
   return (
     <>
-      {!disabled && !readOnly && <EditorToolbar getEditor={get} onLinkClick={handleToolbarLinkClick} onCodeBlockToggle={handleCodeBlockToggle} onBulletListClick={handleBulletListClick} onOrderedListClick={handleOrderedListClick} onTaskListClick={handleTaskListClick} showJinjaTools={showJinjaTools} copyContent={copyContent} />}
+      {!disabled && !readOnly && <EditorToolbar getEditor={get} onLinkClick={handleToolbarLinkClick} onCodeBlockToggle={handleCodeBlockToggle} onBulletListClick={handleBulletListClick} onOrderedListClick={handleOrderedListClick} onChecklistClick={handleChecklistClick} showJinjaTools={showJinjaTools} copyContent={copyContent} />}
       <div
         className={`milkdown-wrapper ${disabled ? 'opacity-50 pointer-events-none' : ''} ${noPadding ? 'no-padding' : ''}`}
         style={{ minHeight }}
@@ -1457,7 +1463,7 @@ function MilkdownEditorInner({
  * Features:
  * - Rich editing with inline markdown rendering
  * - Keyboard shortcuts (Cmd+B, Cmd+I, Cmd+K)
- * - Task list checkbox toggling
+ * - Checklist checkbox toggling
  * - Placeholder text when empty
  * - Copy/paste preserves markdown
  *

--- a/frontend/src/components/PublicHeader.tsx
+++ b/frontend/src/components/PublicHeader.tsx
@@ -57,6 +57,7 @@ export function PublicHeader(): ReactNode {
   const location = useLocation()
 
   const [productOpen, setProductOpen] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
   const [prevPath, setPrevPath] = useState(location.pathname)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
@@ -73,10 +74,11 @@ export function PublicHeader(): ReactNode {
     }
   }, [productOpen])
 
-  // Close dropdown on route change
+  // Close menus on route change
   if (prevPath !== location.pathname) {
     setPrevPath(location.pathname)
     if (productOpen) setProductOpen(false)
+    if (mobileOpen) setMobileOpen(false)
   }
 
   // Show border when scrolled
@@ -152,7 +154,7 @@ export function PublicHeader(): ReactNode {
           </nav>
         </div>
 
-        {/* Right: Auth buttons */}
+        {/* Right: Auth buttons + mobile menu toggle */}
         <div className="flex items-center gap-3">
           {isAuthenticated || isDevMode ? (
             <PrefetchLink
@@ -164,8 +166,72 @@ export function PublicHeader(): ReactNode {
           ) : (
             <AuthButtons />
           )}
+          <button
+            type="button"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={mobileOpen}
+            aria-controls="public-mobile-menu"
+            className="-mr-1 inline-flex h-9 w-9 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 sm:hidden"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              {mobileOpen ? (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              )}
+            </svg>
+          </button>
         </div>
       </div>
+
+      {/* Mobile nav panel */}
+      {mobileOpen && (
+        <div
+          id="public-mobile-menu"
+          className="border-t border-gray-200/60 bg-white sm:hidden"
+        >
+          <nav className="mx-auto flex max-w-5xl flex-col gap-1 px-6 py-3">
+            <div className="px-3 pb-1 pt-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
+              Product
+            </div>
+            {productItems.map((item) => (
+              <PrefetchLink
+                key={item.path}
+                to={item.path}
+                className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  isActiveLink(item.path)
+                    ? 'bg-gray-100 text-gray-900'
+                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                }`}
+              >
+                {item.label}
+              </PrefetchLink>
+            ))}
+            <div className="my-1 border-t border-gray-100" />
+            <PrefetchLink
+              to="/docs"
+              className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                isActiveLink('/docs')
+                  ? 'bg-gray-100 text-gray-900'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+              }`}
+            >
+              Docs
+            </PrefetchLink>
+            <PrefetchLink
+              to="/pricing"
+              className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                isActiveLink('/pricing')
+                  ? 'bg-gray-100 text-gray-900'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+              }`}
+            >
+              Pricing
+            </PrefetchLink>
+          </nav>
+        </div>
+      )}
     </header>
   )
 }

--- a/frontend/src/components/ShortcutsDialog.test.tsx
+++ b/frontend/src/components/ShortcutsDialog.test.tsx
@@ -18,68 +18,15 @@ describe('ShortcutsDialog', () => {
     expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument()
   })
 
-  it('should call onClose when Escape is pressed', () => {
+  // Wiring smoke test: verifies onClose is plumbed through to Modal.
+  // Does NOT test Modal's dismissal mechanism — that lives in Modal.test.tsx.
+  it('forwards dismissal to the onClose prop', () => {
     const onClose = vi.fn()
     render(<ShortcutsDialog isOpen={true} onClose={onClose} />)
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
     expect(onClose).toHaveBeenCalledTimes(1)
-  })
-
-  it('should prevent Escape from reaching other handlers (capture phase + stopImmediatePropagation)', () => {
-    const onClose = vi.fn()
-    const otherHandler = vi.fn()
-
-    // Add another document-level event listener BEFORE rendering the dialog
-    // This simulates a component like Note that was mounted first
-    // Using bubbling phase (default) - this is how Note.tsx adds its listener
-    document.addEventListener('keydown', otherHandler)
-
-    render(<ShortcutsDialog isOpen={true} onClose={onClose} />)
-
-    // Create and dispatch a real KeyboardEvent
-    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
-    document.dispatchEvent(event)
-
-    // Dialog should close
-    expect(onClose).toHaveBeenCalledTimes(1)
-
-    // The other handler should NOT be called because:
-    // 1. Dialog uses capture phase (runs first)
-    // 2. Dialog calls stopImmediatePropagation (prevents bubbling phase)
-    expect(otherHandler).not.toHaveBeenCalled()
-
-    document.removeEventListener('keydown', otherHandler)
-  })
-
-  it('should call onClose when close button is clicked', () => {
-    const onClose = vi.fn()
-    render(<ShortcutsDialog isOpen={true} onClose={onClose} />)
-
-    fireEvent.click(screen.getByRole('button', { name: /close dialog/i }))
-
-    expect(onClose).toHaveBeenCalledTimes(1)
-  })
-
-  it('should call onClose when backdrop is clicked', () => {
-    const onClose = vi.fn()
-    render(<ShortcutsDialog isOpen={true} onClose={onClose} />)
-
-    // Click on the backdrop (the outer div with modal-backdrop class)
-    fireEvent.click(screen.getByRole('dialog'))
-
-    expect(onClose).toHaveBeenCalledTimes(1)
-  })
-
-  it('should not close when clicking inside the dialog content', () => {
-    const onClose = vi.fn()
-    render(<ShortcutsDialog isOpen={true} onClose={onClose} />)
-
-    // Click on the dialog content (not the backdrop)
-    fireEvent.click(screen.getByText('Keyboard Shortcuts'))
-
-    expect(onClose).not.toHaveBeenCalled()
   })
 
   it('should display shortcut groups', () => {

--- a/frontend/src/components/ShortcutsDialog.tsx
+++ b/frontend/src/components/ShortcutsDialog.tsx
@@ -75,10 +75,10 @@ const rightColumnGroups: ShortcutGroup[] = [
       // Code
       { keys: ['\u2318', 'E'], description: 'Inline code' },
       { keys: ['\u2318', '\u21E7', 'E'], description: 'Code block' },
-      // Lists (Notion convention: 7=numbered, 8=bullet, 9=task)
-      { keys: ['\u2318', '\u21E7', '8'], description: 'Bullet list' },
-      { keys: ['\u2318', '\u21E7', '7'], description: 'Numbered list' },
-      { keys: ['\u2318', '\u21E7', '9'], description: 'Task list' },
+      // Lists (matches toolbar/menu order: 7=bullet, 8=numbered, 9=checklist)
+      { keys: ['\u2318', '\u21E7', '7'], description: 'Bullet list' },
+      { keys: ['\u2318', '\u21E7', '8'], description: 'Numbered list' },
+      { keys: ['\u2318', '\u21E7', '9'], description: 'Checklist' },
       // Links and other
       { keys: ['\u2318', 'K'], description: 'Insert link' },
       { keys: ['\u2318', '\u21E7', '-'], description: 'Horizontal rule' },

--- a/frontend/src/components/ShortcutsDialog.tsx
+++ b/frontend/src/components/ShortcutsDialog.tsx
@@ -1,8 +1,8 @@
 /**
  * Dialog showing available keyboard shortcuts.
  */
-import { useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
+import { Modal } from './ui/Modal'
 
 interface ShortcutsDialogProps {
   /** Whether the dialog is open */
@@ -11,20 +11,17 @@ interface ShortcutsDialogProps {
   onClose: () => void
 }
 
-/** Keyboard shortcut definition */
 interface Shortcut {
   keys: string[]
   description: string
 }
 
-/** Shortcut group with title */
 interface ShortcutGroup {
   title: string
   subtitle?: string
   shortcuts: Shortcut[]
 }
 
-// Left column groups: Actions, Navigation, View
 const leftColumnGroups: ShortcutGroup[] = [
   {
     title: 'Actions',
@@ -60,38 +57,29 @@ const leftColumnGroups: ShortcutGroup[] = [
   },
 ]
 
-// Right column: Markdown Editor formatting shortcuts
 // Order matches toolbar layout in CodeMirrorEditor
 const rightColumnGroups: ShortcutGroup[] = [
   {
     title: 'Markdown Editor',
     shortcuts: [
-      // Text formatting (matches toolbar order)
       { keys: ['\u2318', 'B'], description: 'Bold' },
       { keys: ['\u2318', 'I'], description: 'Italic' },
       { keys: ['\u2318', '\u21E7', 'X'], description: 'Strikethrough' },
       { keys: ['\u2318', '\u21E7', 'H'], description: 'Highlight' },
       { keys: ['\u2318', '\u21E7', '.'], description: 'Blockquote' },
-      // Code
       { keys: ['\u2318', 'E'], description: 'Inline code' },
       { keys: ['\u2318', '\u21E7', 'E'], description: 'Code block' },
-      // Lists (matches toolbar/menu order: 7=bullet, 8=numbered, 9=checklist)
       { keys: ['\u2318', '\u21E7', '7'], description: 'Bullet list' },
       { keys: ['\u2318', '\u21E7', '8'], description: 'Numbered list' },
       { keys: ['\u2318', '\u21E7', '9'], description: 'Checklist' },
-      // Links and other
       { keys: ['\u2318', 'K'], description: 'Insert link' },
       { keys: ['\u2318', '\u21E7', '-'], description: 'Horizontal rule' },
       { keys: ['\u2318', 'Click'], description: 'Open link in new tab' },
-      // Selection
       { keys: ['\u2318', 'D'], description: 'Select next occurrence' },
     ],
   },
 ]
 
-/**
- * Renders a keyboard key badge.
- */
 function KeyBadge({ children }: { children: ReactNode }): ReactNode {
   return (
     <kbd className="inline-flex min-w-[24px] items-center justify-center rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 font-mono text-xs font-medium text-gray-700 shadow-sm">
@@ -100,9 +88,6 @@ function KeyBadge({ children }: { children: ReactNode }): ReactNode {
   )
 }
 
-/**
- * Renders a group of shortcuts with a title.
- */
 function ShortcutGroupSection({ group }: { group: ShortcutGroup }): ReactNode {
   return (
     <div>
@@ -142,112 +127,26 @@ function ShortcutGroupSection({ group }: { group: ShortcutGroup }): ReactNode {
   )
 }
 
-/**
- * ShortcutsDialog displays available keyboard shortcuts.
- *
- * Features:
- * - Lists all available shortcuts
- * - Closes on Escape or backdrop click
- * - Shows platform-appropriate modifier keys
- */
 export function ShortcutsDialog({ isOpen, onClose }: ShortcutsDialogProps): ReactNode {
-  const dialogRef = useRef<HTMLDivElement>(null)
-  const previousActiveElement = useRef<HTMLElement | null>(null)
-
-  // Handle escape key and body scroll
-  useEffect(() => {
-    if (!isOpen) return
-
-    previousActiveElement.current = document.activeElement as HTMLElement
-    document.body.style.overflow = 'hidden'
-
-    function handleKeyDown(e: KeyboardEvent): void {
-      if (e.key === 'Escape') {
-        e.stopImmediatePropagation()
-        onClose()
-      }
-    }
-
-    // Use capture phase so this handler runs before other document-level handlers
-    // This ensures Escape closes only the dialog, not components behind it
-    document.addEventListener('keydown', handleKeyDown, true)
-
-    return () => {
-      document.body.style.overflow = ''
-      document.removeEventListener('keydown', handleKeyDown, true)
-
-      if (previousActiveElement.current) {
-        previousActiveElement.current.focus()
-      }
-    }
-  }, [isOpen, onClose])
-
-  // Handle backdrop click
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>): void => {
-    if (e.target === e.currentTarget) {
-      onClose()
-    }
-  }
-
-  if (!isOpen) return null
-
   return (
-    <div
-      className="modal-backdrop bg-gray-900/30"
-      onClick={handleBackdropClick}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="shortcuts-title"
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Keyboard Shortcuts"
+      maxWidth="max-w-sm md:max-w-3xl"
     >
-      <div
-        ref={dialogRef}
-        className="modal-content max-w-sm md:max-w-3xl"
-        style={{ height: '85vh', maxHeight: '85vh' }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-          <h2 id="shortcuts-title" className="text-base font-semibold text-gray-900">
-            Keyboard Shortcuts
-          </h2>
-          <button
-            onClick={onClose}
-            className="btn-icon"
-            aria-label="Close dialog"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+        <div className="space-y-4">
+          {leftColumnGroups.map((group) => (
+            <ShortcutGroupSection key={group.title} group={group} />
+          ))}
         </div>
-
-        {/* Body - two columns on desktop, one on mobile */}
-        <div className="px-4 py-3 grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
-          {/* Left column: Actions, Navigation, View */}
-          <div className="space-y-4">
-            {leftColumnGroups.map((group) => (
-              <ShortcutGroupSection key={group.title} group={group} />
-            ))}
-          </div>
-          {/* Right column: Editor */}
-          <div className="space-y-4">
-            {rightColumnGroups.map((group) => (
-              <ShortcutGroupSection key={group.title} group={group} />
-            ))}
-          </div>
+        <div className="space-y-4">
+          {rightColumnGroups.map((group) => (
+            <ShortcutGroupSection key={group.title} group={group} />
+          ))}
         </div>
-
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/components/editor/EditorToolbarIcons.tsx
+++ b/frontend/src/components/editor/EditorToolbarIcons.tsx
@@ -91,7 +91,7 @@ export function OrderedListIcon(): ReactNode {
   )
 }
 
-export function TaskListIcon(): ReactNode {
+export function ChecklistIcon(): ReactNode {
   return (
     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <rect x="3" y="5" width="14" height="14" rx="2" strokeWidth={2} />

--- a/frontend/src/components/editor/editorCommands.test.ts
+++ b/frontend/src/components/editor/editorCommands.test.ts
@@ -29,7 +29,7 @@ const stubIcons = {
   link: () => createElement('span', null, 'link'),
   bulletList: () => createElement('span', null, 'bulletList'),
   orderedList: () => createElement('span', null, 'orderedList'),
-  taskList: () => createElement('span', null, 'taskList'),
+  checklist: () => createElement('span', null, 'checklist'),
   blockquote: () => createElement('span', null, 'blockquote'),
   horizontalRule: () => createElement('span', null, 'horizontalRule'),
   heading1: () => createElement('span', null, 'heading1'),
@@ -214,7 +214,7 @@ describe('buildEditorCommands', () => {
     expect(insertIds).toContain('heading-3')
     expect(insertIds).toContain('bullet-list')
     expect(insertIds).toContain('numbered-list')
-    expect(insertIds).toContain('todo-list')
+    expect(insertIds).toContain('checklist')
     expect(insertIds).toContain('code-block')
     expect(insertIds).toContain('blockquote')
     expect(insertIds).toContain('link')

--- a/frontend/src/components/editor/editorCommands.ts
+++ b/frontend/src/components/editor/editorCommands.ts
@@ -46,7 +46,7 @@ interface IconFactories {
   link: () => ReactNode
   bulletList: () => ReactNode
   orderedList: () => ReactNode
-  taskList: () => ReactNode
+  checklist: () => ReactNode
   blockquote: () => ReactNode
   horizontalRule: () => ReactNode
   heading1: () => ReactNode
@@ -225,7 +225,7 @@ export function buildEditorCommands({ showJinja, callbacks, icons, isDirty = fal
     label: 'Bulleted list',
     section: 'Insert',
     icon: icons.bulletList(),
-    shortcut: ['\u2318', '\u21e7', '8'],
+    shortcut: ['\u2318', '\u21e7', '7'],
     action: (view) => { toggleLinePrefix(view, '- ') },
   })
   commands.push({
@@ -233,14 +233,14 @@ export function buildEditorCommands({ showJinja, callbacks, icons, isDirty = fal
     label: 'Numbered list',
     section: 'Insert',
     icon: icons.orderedList(),
-    shortcut: ['\u2318', '\u21e7', '7'],
+    shortcut: ['\u2318', '\u21e7', '8'],
     action: (view) => { toggleLinePrefix(view, '1. ') },
   })
   commands.push({
-    id: 'todo-list',
-    label: 'To-do list',
+    id: 'checklist',
+    label: 'Checklist',
     section: 'Insert',
-    icon: icons.taskList(),
+    icon: icons.checklist(),
     shortcut: ['\u2318', '\u21e7', '9'],
     action: (view) => { toggleLinePrefix(view, '- [ ] ') },
   })

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -87,6 +87,19 @@ describe('Modal', () => {
 
       expect(screen.queryByLabelText('Close')).not.toBeInTheDocument()
     })
+
+    it('should not call onClose when backdrop is clicked', () => {
+      const onClose = vi.fn()
+      render(
+        <Modal isOpen={true} onClose={onClose} title="Test Modal">
+          <p>Modal content</p>
+        </Modal>
+      )
+
+      fireEvent.click(screen.getByRole('dialog'))
+
+      expect(onClose).not.toHaveBeenCalled()
+    })
   })
 
   describe('Escape key propagation', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -522,7 +522,10 @@ body {
   @apply my-1;
 }
 
-/* Task lists (checkboxes) - Milkdown uses data attributes instead of input elements
+/* Checklist (checkboxes) - Milkdown uses data attributes instead of input elements.
+ * Note: Milkdown's GFM plugin tags items as `data-item-type="task"` — that
+ * attribute name is owned upstream and can't be renamed; we surface it as
+ * "Checklist" everywhere in our UI.
  * IMPORTANT: The checkbox click detection in MilkdownEditor.tsx (CHECKBOX_CLICK_AREA_WIDTH)
  * depends on these dimensions. The checkbox is 16px (h-4 w-4) + 8px gap = ~24px total.
  * If you change these styles, update CHECKBOX_CLICK_AREA_WIDTH in MilkdownEditor.tsx accordingly.
@@ -531,19 +534,19 @@ body {
   @apply list-none flex flex-wrap items-start gap-x-2;
 }
 
-/* Paragraph content inside task items should stay inline with checkbox */
+/* Paragraph content inside checklist items should stay inline with checkbox */
 .milkdown-wrapper .milkdown li[data-item-type="task"] > p {
   @apply flex-1 min-w-0;
 }
 
-/* Nested lists inside task items should take full width to appear below */
+/* Nested lists inside checklist items should take full width to appear below */
 .milkdown-wrapper .milkdown li[data-item-type="task"] > ul,
 .milkdown-wrapper .milkdown li[data-item-type="task"] > ol {
   @apply w-full my-0;
   margin-left: 1.5rem; /* Indent nested lists */
 }
 
-/* Remove margin from all nested lists within task items to prevent extra gaps */
+/* Remove margin from all nested lists within checklist items to prevent extra gaps */
 .milkdown-wrapper .milkdown li[data-item-type="task"] ul,
 .milkdown-wrapper .milkdown li[data-item-type="task"] ol {
   @apply my-0;
@@ -567,7 +570,7 @@ body {
   background-repeat: no-repeat;
 }
 
-/* Remove default bullet from task list parent */
+/* Remove default bullet from checklist parent */
 .milkdown-wrapper .milkdown ul:has(li[data-item-type="task"]) {
   @apply list-none pl-4;
 }

--- a/frontend/src/pages/docs/DocsShortcuts.tsx
+++ b/frontend/src/pages/docs/DocsShortcuts.tsx
@@ -101,9 +101,9 @@ export function DocsShortcuts(): ReactNode {
           <ShortcutRow keys={['\u2318', '\u21E7', '.']} description="Blockquote" />
           <ShortcutRow keys={['\u2318', 'E']} description="Inline code" />
           <ShortcutRow keys={['\u2318', '\u21E7', 'E']} description="Code block" />
-          <ShortcutRow keys={['\u2318', '\u21E7', '8']} description="Bullet list" />
-          <ShortcutRow keys={['\u2318', '\u21E7', '7']} description="Numbered list" />
-          <ShortcutRow keys={['\u2318', '\u21E7', '9']} description="Task list" />
+          <ShortcutRow keys={['\u2318', '\u21E7', '7']} description="Bullet list" />
+          <ShortcutRow keys={['\u2318', '\u21E7', '8']} description="Numbered list" />
+          <ShortcutRow keys={['\u2318', '\u21E7', '9']} description="Checklist" />
           <ShortcutRow keys={['\u2318', 'K']} description="Insert link" />
           <ShortcutRow keys={['\u2318', '\u21E7', '-']} description="Horizontal rule" />
           <ShortcutRow keys={['\u2318', 'D']} description="Select next occurrence" />
@@ -119,7 +119,7 @@ export function DocsShortcuts(): ReactNode {
       </p>
       <ul className="space-y-1.5 text-sm text-gray-600 mb-4">
         <li>Heading 1, Heading 2, Heading 3</li>
-        <li>Bulleted list, Numbered list, To-do list</li>
+        <li>Bulleted list, Numbered list, Checklist</li>
         <li>Code block, Blockquote, Link, Horizontal rule</li>
       </ul>
       <p className="text-sm text-gray-600">

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -40,7 +40,7 @@ vi.mock('../hooks/useLimits', () => ({
       max_url_length: 2000,
       max_prompt_name_length: 100,
       max_argument_name_length: 100,
-      max_argument_description_length: 500,
+      max_argument_description_length: 1000,
     },
     isLoading: false,
     error: null,

--- a/frontend/src/utils/markdownStyleExtension.test.ts
+++ b/frontend/src/utils/markdownStyleExtension.test.ts
@@ -415,33 +415,33 @@ describe('parseLine', () => {
     })
   })
 
-  describe('tasks', () => {
-    it('should detect unchecked task', () => {
-      const result = parseLine('- [ ] Task', false)
-      expect(result?.type).toBe('task')
+  describe('checklist', () => {
+    it('should detect unchecked checklist item', () => {
+      const result = parseLine('- [ ] Item', false)
+      expect(result?.type).toBe('checklist')
       expect(result?.checked).toBe(false)
     })
 
-    it('should detect checked task', () => {
-      const result = parseLine('- [x] Task', false)
-      expect(result?.type).toBe('task')
+    it('should detect checked checklist item', () => {
+      const result = parseLine('- [x] Item', false)
+      expect(result?.type).toBe('checklist')
       expect(result?.checked).toBe(true)
     })
 
-    it('should detect checked task with uppercase X', () => {
-      const result = parseLine('- [X] Task', false)
-      expect(result?.type).toBe('task')
+    it('should detect checked checklist item with uppercase X', () => {
+      const result = parseLine('- [X] Item', false)
+      expect(result?.type).toBe('checklist')
       expect(result?.checked).toBe(true)
     })
 
     it('should provide bracket position', () => {
-      const result = parseLine('- [ ] Task', false)
+      const result = parseLine('- [ ] Item', false)
       expect(result?.bracketPos).toBe(2)  // Position of [ for editing
     })
 
-    it('should handle indented tasks', () => {
-      const result = parseLine('  - [ ] Nested task', false)
-      expect(result?.type).toBe('task')
+    it('should handle indented checklist items', () => {
+      const result = parseLine('  - [ ] Nested item', false)
+      expect(result?.type).toBe('checklist')
       expect(result?.bracketPos).toBe(4)  // Position of [ for editing
     })
   })

--- a/frontend/src/utils/markdownStyleExtension.test.ts
+++ b/frontend/src/utils/markdownStyleExtension.test.ts
@@ -454,6 +454,38 @@ describe('parseLine', () => {
       const result = parseLine('123. Item', false)
       expect(result?.type).toBe('numbered')
     })
+
+    // prefixLen powers the per-line hanging-indent CSS variable so wrapped
+    // list lines align with the content after the marker (KAN-111).
+    describe('prefixLen (hanging indent width)', () => {
+      it('returns 2 for "- Item"', () => {
+        expect(parseLine('- Item', false)?.prefixLen).toBe(2)
+      })
+
+      it('returns 3 for "1. Item"', () => {
+        expect(parseLine('1. Item', false)?.prefixLen).toBe(3)
+      })
+
+      it('returns 5 for "123. Item"', () => {
+        expect(parseLine('123. Item', false)?.prefixLen).toBe(5)
+      })
+
+      it('includes leading indent for nested bullet', () => {
+        expect(parseLine('  - Nested', false)?.prefixLen).toBe(4)
+      })
+
+      it('includes leading indent for deeply nested bullet', () => {
+        expect(parseLine('      - Deep', false)?.prefixLen).toBe(8)
+      })
+
+      it('returns 6 for "- [ ] Item"', () => {
+        expect(parseLine('- [ ] Item', false)?.prefixLen).toBe(6)
+      })
+
+      it('includes leading indent for nested checklist', () => {
+        expect(parseLine('  - [x] Nested', false)?.prefixLen).toBe(8)
+      })
+    })
   })
 
   describe('checklist', () => {
@@ -484,6 +516,18 @@ describe('parseLine', () => {
       const result = parseLine('  - [ ] Nested item', false)
       expect(result?.type).toBe('checklist')
       expect(result?.bracketPos).toBe(4)  // Position of [ for editing
+    })
+
+    // bracketPos is now computed from the actual match position of "[" so it
+    // stays correct for multi-space variants. The click-to-toggle handler
+    // dispatches a 3-character replacement at bracketPos; if this were off by
+    // one, the toggle would corrupt the line.
+    it('returns correct bracketPos for multi-space between marker and [', () => {
+      expect(parseLine('-  [ ] Item', false)?.bracketPos).toBe(3)
+    })
+
+    it('returns correct bracketPos for indent + multi-space', () => {
+      expect(parseLine('  -  [x] Item', false)?.bracketPos).toBe(5)
     })
   })
 
@@ -978,6 +1022,42 @@ describe('link dom event handlers', () => {
       )
       // Selection untouched — no secondary cursor added.
       expect(view.state.selection.ranges.length).toBe(initialRangeCount)
+    })
+  })
+
+  describe('checklist toggle on multi-space lines', () => {
+    // Locks in the bracketPos fix: parseLine now derives bracketPos from the
+    // actual match position of "[" so the click-to-toggle handler correctly
+    // replaces the 3-char checkbox even when there are multiple spaces
+    // between the marker and "[". Before the fix, bracketPos was hardcoded
+    // off-by-N and the toggle would corrupt the line.
+    it('toggles "[ ]" → "[x]" on a line with multi-space marker spacing', () => {
+      const doc = '-  [ ] Item'
+      // Any pos inside the line works; the handler re-derives bracketPos
+      // from parseLine on the line's text. Position 3 is "[".
+      const view = track(buildView(doc, 3))
+
+      const target = document.createElement('span')
+      target.className = 'cm-md-checklist-checkbox cm-md-checklist-checkbox-unchecked'
+      const event = makeMouseEvent({}, target)
+
+      const handled = handleEditorMousedown(event, view)
+
+      expect(handled).toBe(true)
+      expect(view.state.doc.toString()).toBe('-  [x] Item')
+    })
+
+    it('toggles "[x]" → "[ ]" on an indented multi-space line', () => {
+      const doc = '  -  [x] Item'
+      const view = track(buildView(doc, 5))
+
+      const target = document.createElement('span')
+      target.className = 'cm-md-checklist-checkbox cm-md-checklist-checkbox-checked'
+      const event = makeMouseEvent({}, target)
+
+      handleEditorMousedown(event, view)
+
+      expect(view.state.doc.toString()).toBe('  -  [ ] Item')
     })
   })
 })

--- a/frontend/src/utils/markdownStyleExtension.test.ts
+++ b/frontend/src/utils/markdownStyleExtension.test.ts
@@ -1,10 +1,51 @@
 /**
  * Tests for markdown style extension helper functions.
  */
-import { describe, it, expect } from 'vitest'
-import { _testExports } from './markdownStyleExtension'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { _testExports, markdownStyleExtension } from './markdownStyleExtension'
 
-const { findImages, findLinks, findInlineCode, findStrikethrough, findHighlight, findBold, findItalic, findBlockquoteSyntax, findJinjaExpressions, parseLine } = _testExports
+const {
+  findImages,
+  findLinks,
+  findInlineCode,
+  findStrikethrough,
+  findHighlight,
+  findBold,
+  findItalic,
+  findBlockquoteSyntax,
+  findJinjaExpressions,
+  parseLine,
+  handleEditorMousedown,
+  handleEditorClick,
+  handleEditorMousemove,
+  handleEditorMouseleave,
+  handleEditorKeyup,
+} = _testExports
+
+/**
+ * Build a minimal EditorView for handler tests. jsdom doesn't compute layout,
+ * so we stub `posAtCoords` to return a fixed document position — handlers call
+ * it with client coords and only care about the returned doc position.
+ */
+function buildView(doc: string, posAtCoordsReturn: number | null): EditorView {
+  const parent = document.createElement('div')
+  const view = new EditorView({
+    state: EditorState.create({ doc, extensions: [markdownStyleExtension] }),
+    parent,
+  })
+  vi.spyOn(view, 'posAtCoords').mockReturnValue(posAtCoordsReturn)
+  return view
+}
+
+function makeMouseEvent(init: Partial<MouseEventInit> = {}, target?: HTMLElement): MouseEvent {
+  const event = new MouseEvent('mousedown', { button: 0, ...init })
+  // Give the event a non-null target so handler code that reads target.classList works.
+  Object.defineProperty(event, 'target', { value: target ?? document.createElement('div') })
+  vi.spyOn(event, 'preventDefault')
+  return event
+}
 
 describe('findImages', () => {
   it('should find a simple image', () => {
@@ -698,6 +739,245 @@ describe('findJinjaExpressions', () => {
       const result = findJinjaExpressions('{{}}')
       expect(result).toHaveLength(1)
       expect(result[0].type).toBe('variable')
+    })
+  })
+})
+
+describe('link dom event handlers', () => {
+  let views: EditorView[] = []
+
+  beforeEach(() => {
+    views = []
+  })
+
+  afterEach(() => {
+    views.forEach((v) => v.destroy())
+    vi.restoreAllMocks()
+  })
+
+  function track(view: EditorView): EditorView {
+    views.push(view)
+    return view
+  }
+
+  describe('handleEditorMousedown — cmd/ctrl intercept', () => {
+    it('returns true and prevents default when cmd+mousedown over a link', () => {
+      const doc = 'see [example](https://example.com) here'
+      // position 6 is inside "[example]"
+      const view = track(buildView(doc, 6))
+      const event = makeMouseEvent({ metaKey: true })
+
+      const handled = handleEditorMousedown(event, view)
+
+      expect(handled).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('does not intercept cmd+mousedown outside a link', () => {
+      const doc = 'plain text without any link'
+      const view = track(buildView(doc, 3))
+      const event = makeMouseEvent({ metaKey: true })
+
+      const handled = handleEditorMousedown(event, view)
+
+      expect(handled).toBe(false)
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('does not intercept plain mousedown over a link', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      const event = makeMouseEvent({})
+
+      const handled = handleEditorMousedown(event, view)
+
+      expect(handled).toBe(false)
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('also intercepts ctrl+mousedown over a link', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      const event = makeMouseEvent({ ctrlKey: true })
+
+      expect(handleEditorMousedown(event, view)).toBe(true)
+    })
+
+    it('treats url portion of [title](url) as part of the link', () => {
+      const doc = 'see [example](https://example.com) here'
+      // position 20 is inside the URL
+      const view = track(buildView(doc, 20))
+      const event = makeMouseEvent({ metaKey: true })
+
+      expect(handleEditorMousedown(event, view)).toBe(true)
+    })
+  })
+
+  describe('handleEditorClick — open link', () => {
+    it('opens link via window.open when cmd+click over a link', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const event = makeMouseEvent({ metaKey: true })
+
+      const handled = handleEditorClick(event, view)
+
+      expect(handled).toBe(true)
+      expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('prepends https:// when URL lacks a scheme', () => {
+      const doc = '[bare](example.com)'
+      const view = track(buildView(doc, 3))
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const event = makeMouseEvent({ metaKey: true })
+
+      handleEditorClick(event, view)
+
+      expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+    })
+
+    it('does nothing on plain click', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const event = makeMouseEvent({})
+
+      const handled = handleEditorClick(event, view)
+
+      expect(handled).toBe(false)
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not open when cmd+click outside a link', () => {
+      const doc = 'plain text without any link'
+      const view = track(buildView(doc, 3))
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const event = makeMouseEvent({ metaKey: true })
+
+      expect(handleEditorClick(event, view)).toBe(false)
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleEditorMousemove — pointer cursor', () => {
+    it('adds link-hover class when cmd held over a link', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      const event = makeMouseEvent({ metaKey: true })
+
+      handleEditorMousemove(event, view)
+
+      expect(view.dom.classList.contains('cm-md-link-hover')).toBe(true)
+    })
+
+    it('removes link-hover class when cmd no longer held', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      view.dom.classList.add('cm-md-link-hover')
+      const event = makeMouseEvent({})
+
+      handleEditorMousemove(event, view)
+
+      expect(view.dom.classList.contains('cm-md-link-hover')).toBe(false)
+    })
+
+    it('does not add link-hover class when cmd held but not over a link', () => {
+      const doc = 'plain text with no links here'
+      const view = track(buildView(doc, 5))
+      const event = makeMouseEvent({ metaKey: true })
+
+      handleEditorMousemove(event, view)
+
+      expect(view.dom.classList.contains('cm-md-link-hover')).toBe(false)
+    })
+
+    it('does not touch inline cursor style on contentDOM', () => {
+      // Guards the ownership invariant: this handler should not mutate
+      // inline cursor styles it doesn't own.
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      view.contentDOM.style.cursor = 'text'
+      const event = makeMouseEvent({})
+
+      handleEditorMousemove(event, view)
+
+      expect(view.contentDOM.style.cursor).toBe('text')
+    })
+  })
+
+  describe('handleEditorMouseleave', () => {
+    it('removes link-hover class on mouseleave', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      view.dom.classList.add('cm-md-link-hover')
+
+      handleEditorMouseleave(new MouseEvent('mouseleave'), view)
+
+      expect(view.dom.classList.contains('cm-md-link-hover')).toBe(false)
+    })
+
+    it('does not touch inline cursor style on contentDOM', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      view.contentDOM.style.cursor = 'text'
+
+      handleEditorMouseleave(new MouseEvent('mouseleave'), view)
+
+      expect(view.contentDOM.style.cursor).toBe('text')
+    })
+  })
+
+  describe('handleEditorKeyup', () => {
+    it('removes link-hover class when cmd is released', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      view.dom.classList.add('cm-md-link-hover')
+      const event = new KeyboardEvent('keyup', { key: 'Meta' })
+
+      handleEditorKeyup(event, view)
+
+      expect(view.dom.classList.contains('cm-md-link-hover')).toBe(false)
+    })
+
+    it('does not remove link-hover class while cmd still held', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      view.dom.classList.add('cm-md-link-hover')
+      const event = new KeyboardEvent('keyup', { key: 'a', metaKey: true })
+
+      handleEditorKeyup(event, view)
+
+      expect(view.dom.classList.contains('cm-md-link-hover')).toBe(true)
+    })
+  })
+
+  describe('cmd+click end-to-end sequence', () => {
+    // Core contract of the fix: mousedown intercepts to prevent multi-cursor,
+    // and the subsequent click still opens the link with a single selection.
+    it('opens link and preserves single selection across mousedown+click', () => {
+      const doc = 'see [example](https://example.com) here'
+      const view = track(buildView(doc, 6))
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+      const initialRangeCount = view.state.selection.ranges.length
+
+      const mousedown = makeMouseEvent({ metaKey: true })
+      const mousedownHandled = handleEditorMousedown(mousedown, view)
+
+      const click = makeMouseEvent({ metaKey: true })
+      const clickHandled = handleEditorClick(click, view)
+
+      expect(mousedownHandled).toBe(true)
+      expect(clickHandled).toBe(true)
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://example.com',
+        '_blank',
+        'noopener,noreferrer',
+      )
+      // Selection untouched — no secondary cursor added.
+      expect(view.state.selection.ranges.length).toBe(initialRangeCount)
     })
   })
 })

--- a/frontend/src/utils/markdownStyleExtension.ts
+++ b/frontend/src/utils/markdownStyleExtension.ts
@@ -30,7 +30,7 @@ const SYNTAX_FONT_SIZE = '0.9em'
  * Parse a line and return decoration info if it matches a markdown pattern.
  */
 interface LineInfo {
-  type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'bullet' | 'numbered' | 'task' | 'blockquote' | 'code-start' | 'code-end' | 'code-content' | 'hr'
+  type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'bullet' | 'numbered' | 'checklist' | 'blockquote' | 'code-start' | 'code-end' | 'code-content' | 'hr'
   checked?: boolean
   bracketPos?: number   // Position of [ character for editing
 }
@@ -54,14 +54,14 @@ function parseLine(text: string, inCodeBlock: boolean): LineInfo | null {
   if (text.startsWith('##### ')) return { type: 'h5' }
   if (text.startsWith('###### ')) return { type: 'h6' }
 
-  // Task lists - check for [ ] or [x]
-  const taskMatch = text.match(/^(\s*)([-*+])\s+\[([ xX])\]\s/)
-  if (taskMatch) {
-    const checked = taskMatch[3].toLowerCase() === 'x'
-    const indent = taskMatch[1].length
+  // Checklist - check for [ ] or [x]
+  const checklistMatch = text.match(/^(\s*)([-*+])\s+\[([ xX])\]\s/)
+  if (checklistMatch) {
+    const checked = checklistMatch[3].toLowerCase() === 'x'
+    const indent = checklistMatch[1].length
     // bracketPos: position of [ character - for editing when clicked
-    const bracketPos = indent + taskMatch[2].length + 1 // indent + "-" + " "
-    return { type: 'task', checked, bracketPos }
+    const bracketPos = indent + checklistMatch[2].length + 1 // indent + "-" + " "
+    return { type: 'checklist', checked, bracketPos }
   }
 
   // Bullet lists
@@ -398,15 +398,15 @@ const boldContentMark = Decoration.mark({ class: 'cm-md-bold-content' })
 // Decorations for italic
 const italicContentMark = Decoration.mark({ class: 'cm-md-italic-content' })
 
-// Decoration for task syntax
-const taskSyntaxMark = Decoration.mark({ class: 'cm-md-task-syntax' })
+// Decoration for checklist syntax
+const checklistSyntaxMark = Decoration.mark({ class: 'cm-md-checklist-syntax' })
 
 // Decorations for clickable checkbox text ([ ] or [x])
-const taskCheckboxUncheckedMark = Decoration.mark({ class: 'cm-md-task-checkbox cm-md-task-checkbox-unchecked' })
-const taskCheckboxCheckedMark = Decoration.mark({ class: 'cm-md-task-checkbox cm-md-task-checkbox-checked' })
+const checklistCheckboxUncheckedMark = Decoration.mark({ class: 'cm-md-checklist-checkbox cm-md-checklist-checkbox-unchecked' })
+const checklistCheckboxCheckedMark = Decoration.mark({ class: 'cm-md-checklist-checkbox cm-md-checklist-checkbox-checked' })
 
-// Decoration for checked task content (strikethrough)
-const taskCheckedContentMark = Decoration.mark({ class: 'cm-md-task-checked-content' })
+// Decoration for checked checklist content (strikethrough)
+const checklistCheckedContentMark = Decoration.mark({ class: 'cm-md-checklist-checked-content' })
 
 // Decoration for header syntax
 const headerSyntaxMark = Decoration.mark({ class: 'cm-md-header-syntax' })
@@ -415,10 +415,10 @@ const headerSyntaxMark = Decoration.mark({ class: 'cm-md-header-syntax' })
 const blockquoteSyntaxMark = Decoration.mark({ class: 'cm-md-blockquote-syntax' })
 
 /**
- * Find task list syntax in a line (e.g., "- [ ] " or "- [x] ").
- * Returns the range to gray out, or null if not a task line.
+ * Find checklist syntax in a line (e.g., "- [ ] " or "- [x] ").
+ * Returns the range to gray out, or null if not a checklist line.
  */
-function findTaskSyntax(text: string): { from: number; to: number } | null {
+function findChecklistSyntax(text: string): { from: number; to: number } | null {
   const match = text.match(/^(\s*)[-*+]\s+\[([ xX])\]\s/)
   if (match) {
     return { from: match[1].length, to: match[0].length }
@@ -554,9 +554,9 @@ function buildDecorations(view: EditorView): DecorationSet {
     // Add line decoration if we have line-level styling
     if (info) {
       let lineClass = `cm-md-${info.type}`
-      // Add checked class for completed tasks
-      if (info.type === 'task' && info.checked) {
-        lineClass += ' cm-md-task-checked'
+      // Add checked class for completed checklist items
+      if (info.type === 'checklist' && info.checked) {
+        lineClass += ' cm-md-checklist-checked'
       }
       builder.add(line.from, line.from, Decoration.line({ class: lineClass }))
     }
@@ -566,17 +566,17 @@ function buildDecorations(view: EditorView): DecorationSet {
       // Collect all inline decorations with their positions
       const inlineDecorations: Array<{ from: number; to: number; decoration: Decoration }> = []
 
-      // Task syntax and clickable checkbox for task items
-      const taskSyntax = findTaskSyntax(line.text)
-      if (taskSyntax && info?.type === 'task' && info.bracketPos !== undefined) {
+      // Checklist syntax and clickable checkbox
+      const checklistSyntax = findChecklistSyntax(line.text)
+      if (checklistSyntax && info?.type === 'checklist' && info.bracketPos !== undefined) {
         const bracketPos = line.from + info.bracketPos   // Where [ is in the document
 
         // Style "- " before the checkbox as dimmed syntax
-        if (info.bracketPos > taskSyntax.from) {
+        if (info.bracketPos > checklistSyntax.from) {
           inlineDecorations.push({
-            from: line.from + taskSyntax.from,
+            from: line.from + checklistSyntax.from,
             to: bracketPos,
-            decoration: taskSyntaxMark,
+            decoration: checklistSyntaxMark,
           })
         }
 
@@ -584,14 +584,14 @@ function buildDecorations(view: EditorView): DecorationSet {
         inlineDecorations.push({
           from: bracketPos,
           to: bracketPos + 3,
-          decoration: info.checked ? taskCheckboxCheckedMark : taskCheckboxUncheckedMark,
+          decoration: info.checked ? checklistCheckboxCheckedMark : checklistCheckboxUncheckedMark,
         })
         // Apply strikethrough to content after checkbox when checked
-        if (info?.type === 'task' && info.checked && taskSyntax.to < line.text.length) {
+        if (info?.type === 'checklist' && info.checked && checklistSyntax.to < line.text.length) {
           inlineDecorations.push({
-            from: line.from + taskSyntax.to,
+            from: line.from + checklistSyntax.to,
             to: line.to,
-            decoration: taskCheckedContentMark,
+            decoration: checklistCheckedContentMark,
           })
         }
       }
@@ -893,22 +893,22 @@ const markdownBaseTheme = EditorView.theme({
   },
 
   // Lists
-  '.cm-md-bullet, .cm-md-numbered, .cm-md-task': {
+  '.cm-md-bullet, .cm-md-numbered, .cm-md-checklist': {
     paddingLeft: '0.5em',
   },
 
-  // Task items
-  '.cm-md-task': {
+  // Checklist items
+  '.cm-md-checklist': {
     position: 'relative',
   },
 
-  // Completed tasks - dimmed color (strikethrough applied to content only)
-  '.cm-md-task-checked': {
+  // Completed checklist items - dimmed color (strikethrough applied to content only)
+  '.cm-md-checklist-checked': {
     color: '#6b7280',
   },
 
-  // Completed task content - strikethrough only on text, not full line
-  '.cm-md-task-checked-content': {
+  // Completed checklist content - strikethrough only on text, not full line
+  '.cm-md-checklist-checked-content': {
     textDecoration: 'line-through',
     textDecorationColor: '#6b7280',
   },
@@ -993,36 +993,36 @@ const markdownBaseTheme = EditorView.theme({
   },
 
   // Clickable checkbox text ([ ] or [x]) - click to toggle
-  '.cm-md-task-checkbox': {
+  '.cm-md-checklist-checkbox': {
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
     cursor: 'pointer',
     borderRadius: '3px',
     padding: '1px 2px',
     transition: 'background-color 0.15s',
   },
-  '.cm-md-task-checkbox:hover': {
+  '.cm-md-checklist-checkbox:hover': {
     backgroundColor: 'rgba(0, 0, 0, 0.08)',
   },
-  '.cm-md-task-checkbox-unchecked': {
+  '.cm-md-checklist-checkbox-unchecked': {
     color: '#374151',
     fontWeight: 'bold',
   },
-  '.cm-md-task-checkbox-checked': {
+  '.cm-md-checklist-checkbox-checked': {
     color: '#6b7280',
     fontWeight: 'bold',
     textDecoration: 'none !important',
   },
-  '.cm-md-task-checkbox-checked *': {
+  '.cm-md-checklist-checkbox-checked *': {
     textDecoration: 'none !important',
   },
 
-  // Task syntax (- [ ] or - [x]) - dimmed gray like other markdown syntax
-  '.cm-md-task-syntax': {
+  // Checklist syntax (- [ ] or - [x]) - dimmed gray like other markdown syntax
+  '.cm-md-checklist-syntax': {
     color: `${SYNTAX_COLOR} !important`,
     textDecoration: 'none !important',
     fontSize: SYNTAX_FONT_SIZE,
   },
-  '.cm-md-task-syntax *': {
+  '.cm-md-checklist-syntax *': {
     color: `${SYNTAX_COLOR} !important`,
     textDecoration: 'none !important',
   },
@@ -1333,7 +1333,7 @@ function findLinkAtPosition(view: EditorView, pos: number): string | null {
 }
 
 /**
- * Event handler for clicking checkbox text ([ ] or [x]) to toggle task state,
+ * Event handler for clicking checkbox text ([ ] or [x]) to toggle checklist state,
  * and Cmd+click (or Ctrl+click) to open links.
  */
 const clickHandler = EditorView.domEventHandlers({
@@ -1342,8 +1342,8 @@ const clickHandler = EditorView.domEventHandlers({
     if (event.button !== 0) return false
 
     const target = event.target as HTMLElement
-    if (!target.classList.contains('cm-md-task-checkbox') &&
-        !target.closest('.cm-md-task-checkbox')) {
+    if (!target.classList.contains('cm-md-checklist-checkbox') &&
+        !target.closest('.cm-md-checklist-checkbox')) {
       return false
     }
 
@@ -1352,7 +1352,7 @@ const clickHandler = EditorView.domEventHandlers({
 
     const line = view.state.doc.lineAt(pos)
     const info = parseLine(line.text, false)
-    if (info?.type !== 'task' || info.bracketPos === undefined) return false
+    if (info?.type !== 'checklist' || info.bracketPos === undefined) return false
 
     const bracketPos = line.from + info.bracketPos
     const newText = info.checked ? '[ ]' : '[x]'

--- a/frontend/src/utils/markdownStyleExtension.ts
+++ b/frontend/src/utils/markdownStyleExtension.ts
@@ -829,6 +829,12 @@ const markdownBaseTheme = EditorView.theme({
     lineHeight: '1.5 !important',
   },
 
+  // Pointer cursor shown when Cmd/Ctrl is held over a link. The class is
+  // toggled on view.dom by handleEditorMousemove / handleEditorMouseleave.
+  '&.cm-md-link-hover .cm-content': {
+    cursor: 'pointer',
+  },
+
   // Remove underlines from default markdown heading syntax highlighting
   // Try multiple selectors to catch whatever CodeMirror is using
   '.cmt-heading, .cmt-heading1, .cmt-heading2, .cmt-heading3, .cmt-heading4, .cmt-heading5, .cmt-heading6': {
@@ -1332,65 +1338,120 @@ function findLinkAtPosition(view: EditorView, pos: number): string | null {
   return null
 }
 
+const LINK_HOVER_CLASS = 'cm-md-link-hover'
+
 /**
- * Event handler for clicking checkbox text ([ ] or [x]) to toggle checklist state,
- * and Cmd+click (or Ctrl+click) to open links.
+ * Handle mousedown on the editor. Toggles checklist checkboxes, and intercepts
+ * Cmd/Ctrl+mousedown over a link so CodeMirror doesn't add a secondary cursor.
+ *
+ * Browsers still fire the subsequent `click` event even when `mousedown` is
+ * defaultPrevented (as long as mouseup lands on the same element), so the
+ * click handler below runs and opens the link. That's how we suppress the
+ * multi-cursor side effect without breaking cmd+click-to-open.
  */
-const clickHandler = EditorView.domEventHandlers({
-  // Use mousedown for checkbox toggle to prevent cursor from moving
-  mousedown(event: MouseEvent, view: EditorView) {
-    if (event.button !== 0) return false
+function handleEditorMousedown(event: MouseEvent, view: EditorView): boolean {
+  if (event.button !== 0) return false
 
-    const target = event.target as HTMLElement
-    if (!target.classList.contains('cm-md-checklist-checkbox') &&
-        !target.closest('.cm-md-checklist-checkbox')) {
-      return false
-    }
-
+  if (event.metaKey || event.ctrlKey) {
     const pos = view.posAtCoords({ x: event.clientX, y: event.clientY })
-    if (pos === null) return false
-
-    const line = view.state.doc.lineAt(pos)
-    const info = parseLine(line.text, false)
-    if (info?.type !== 'checklist' || info.bracketPos === undefined) return false
-
-    const bracketPos = line.from + info.bracketPos
-    const newText = info.checked ? '[ ]' : '[x]'
-
-    // Save current selection and restore it after the toggle
-    const selection = view.state.selection
-    view.dispatch({
-      changes: { from: bracketPos, to: bracketPos + 3, insert: newText },
-      selection,
-    })
-    event.preventDefault()
-    return true
-  },
-
-  // Cmd+click (Mac) or Ctrl+click (Windows/Linux) to open links
-  click(event: MouseEvent, view: EditorView) {
-    if (!event.metaKey && !event.ctrlKey) {
-      return false
-    }
-
-    const pos = view.posAtCoords({ x: event.clientX, y: event.clientY })
-    if (pos === null) {
-      return false
-    }
-
-    const url = findLinkAtPosition(view, pos)
-    if (url) {
-      let finalUrl = url
-      if (!url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/)) {
-        finalUrl = 'https://' + url
-      }
-      window.open(finalUrl, '_blank', 'noopener,noreferrer')
+    if (pos !== null && findLinkAtPosition(view, pos)) {
       event.preventDefault()
       return true
     }
+  }
 
+  const target = event.target as HTMLElement
+  if (!target.classList.contains('cm-md-checklist-checkbox') &&
+      !target.closest('.cm-md-checklist-checkbox')) {
     return false
-  },
+  }
+
+  const pos = view.posAtCoords({ x: event.clientX, y: event.clientY })
+  if (pos === null) return false
+
+  const line = view.state.doc.lineAt(pos)
+  const info = parseLine(line.text, false)
+  if (info?.type !== 'checklist' || info.bracketPos === undefined) return false
+
+  const bracketPos = line.from + info.bracketPos
+  const newText = info.checked ? '[ ]' : '[x]'
+
+  // Save current selection and restore it after the toggle
+  const selection = view.state.selection
+  view.dispatch({
+    changes: { from: bracketPos, to: bracketPos + 3, insert: newText },
+    selection,
+  })
+  event.preventDefault()
+  return true
+}
+
+/** Cmd+click (Mac) or Ctrl+click (Windows/Linux) to open links. */
+function handleEditorClick(event: MouseEvent, view: EditorView): boolean {
+  if (event.button !== 0) return false
+  if (!event.metaKey && !event.ctrlKey) {
+    return false
+  }
+
+  const pos = view.posAtCoords({ x: event.clientX, y: event.clientY })
+  if (pos === null) {
+    return false
+  }
+
+  const url = findLinkAtPosition(view, pos)
+  if (url) {
+    let finalUrl = url
+    if (!url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/)) {
+      finalUrl = 'https://' + url
+    }
+    window.open(finalUrl, '_blank', 'noopener,noreferrer')
+    event.preventDefault()
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Show a pointer cursor when Cmd/Ctrl is held over a link by toggling
+ * LINK_HOVER_CLASS on view.dom (the theme supplies the actual cursor style).
+ *
+ * Known limitation: the affordance only updates on mousemove and keyup — if
+ * the user rests the mouse on a link and then presses Cmd/Ctrl without moving,
+ * the cursor won't change until they move again. Fixing it would require
+ * tracking the last mouse coords and reacting to keydown; we've decided the
+ * extra state isn't worth it for the uncommon "hover, then press modifier"
+ * ordering. Revisit if users report it.
+ */
+function handleEditorMousemove(event: MouseEvent, view: EditorView): boolean {
+  let wantHover = false
+  if (event.metaKey || event.ctrlKey) {
+    const pos = view.posAtCoords({ x: event.clientX, y: event.clientY })
+    wantHover = pos !== null && findLinkAtPosition(view, pos) !== null
+  }
+  view.dom.classList.toggle(LINK_HOVER_CLASS, wantHover)
+  return false
+}
+
+function handleEditorMouseleave(_event: MouseEvent, view: EditorView): boolean {
+  view.dom.classList.remove(LINK_HOVER_CLASS)
+  return false
+}
+
+/** Clear the pointer cursor when the modifier is released without moving the mouse. */
+function handleEditorKeyup(event: KeyboardEvent, view: EditorView): boolean {
+  if (!event.metaKey && !event.ctrlKey) {
+    view.dom.classList.remove(LINK_HOVER_CLASS)
+  }
+  return false
+}
+
+const clickHandler = EditorView.domEventHandlers({
+  mousedown: handleEditorMousedown,
+  click: handleEditorClick,
+  mousemove: handleEditorMousemove,
+  mouseleave: handleEditorMouseleave,
+  keyup: handleEditorKeyup,
 })
 
 /**
@@ -1435,4 +1496,10 @@ export const _testExports = {
   findBlockquoteSyntax,
   findJinjaExpressions,
   parseLine,
+  findLinkAtPosition,
+  handleEditorMousedown,
+  handleEditorClick,
+  handleEditorMousemove,
+  handleEditorMouseleave,
+  handleEditorKeyup,
 }

--- a/frontend/src/utils/markdownStyleExtension.ts
+++ b/frontend/src/utils/markdownStyleExtension.ts
@@ -33,6 +33,10 @@ interface LineInfo {
   type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'bullet' | 'numbered' | 'checklist' | 'blockquote' | 'code-start' | 'code-end' | 'code-content' | 'hr'
   checked?: boolean
   bracketPos?: number   // Position of [ character for editing
+  // For list-type lines (bullet/numbered/checklist): number of characters from
+  // the start of the line through the marker's trailing space. Used for
+  // hanging-indent so wrapped lines align with the content start (KAN-111).
+  prefixLen?: number
 }
 
 function parseLine(text: string, inCodeBlock: boolean): LineInfo | null {
@@ -58,17 +62,20 @@ function parseLine(text: string, inCodeBlock: boolean): LineInfo | null {
   const checklistMatch = text.match(/^(\s*)([-*+])\s+\[([ xX])\]\s/)
   if (checklistMatch) {
     const checked = checklistMatch[3].toLowerCase() === 'x'
-    const indent = checklistMatch[1].length
-    // bracketPos: position of [ character - for editing when clicked
-    const bracketPos = indent + checklistMatch[2].length + 1 // indent + "-" + " "
-    return { type: 'checklist', checked, bracketPos }
+    // bracketPos: position of [ character — computed from the actual match so
+    // it stays correct for multi-space variants like "-  [ ]". Used by the
+    // click-to-toggle handler to dispatch the 3-char checkbox replacement.
+    const bracketPos = checklistMatch[0].indexOf('[')
+    return { type: 'checklist', checked, bracketPos, prefixLen: checklistMatch[0].length }
   }
 
   // Bullet lists
-  if (/^\s*[-*+]\s/.test(text)) return { type: 'bullet' }
+  const bulletMatch = text.match(/^\s*[-*+]\s/)
+  if (bulletMatch) return { type: 'bullet', prefixLen: bulletMatch[0].length }
 
   // Numbered lists
-  if (/^\s*\d+\.\s/.test(text)) return { type: 'numbered' }
+  const numberedMatch = text.match(/^\s*\d+\.\s/)
+  if (numberedMatch) return { type: 'numbered', prefixLen: numberedMatch[0].length }
 
   // Blockquotes
   if (text.startsWith('>')) return { type: 'blockquote' }
@@ -534,9 +541,109 @@ const jinjaTagContentMark = Decoration.mark({ class: 'cm-md-jinja-tag-content' }
 const jinjaCommentMark = Decoration.mark({ class: 'cm-md-jinja-comment' })
 
 /**
+ * Build a cache key capturing the dimensions that actually affect a prefix's
+ * rendered width: type, indent width, and marker shape (marker char for
+ * bullets, digit count for numbered, checked state for checklists).
+ *
+ * Intentional trade-off: two structurally distinct prefixes of equal length
+ * can collide in theory (and their widths may differ sub-pixel in
+ * proportional fonts), but within a single list all items share the same
+ * structure, so this keeps the cache O(distinct list structures) instead of
+ * O(distinct prefix texts) — important for, e.g., a 500-item numbered list
+ * where keying on literal prefix would cause 500 forced layouts on first
+ * render.
+ */
+function prefixCacheKey(info: LineInfo, prefix: string): string {
+  if (info.type === 'checklist' && info.bracketPos !== undefined) {
+    const indent = info.bracketPos - 2 // "- " between indent and "[" is 2 chars
+    return `c|${indent}|${info.checked ? 1 : 0}`
+  }
+  if (info.type === 'numbered') {
+    const m = prefix.match(/^(\s*)(\d+)/)
+    if (m) return `n|${m[1].length}|${m[2].length}`
+  }
+  if (info.type === 'bullet') {
+    const m = prefix.match(/^(\s*)([-*+])/)
+    if (m) return `b|${m[1].length}|${m[2]}`
+  }
+  return `${info.type}|${prefix}` // fallback
+}
+
+/**
+ * Measure the pixel width of a list line's prefix as it renders in the editor.
+ * Uses a hidden probe appended to a measurement host that sits as a child of
+ * view.dom — NOT view.contentDOM — so it doesn't trigger CM6's
+ * MutationObserver on the contenteditable region (which could misinterpret
+ * the mutation as user input).
+ *
+ * For checklists, the probe mirrors the inline decoration structure
+ * (`cm-md-checklist-syntax` on "- ", `cm-md-checklist-checkbox` on
+ * "[ ]"/"[x]"), which differ from plain text in font-family, font-size,
+ * font-weight, and padding — without this, wrapped checklist lines would be
+ * under-indented by several pixels.
+ *
+ * Results are cached per prefixCacheKey; the cache is cleared by the plugin
+ * on geometry changes (e.g., font swaps). Failed measurements (width === 0,
+ * e.g., jsdom or a detached host) are deliberately NOT cached so a later
+ * successful measurement can populate the cache.
+ */
+function measurePrefixWidth(
+  host: HTMLElement,
+  info: LineInfo,
+  prefix: string,
+  cache: Map<string, number>,
+): number {
+  const key = prefixCacheKey(info, prefix)
+  const cached = cache.get(key)
+  if (cached !== undefined) return cached
+
+  const probe = document.createElement('span')
+  probe.style.cssText = 'white-space:pre;'
+
+  if (info.type === 'checklist' && info.bracketPos !== undefined) {
+    // Mirror the inline decorations applied to the real prefix:
+    //   [plain leading indent][syntax span: "- "][checkbox span: "[ ]"][plain trailing space]
+    const syntaxFrom = info.bracketPos - 2 // where "- " starts = indent length
+    const bracketEnd = info.bracketPos + 3 // after "[ ]" or "[x]"
+
+    if (syntaxFrom > 0) {
+      probe.appendChild(document.createTextNode(prefix.slice(0, syntaxFrom)))
+    }
+    const syntax = document.createElement('span')
+    syntax.className = 'cm-md-checklist-syntax'
+    syntax.textContent = prefix.slice(syntaxFrom, info.bracketPos)
+    probe.appendChild(syntax)
+
+    const checkbox = document.createElement('span')
+    checkbox.className = info.checked
+      ? 'cm-md-checklist-checkbox cm-md-checklist-checkbox-checked'
+      : 'cm-md-checklist-checkbox cm-md-checklist-checkbox-unchecked'
+    checkbox.textContent = prefix.slice(info.bracketPos, bracketEnd)
+    probe.appendChild(checkbox)
+
+    if (bracketEnd < prefix.length) {
+      probe.appendChild(document.createTextNode(prefix.slice(bracketEnd)))
+    }
+  } else {
+    probe.textContent = prefix
+  }
+
+  host.appendChild(probe)
+  const width = probe.getBoundingClientRect().width
+  host.removeChild(probe)
+
+  if (width > 0) cache.set(key, width)
+  return width
+}
+
+/**
  * Build decorations for the entire document.
  */
-function buildDecorations(view: EditorView): DecorationSet {
+function buildDecorations(
+  view: EditorView,
+  prefixWidthCache: Map<string, number>,
+  measurementHost: HTMLElement,
+): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>()
   let inCodeBlock = false
 
@@ -558,7 +665,17 @@ function buildDecorations(view: EditorView): DecorationSet {
       if (info.type === 'checklist' && info.checked) {
         lineClass += ' cm-md-checklist-checked'
       }
-      builder.add(line.from, line.from, Decoration.line({ class: lineClass }))
+      const spec: Parameters<typeof Decoration.line>[0] = { class: lineClass }
+      if (info.prefixLen !== undefined) {
+        // Per-line hanging-indent width (KAN-111) so wrapped list lines align
+        // with the content after the marker. See measurePrefixWidth.
+        const prefix = line.text.slice(0, info.prefixLen)
+        const width = measurePrefixWidth(measurementHost, info, prefix, prefixWidthCache)
+        if (width > 0) {
+          spec.attributes = { style: `--md-list-indent: ${width}px` }
+        }
+      }
+      builder.add(line.from, line.from, Decoration.line(spec))
     }
 
     // Add inline decorations (only outside of code blocks)
@@ -803,15 +920,34 @@ const cursorInCodeBlockPlugin = ViewPlugin.fromClass(
 const markdownDecorationPlugin = ViewPlugin.fromClass(
   class {
     decorations: DecorationSet
+    // Cache of measured prefix widths (see measurePrefixWidth). Cleared when
+    // geometry changes so font swaps (mono ↔ proportional) remeasure.
+    prefixWidthCache = new Map<string, number>()
+    // Off-screen host for prefix measurement probes. Lives under view.dom
+    // (not view.contentDOM) to avoid triggering CM6's MutationObserver on the
+    // contenteditable region.
+    measurementHost: HTMLElement
 
     constructor(view: EditorView) {
-      this.decorations = buildDecorations(view)
+      this.measurementHost = document.createElement('div')
+      this.measurementHost.className = 'cm-md-measure'
+      this.measurementHost.style.cssText =
+        'position:absolute;visibility:hidden;pointer-events:none;top:0;left:-9999px;white-space:pre;'
+      view.dom.appendChild(this.measurementHost)
+      this.decorations = buildDecorations(view, this.prefixWidthCache, this.measurementHost)
     }
 
     update(update: ViewUpdate): void {
-      if (update.docChanged || update.viewportChanged) {
-        this.decorations = buildDecorations(update.view)
+      if (update.geometryChanged) {
+        this.prefixWidthCache.clear()
       }
+      if (update.docChanged || update.viewportChanged || update.geometryChanged) {
+        this.decorations = buildDecorations(update.view, this.prefixWidthCache, this.measurementHost)
+      }
+    }
+
+    destroy(): void {
+      this.measurementHost.remove()
     }
   },
   {
@@ -898,9 +1034,14 @@ const markdownBaseTheme = EditorView.theme({
     textDecoration: 'none',
   },
 
-  // Lists
+  // Lists — hanging indent so wrapped lines align with content after the
+  // marker (KAN-111). The --md-list-indent custom property is set per line in
+  // buildDecorations from a pixel measurement of the actual prefix text.
+  // text-indent pulls the first visual line back to column 0 while
+  // padding-left applies to wrapped lines.
   '.cm-md-bullet, .cm-md-numbered, .cm-md-checklist': {
-    paddingLeft: '0.5em',
+    paddingLeft: 'calc(0.5em + var(--md-list-indent, 0px))',
+    textIndent: 'calc(-1 * var(--md-list-indent, 0px))',
   },
 
   // Checklist items

--- a/frontend/src/utils/slashCommands.test.ts
+++ b/frontend/src/utils/slashCommands.test.ts
@@ -88,7 +88,7 @@ describe('buildCommands', () => {
       'Heading 3',
       'Bulleted list',
       'Numbered list',
-      'To-do list',
+      'Checklist',
       'Code block',
       'Blockquote',
       'Link',
@@ -108,7 +108,7 @@ describe('buildCommands', () => {
       'Heading 3',
       'Bulleted list',
       'Numbered list',
-      'To-do list',
+      'Checklist',
       'Code block',
       'Blockquote',
       'Link',
@@ -352,7 +352,7 @@ describe('apply functions', () => {
       ['Heading 3', '### '],
       ['Bulleted list', '- '],
       ['Numbered list', '1. '],
-      ['To-do list', '- [ ] '],
+      ['Checklist', '- [ ] '],
       ['Blockquote', '> '],
     ])('test__apply__%s__inserts_correct_text', (label: string, expected: string) => {
       const result = applyCommand('/', label)

--- a/frontend/src/utils/slashCommands.ts
+++ b/frontend/src/utils/slashCommands.ts
@@ -43,7 +43,7 @@ const SVG_ICONS: Record<string, string> = {
   h3: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h8"/><path d="M4 18V6"/><path d="M12 18V6"/><path d="M17.5 10.5c1.7-1 3.5 0 3.5 1.5a2 2 0 0 1-2 2"/><path d="M17 17.5c2 1.5 4 .3 4-1.5a2 2 0 0 0-2-2"/></svg>',
   bullet: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h12M8 12h12M8 18h12"/><circle cx="3" cy="6" r="1" fill="currentColor" stroke="none"/><circle cx="3" cy="12" r="1" fill="currentColor" stroke="none"/><circle cx="3" cy="18" r="1" fill="currentColor" stroke="none"/></svg>',
   number: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 6h11M10 12h11M10 18h11"/><text x="2" y="9" font-size="8" fill="currentColor" stroke="none" font-weight="600">1</text><text x="2" y="15" font-size="8" fill="currentColor" stroke="none" font-weight="600">2</text><text x="2" y="21" font-size="8" fill="currentColor" stroke="none" font-weight="600">3</text></svg>',
-  todo: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="14" height="14" rx="2"/><path stroke-width="2.5" d="M6 12l3 3 5-5"/></svg>',
+  checklist: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="14" height="14" rx="2"/><path stroke-width="2.5" d="M6 12l3 3 5-5"/></svg>',
   code: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4c-2 0-3 1-3 3v3c0 1.5-1 2-2 2 1 0 2 .5 2 2v3c0 2 1 3 3 3M16 4c2 0 3 1 3 3v3c0 1.5 1 2 2 2-1 0-2 .5-2 2v3c0 2-1 3-3 3"/></svg>',
   quote: '<svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="2.5" height="16" rx="1" fill="currentColor"/><path d="M10 8h10M10 12h8M10 16h6" stroke="currentColor" stroke-width="2"/></svg>',
   link: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.828 10.172a4 4 0 0 0-5.656 0l-4 4a4 4 0 1 0 5.656 5.656l1.102-1.101"/><path d="M10.172 13.828a4 4 0 0 0 5.656 0l4-4a4 4 0 0 0-5.656-5.656l-1.1 1.1"/></svg>',
@@ -109,7 +109,7 @@ function buildCommands(showJinjaTools: boolean): Completion[] {
     { label: 'Heading 3', detail: '###', type: 'h3', section: BASIC_SECTION, boost: 4, apply: applySimple('### ') },
     { label: 'Bulleted list', detail: '-', type: 'bullet', section: BASIC_SECTION, boost: 3, apply: applySimple('- ') },
     { label: 'Numbered list', detail: '1.', type: 'number', section: BASIC_SECTION, boost: 2, apply: applySimple('1. ') },
-    { label: 'To-do list', detail: '- [ ]', type: 'todo', section: BASIC_SECTION, boost: 1, apply: applySimple('- [ ] ') },
+    { label: 'Checklist', detail: '- [ ]', type: 'checklist', section: BASIC_SECTION, boost: 1, apply: applySimple('- [ ] ') },
     {
       label: 'Code block',
       detail: '```',
@@ -215,9 +215,9 @@ function createSlashCommandSource(showJinjaTools: boolean): CompletionSource {
 // ---------------------------------------------------------------------------
 
 const SHORTCUT_MAP: Record<string, string[]> = {
-  bullet: ['⌘', '⇧', '8'],
-  number: ['⌘', '⇧', '7'],
-  todo: ['⌘', '⇧', '9'],
+  bullet: ['⌘', '⇧', '7'],
+  number: ['⌘', '⇧', '8'],
+  checklist: ['⌘', '⇧', '9'],
   quote: ['⌘', '⇧', '.'],
   code: ['⌘', '⇧', 'E'],
   link: ['⌘', 'K'],


### PR DESCRIPTION
## Summary

Small, independent fixes across the frontend and one backend limit bump. Each change is self-contained and reviewable in isolation by commit.

## Changes

- **[KAN-122](https://tiddly.atlassian.net/browse/KAN-122)** — Shortcuts dialog migrated to the shared `Modal` component. Fixes the overflow bug (long columns ran off the fixed-height dialog with no scroll) and deletes ~140 lines of duplicated modal plumbing. Behavior change: backdrop click no longer dismisses (consistent with every other modal).
- **[KAN-111](https://tiddly.atlassian.net/browse/KAN-111)** — CodeMirror editor now hanging-indents wrapped list lines so soft-wrapped text aligns under the content after the marker. Measures prefix pixel widths via a hidden probe, caches per `(type, indent, marker, checked)`, and exposes it as a `--md-list-indent` CSS var. Also fixes a latent checklist toggle bug on lines with multi-space spacing.
- **[KAN-108](https://tiddly.atlassian.net/browse/KAN-108)** — Cmd/Ctrl+click on a link in the markdown editor no longer drops a secondary cursor. Intercepts the mousedown before CodeMirror's default multi-cursor handler runs, and adds a hover-with-modifier pointer affordance.
- **[KAN-113](https://tiddly.atlassian.net/browse/KAN-113)** — Unified the checkbox-list feature under one name ("Checklist") across labels, identifiers, CSS classes, and tests. Previously called "Task list" in the toolbar and "To-do list" in the slash menu. Also fixes list-shortcut drift: `⌘⇧7/8/9` now mean Bullet/Numbered/Checklist in both editors (was swapped 7↔8 in Milkdown).
- **[KAN-115](https://tiddly.atlassian.net/browse/KAN-115)** — Public header now has a mobile hamburger menu with Product/Docs/Pricing. The nav was previously `hidden sm:flex`, so users on <640px viewports couldn't reach those pages.
- **Prompt argument description limit**: bumped from 500 → 1000 chars in `tier_limits.py` to match the prompt-level limit. JSONB column, no migration.

## Impact

- **Behavior changes** worth calling out: shortcuts dialog no longer dismisses on backdrop click (Esc/X only); list shortcut keybindings reshuffled to match visual order (old muscle memory for `⌘⇧7`/`⌘⇧8` in Milkdown will be reversed).
- **No breaking API changes**, no dependencies added, no migrations needed.
- **Areas worth a closer look in review**:
  - `markdownStyleExtension.ts` — largest diff; the prefix-measurement probe and cache keying are the subtle parts.
  - KAN-113 renames touch a lot of files; bridging comments call out the GFM-locked spots where "task" legitimately stays (`data-item-type="task"`, `list_item.attrs.checked`).
- **Manual verification owed on KAN-122** (the one I just finished): short-viewport scroll behavior, narrow/wide column layout, backdrop tint, padding — not covered by JSDOM tests.