### PR TITLE
KAN-123: Preserve latest versioned history record during time-based cleanup

### DIFF
--- a/backend/src/tasks/cleanup.py
+++ b/backend/src/tasks/cleanup.py
@@ -17,8 +17,9 @@ import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from core.tier_limits import TIER_LIMITS, Tier
 from models.bookmark import Bookmark
@@ -125,11 +126,18 @@ async def cleanup_expired_history(
     now: datetime | None = None,
 ) -> CleanupStats:
     """
-    Delete history records older than retention period, batched by tier.
+    Delete history records older than retention period, batched by tier,
+    except the most recent versioned record per entity.
 
     For each tier:
     1. Calculate the cutoff date based on tier's history_retention_days
-    2. Delete all history records for users in that tier older than cutoff
+    2. Delete all aged history records for users in that tier EXCEPT the
+       single most recent versioned record per (user_id, entity_type, entity_id)
+
+    Preserving the latest versioned record per entity guarantees diff and
+    restore remain functional after long idle periods. Audit records
+    (DELETE/UNDELETE/ARCHIVE/UNARCHIVE — NULL version) carry no diff/restore
+    value and remain fully subject to time-based pruning.
 
     This is more efficient than per-user deletion as it executes one DELETE
     per tier rather than one per user.
@@ -151,8 +159,21 @@ async def cleanup_expired_history(
     for tier, limits in TIER_LIMITS.items():
         cutoff = now - timedelta(days=limits.history_retention_days)
 
-        # Delete history for all users in this tier with aged records
-        # Use coalesce to handle NULL tier values (default to FREE)
+        # Delete aged history for users in this tier, preserving the single
+        # latest versioned row per entity. Use coalesce to handle NULL tier
+        # values (default to FREE).
+        #
+        # A row is deletable when aged AND either:
+        #   - it's an audit row (version IS NULL), OR
+        #   - a higher-versioned row exists for the same entity.
+        #
+        # IMPORTANT — foot-gun warning: do NOT narrow the `newer` self-alias
+        # by `newer.created_at < cutoff` or similar. The comparison must span
+        # ALL versioned rows for the entity (aged or fresh). Narrowing to
+        # aged-only would preserve a stale aged anchor even when a fresh
+        # higher-versioned row already exists, reintroducing the original bug
+        # in a different shape.
+        newer = aliased(ContentHistory)
         delete_stmt = delete(ContentHistory).where(
             ContentHistory.user_id.in_(
                 select(User.id).where(
@@ -160,6 +181,16 @@ async def cleanup_expired_history(
                 ),
             ),
             ContentHistory.created_at < cutoff,
+            or_(
+                ContentHistory.version.is_(None),
+                select(1).where(
+                    newer.user_id == ContentHistory.user_id,
+                    newer.entity_type == ContentHistory.entity_type,
+                    newer.entity_id == ContentHistory.entity_id,
+                    newer.version.is_not(None),
+                    newer.version > ContentHistory.version,
+                ).exists(),
+            ),
         )
 
         result = await db.execute(delete_stmt)

--- a/backend/tests/services/test_history_integration.py
+++ b/backend/tests/services/test_history_integration.py
@@ -1,4 +1,6 @@
 """Integration tests for history recording in services."""
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from uuid import UUID, uuid4
 
@@ -9,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core import tier_limits
 from core.request_context import AuthType, RequestContext
 from core.tier_limits import Tier, TierLimits, get_tier_limits
+from models.bookmark import Bookmark
 from models.content_history import ActionType, ContentHistory, EntityType
 from models.user import User
 from schemas.bookmark import BookmarkCreate, BookmarkUpdate
@@ -19,6 +22,7 @@ from services.bookmark_service import BookmarkService, DuplicateUrlError
 from services.history_service import PRUNE_CHECK_INTERVAL, history_service
 from services.note_service import NoteService
 from services.prompt_service import PromptService
+from tasks.cleanup import cleanup_expired_history
 
 
 @pytest.fixture
@@ -1681,3 +1685,201 @@ class TestRelationshipHistoryIntegration:
         history = await get_entity_history(db_session, test_user.id, EntityType.PROMPT, prompt.id)
         assert len(history) == 1
         assert len(history[0].metadata_snapshot['relationships']) == 1
+
+
+class TestCleanupPreservationServicePathRegression:
+    """
+    Symptom-level regression test for KAN-123.
+
+    After time-based cleanup on a long-idle entity, the next edit driven
+    through the service layer must still produce a working diff and a
+    restorable anchor. Drives the post-cleanup update through
+    BookmarkService.update (not a direct ORM insert) so record_action
+    correctly reads the preserved predecessor when computing the next diff.
+    """
+
+    @pytest.mark.parametrize(
+        "starting_state",
+        ["versioned-aged", "audit-only-aged"],
+    )
+    async def test__edit_after_long_idle_produces_working_diff_and_anchor(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+        starting_state: str,
+    ) -> None:
+        """
+        Edit through the service after cleanup produces a working diff/anchor.
+
+        Two starting states:
+
+        - versioned-aged: multiple aged versioned rows. Preservation rule
+          retains the latest (v2); the next edit anchors on it and the diff
+          endpoint reads v2's metadata as `before_metadata`.
+
+        - audit-only-aged: only aged audit rows (e.g. ARCHIVE/UNARCHIVE).
+          This is a legacy-data edge case — it only arises for entities whose
+          CREATE record was deleted by pre-fix cleanup runs. New entities
+          always retain their CREATE. The contract here is a
+          pruned-predecessor UPDATE: `_get_next_version` over NULL versions
+          yields 1, so the first post-cleanup edit lands at v1 with
+          `action='update'`, `content_diff` set, `content_snapshot` None,
+          and `before_metadata` None on the diff endpoint. The frontend's
+          "Previous metadata unavailable" branch is the expected UX here.
+        """
+        now = datetime.now(UTC)
+        aged_at = now - timedelta(days=60)  # past FREE retention
+        service = BookmarkService()
+        limits = get_tier_limits(Tier.FREE)
+        context = make_context()
+
+        # Seed entity and aged history directly (bypasses service for seeding
+        # only — the post-cleanup edit below goes through the service).
+        bookmark = Bookmark(
+            user_id=test_user.id,
+            url="https://example.com/post-cleanup",
+            title="Current entity title",
+            content="current content",
+        )
+        db_session.add(bookmark)
+        await db_session.flush()
+
+        seeded_v2_metadata: dict | None = None
+        if starting_state == "versioned-aged":
+            # v1 CREATE (aged), v2 UPDATE (aged, metadata differs from entity).
+            db_session.add(ContentHistory(
+                user_id=test_user.id,
+                entity_type=EntityType.BOOKMARK.value,
+                entity_id=bookmark.id,
+                action=ActionType.CREATE.value,
+                version=1,
+                content_snapshot="v1 content",
+                metadata_snapshot={
+                    "title": "v1 title",
+                    "url": "https://example.com/post-cleanup",
+                    "tags": [],
+                },
+                source="web",
+                auth_type=AuthType.AUTH0.value,
+                created_at=aged_at,
+            ))
+            seeded_v2_metadata = {
+                "title": "v2 title",
+                "url": "https://example.com/post-cleanup",
+                "tags": [{"name": "tag-v2"}],
+            }
+            # Real reverse diff v2 -> v1. The test's assertions don't depend
+            # on this value being walked (reconstruction at v2 anchors on
+            # entity.content and applies v3's diff, not v2's), but using a
+            # valid diff here makes the test robust to future changes in
+            # reconstruction semantics — a failure would then point at the
+            # preservation rule, not a cryptic diff parser error.
+            v2_reverse_diff = history_service.dmp.patch_toText(
+                history_service.dmp.patch_make("v2 content", "v1 content"),
+            )
+            db_session.add(ContentHistory(
+                user_id=test_user.id,
+                entity_type=EntityType.BOOKMARK.value,
+                entity_id=bookmark.id,
+                action=ActionType.UPDATE.value,
+                version=2,
+                content_snapshot=None,
+                content_diff=v2_reverse_diff,
+                metadata_snapshot=seeded_v2_metadata,
+                source="web",
+                auth_type=AuthType.AUTH0.value,
+                created_at=aged_at,
+            ))
+        else:  # audit-only-aged
+            for action in [ActionType.ARCHIVE, ActionType.UNARCHIVE]:
+                db_session.add(ContentHistory(
+                    user_id=test_user.id,
+                    entity_type=EntityType.BOOKMARK.value,
+                    entity_id=bookmark.id,
+                    action=action.value,
+                    version=None,
+                    content_snapshot=None,
+                    content_diff=None,
+                    metadata_snapshot={"title": "audit"},
+                    source="web",
+                    auth_type=AuthType.AUTH0.value,
+                    created_at=aged_at,
+                ))
+        await db_session.commit()
+
+        # Inject a `now` that makes all seeded rows aged, and run cleanup.
+        await cleanup_expired_history(db_session, now=now)
+
+        # Verify expected surviving set.
+        surviving = await get_entity_history(
+            db_session, test_user.id, EntityType.BOOKMARK, bookmark.id,
+        )
+        if starting_state == "versioned-aged":
+            assert len(surviving) == 1
+            assert surviving[0].version == 2
+        else:
+            assert len(surviving) == 0
+
+        # Drive the post-cleanup edit through the service.
+        await service.update(
+            db_session,
+            test_user.id,
+            bookmark.id,
+            BookmarkUpdate(
+                title="title after edit",
+                content="updated content after long idle",
+            ),
+            limits,
+            context,
+        )
+
+        post = await get_entity_history(
+            db_session, test_user.id, EntityType.BOOKMARK, bookmark.id,
+        )
+
+        if starting_state == "versioned-aged":
+            # Exactly [preserved v2, new v3].
+            assert [r.version for r in post] == [2, 3]
+            new_record = post[-1]
+            assert new_record.action == ActionType.UPDATE.value
+            assert new_record.content_diff is not None
+
+            # Diff endpoint reads the right predecessor — v2's metadata.
+            diff = await history_service.get_version_diff(
+                db_session, test_user.id, EntityType.BOOKMARK, bookmark.id, 3,
+            )
+            assert diff.found is True
+            assert diff.before_metadata is not None
+            assert seeded_v2_metadata is not None
+            assert diff.before_metadata["title"] == seeded_v2_metadata["title"]
+            assert diff.before_metadata["url"] == seeded_v2_metadata["url"]
+            assert diff.before_metadata["tags"] == seeded_v2_metadata["tags"]
+
+            # Restore anchor works: reconstructing at v2 applies v3's
+            # reverse diff to the current entity content, yielding the
+            # pre-edit content.
+            recon = await history_service.reconstruct_content_at_version(
+                db_session, test_user.id, EntityType.BOOKMARK, bookmark.id, 2,
+            )
+            assert recon.found is True
+            assert recon.content == "current content"
+        else:
+            # audit-only-aged: pruned-predecessor UPDATE contract.
+            # _get_next_version over NULL versions yields 1; the first
+            # post-cleanup edit lands at v1 with action='update',
+            # content_diff set, content_snapshot None. Not a CREATE path.
+            assert len(post) == 1
+            new_record = post[-1]
+            assert new_record.version == 1
+            assert new_record.action == ActionType.UPDATE.value
+            assert new_record.content_diff is not None
+            assert new_record.content_snapshot is None
+
+            # Diff endpoint for v1 returns no predecessor metadata (no v0).
+            # Frontend renders "Previous metadata unavailable" here —
+            # expected degraded UX for this legacy-data edge.
+            diff = await history_service.get_version_diff(
+                db_session, test_user.id, EntityType.BOOKMARK, bookmark.id, 1,
+            )
+            assert diff.found is True
+            assert diff.before_metadata is None

--- a/backend/tests/tasks/test_cleanup.py
+++ b/backend/tests/tasks/test_cleanup.py
@@ -5,7 +5,7 @@ These tests verify the cleanup logic handles all edge cases correctly
 since this is critical code that deletes production user data.
 """
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import func, select, text
@@ -18,6 +18,7 @@ from models.content_history import ActionType, ContentHistory, EntityType
 from models.note import Note
 from models.prompt import Prompt
 from models.user import User
+from services.history_service import history_service
 from tasks.cleanup import (
     SOFT_DELETE_EXPIRY_DAYS,
     CleanupStats,
@@ -48,6 +49,62 @@ def create_history_record(
         version=version,
         content_snapshot=f"Content v{version}",
         metadata_snapshot={"title": f"Test v{version}"},
+        source="web",
+        auth_type=AuthType.AUTH0.value,
+        created_at=created_at,
+    )
+
+
+def create_versioned_history_record(
+    user_id: UUID,
+    entity_type: EntityType,
+    entity_id: UUID,
+    version: int,
+    action: ActionType = ActionType.CREATE,
+    content_snapshot: str | None = None,
+    content_diff: str | None = None,
+    metadata: dict | None = None,
+    created_at: datetime | None = None,
+) -> ContentHistory:
+    """
+    Create a versioned ContentHistory record with explicit action/content shape.
+
+    Prefer over `create_history_record` when you need to control
+    content_snapshot/content_diff explicitly (e.g. UPDATE with diff only,
+    modulo-10 snapshot, CREATE with snapshot only).
+    """
+    return ContentHistory(
+        user_id=user_id,
+        entity_type=entity_type.value,
+        entity_id=entity_id,
+        action=action.value,
+        version=version,
+        content_snapshot=content_snapshot,
+        content_diff=content_diff,
+        metadata_snapshot=metadata or {"title": f"Test v{version}"},
+        source="web",
+        auth_type=AuthType.AUTH0.value,
+        created_at=created_at,
+    )
+
+
+def create_audit_history_record(
+    user_id: UUID,
+    entity_type: EntityType,
+    entity_id: UUID,
+    action: ActionType,
+    created_at: datetime | None = None,
+) -> ContentHistory:
+    """Create an audit (NULL version) ContentHistory record."""
+    return ContentHistory(
+        user_id=user_id,
+        entity_type=entity_type.value,
+        entity_id=entity_id,
+        action=action.value,
+        version=None,
+        content_snapshot=None,
+        content_diff=None,
+        metadata_snapshot={"title": "Audit marker"},
         source="web",
         auth_type=AuthType.AUTH0.value,
         created_at=created_at,
@@ -378,80 +435,113 @@ class TestCleanupExpiredHistoryBoundaryConditions:
         db_session: AsyncSession,
         user: User,
     ) -> None:
-        """Record created just past the retention boundary should be deleted."""
+        """
+        Record created just past the retention boundary should be deleted.
+
+        The preservation rule protects the *latest* versioned row per entity,
+        so this test seeds a fresh higher-versioned anchor (v2) to ensure
+        v1 is not the latest and thus remains deletable.
+        """
         now = datetime.now(UTC)
         entity_id = uuid4()
 
-        just_past_cutoff = now - timedelta(days=FREE_RETENTION_DAYS, seconds=1)
-        record = create_history_record(
+        # Fresh anchor (v2) so v1 is not the latest versioned row.
+        db_session.add(create_history_record(
             user_id=user.id,
             entity_type=EntityType.NOTE,
             entity_id=entity_id,
+            version=2,
+            created_at=now - timedelta(hours=1),
+        ))
+        just_past_cutoff = now - timedelta(days=FREE_RETENTION_DAYS, seconds=1)
+        db_session.add(create_history_record(
+            user_id=user.id,
+            entity_type=EntityType.NOTE,
+            entity_id=entity_id,
+            version=1,
             created_at=just_past_cutoff,
-        )
-        db_session.add(record)
+        ))
         await db_session.commit()
 
         stats = await cleanup_expired_history(db_session, now=now)
 
         assert stats.expired_deleted == 1
         assert stats.expired_by_tier[Tier.FREE.value] == 1
-        assert await count_history_records(db_session, user.id) == 0
+        # v2 anchor remains; v1 deleted.
+        assert await count_history_records(db_session, user.id) == 1
 
     async def test__well_past_boundary__record_is_deleted(
         self,
         db_session: AsyncSession,
         user: User,
     ) -> None:
-        """Record created well past the retention boundary should be deleted."""
+        """
+        Record created well past the retention boundary should be deleted.
+
+        Seeds a fresh higher-versioned anchor (v2) so the aged v1 is not the
+        latest versioned row and thus remains deletable under the preservation
+        rule.
+        """
         now = datetime.now(UTC)
         entity_id = uuid4()
 
-        # Create record well past retention
-        record = create_history_record(
+        # Fresh anchor (v2) so v1 is not the latest versioned row.
+        db_session.add(create_history_record(
             user_id=user.id,
             entity_type=EntityType.NOTE,
             entity_id=entity_id,
+            version=2,
+            created_at=now - timedelta(hours=1),
+        ))
+        db_session.add(create_history_record(
+            user_id=user.id,
+            entity_type=EntityType.NOTE,
+            entity_id=entity_id,
+            version=1,
             created_at=now - timedelta(days=FREE_RETENTION_DAYS + 5),
-        )
-        db_session.add(record)
+        ))
         await db_session.commit()
 
-        # Run cleanup
         stats = await cleanup_expired_history(db_session, now=now)
 
-        # Verify record WAS deleted
+        # v1 deleted; v2 anchor remains.
         assert stats.expired_deleted == 1
-        assert await count_history_records(db_session, user.id) == 0
+        assert await count_history_records(db_session, user.id) == 1
 
     async def test__mixed_ages__only_old_deleted(
         self,
         db_session: AsyncSession,
         user: User,
     ) -> None:
-        """With mixed record ages, only records past retention are deleted."""
+        """
+        With mixed record ages, only records past retention are deleted.
+
+        Versions are seeded so higher version = newer (realistic entity
+        evolution). v5 is fresh and serves as the latest-versioned anchor,
+        so all aged rows (v1, v2, v3) are deletable under the preservation
+        rule. v4 is exactly at the cutoff and preserved by strict `<`.
+        """
         now = datetime.now(UTC)
         entity_id = uuid4()
 
-        # Create records at various ages relative to retention period
+        # Higher version = newer (chronological with entity evolution).
         r = FREE_RETENTION_DAYS
         ages_and_expected = [
-            (timedelta(hours=1), True),                # just now - keep
-            (timedelta(days=r), True),                 # exactly at boundary - keep
-            (timedelta(days=r, seconds=1), False),     # just past boundary - delete
-            (timedelta(days=r + 5), False),            # well past boundary - delete
-            (timedelta(days=r * 10), False),           # far past boundary - delete
+            (timedelta(days=r * 10), False),           # v1 far past - delete
+            (timedelta(days=r + 5), False),            # v2 well past - delete
+            (timedelta(days=r, seconds=1), False),     # v3 just past - delete
+            (timedelta(days=r), True),                 # v4 exactly at boundary - keep
+            (timedelta(hours=1), True),                # v5 fresh / latest - keep
         ]
 
-        for version, (age, should_keep) in enumerate(ages_and_expected, 1):
-            record = create_history_record(
+        for version, (age, _) in enumerate(ages_and_expected, 1):
+            db_session.add(create_history_record(
                 user_id=user.id,
                 entity_type=EntityType.NOTE,
                 entity_id=entity_id,
                 version=version,
                 created_at=now - age,
-            )
-            db_session.add(record)
+            ))
         await db_session.commit()
 
         stats = await cleanup_expired_history(db_session, now=now)
@@ -469,12 +559,18 @@ class TestCleanupExpiredHistoryBatchByTier:
         self,
         db_session: AsyncSession,
     ) -> None:
-        """Multiple users in same tier are cleaned with single DELETE per tier."""
+        """
+        Multiple users in the same tier are cleaned with a single DELETE per tier.
+
+        Each user's entity gets a fresh v2 anchor so the aged v1 remains
+        deletable under the preservation rule. Verifies the tier-batched
+        DELETE applies to aged rows across all users in one statement.
+        """
         now = datetime.now(UTC)
 
         # Create 3 users all in FREE tier
         users = []
-        for i in range(3):
+        for _ in range(3):
             user = User(
                 auth0_id=f"test-tier-{uuid4()}",
                 email=f"tier-{uuid4()}@test.com",
@@ -484,26 +580,32 @@ class TestCleanupExpiredHistoryBatchByTier:
             users.append(user)
         await db_session.flush()
 
-        # Each user has old records
+        # Each user: aged v1 + fresh v2 anchor (so v1 is deletable).
+        entity_ids = {user.id: uuid4() for user in users}
         for user in users:
             db_session.add(create_history_record(
                 user_id=user.id,
                 entity_type=EntityType.NOTE,
-                entity_id=uuid4(),
+                entity_id=entity_ids[user.id],
+                version=1,
                 created_at=now - timedelta(days=60),
+            ))
+            db_session.add(create_history_record(
+                user_id=user.id,
+                entity_type=EntityType.NOTE,
+                entity_id=entity_ids[user.id],
+                version=2,
+                created_at=now - timedelta(hours=1),
             ))
         await db_session.commit()
 
-        # Run cleanup
         stats = await cleanup_expired_history(db_session, now=now)
 
-        # All 3 records deleted, tracked by tier
+        # 3 aged v1 rows deleted in one tier DELETE; 3 fresh v2 anchors remain.
         assert stats.expired_deleted == 3
         assert stats.expired_by_tier[Tier.FREE.value] == 3
-
-        # All users cleaned
         for user in users:
-            assert await count_history_records(db_session, user.id) == 0
+            assert await count_history_records(db_session, user.id) == 1
 
     async def test__unknown_tier__not_cleaned_by_any_tier(
         self,
@@ -568,25 +670,563 @@ class TestCleanupExpiredHistoryEntityTypes:
         db_session: AsyncSession,
         user: User,
     ) -> None:
-        """Cleanup applies to bookmark, note, and prompt history equally."""
+        """
+        Cleanup applies to bookmark, note, and prompt history equally.
+
+        Each entity gets an aged v1 + fresh v2 anchor so the aged rows
+        remain deletable under the preservation rule.
+        """
         now = datetime.now(UTC)
 
-        # Create old records for each entity type
         for entity_type in [EntityType.BOOKMARK, EntityType.NOTE, EntityType.PROMPT]:
+            entity_id = uuid4()
             db_session.add(create_history_record(
                 user_id=user.id,
                 entity_type=entity_type,
-                entity_id=uuid4(),
+                entity_id=entity_id,
+                version=1,
                 created_at=now - timedelta(days=60),
+            ))
+            db_session.add(create_history_record(
+                user_id=user.id,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                version=2,
+                created_at=now - timedelta(hours=1),
             ))
         await db_session.commit()
 
-        # Run cleanup
         stats = await cleanup_expired_history(db_session, now=now)
 
-        # All 3 records deleted
+        # 3 aged v1 rows deleted across entity types; 3 fresh v2 anchors remain.
+        assert stats.expired_deleted == 3
+        assert await count_history_records(db_session, user.id) == 3
+
+
+class TestCleanupExpiredHistoryPreservesLatestVersioned:
+    """
+    Tests for the preservation rule in cleanup_expired_history.
+
+    Rule: always preserve the single most recent versioned ContentHistory row
+    per (user_id, entity_type, entity_id), regardless of age. Audit rows
+    (NULL version) are never "latest" for this rule — they remain fully
+    subject to time-based pruning.
+    """
+
+    @pytest.fixture
+    async def user(self, db_session: AsyncSession) -> User:
+        """Create a test user on FREE tier."""
+        user = User(
+            auth0_id=f"test-preserve-{uuid4()}",
+            email=f"preserve-{uuid4()}@test.com",
+            tier=Tier.FREE.value,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+
+    async def test_preserves_only_versioned_record_when_aged(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """A single aged versioned row is preserved (not deleted)."""
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        db_session.add(create_history_record(
+            user_id=user.id,
+            entity_type=EntityType.NOTE,
+            entity_id=entity_id,
+            version=1,
+            created_at=now - timedelta(days=FREE_RETENTION_DAYS + 10),
+        ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        assert stats.expired_deleted == 0
+        assert await count_history_records(db_session, user.id) == 1
+
+    async def test_preserves_latest_and_deletes_older_aged_records(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """Multiple aged versioned rows: only the highest-version row survives."""
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        for version in [1, 2, 3]:
+            db_session.add(create_history_record(
+                user_id=user.id,
+                entity_type=EntityType.NOTE,
+                entity_id=entity_id,
+                version=version,
+                created_at=aged_at,
+            ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        assert stats.expired_deleted == 2
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].version == 3
+
+    async def test_mixed_aged_and_fresh_records(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """
+        Mixed aged and fresh versioned rows for one entity: fresh rows always
+        preserved. Aged rows deleted when any higher versioned row exists.
+        """
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        fresh_at = now - timedelta(hours=1)
+
+        # v1, v2 aged; v3 fresh (higher than both aged).
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=1, created_at=aged_at,
+        ))
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=2, created_at=aged_at,
+        ))
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=3, created_at=fresh_at,
+        ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        # v1, v2 deleted (v3 higher exists). v3 preserved (fresh and latest).
+        assert stats.expired_deleted == 2
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert [r.version for r in rows] == [3]
+
+    async def test_audit_records_still_deleted_when_aged(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """Aged audit records (NULL version) are deleted; not exempted."""
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        for action in [ActionType.ARCHIVE, ActionType.UNARCHIVE, ActionType.DELETE]:
+            db_session.add(create_audit_history_record(
+                user_id=user.id,
+                entity_type=EntityType.NOTE,
+                entity_id=entity_id,
+                action=action,
+                created_at=aged_at,
+            ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
         assert stats.expired_deleted == 3
         assert await count_history_records(db_session, user.id) == 0
+
+    async def test_audit_record_does_not_count_as_latest(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """
+        The "latest" anchor is the latest *versioned* row, not the latest row.
+        An aged audit row newer than all versioned rows is still deleted;
+        the latest versioned row is preserved.
+        """
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        old_aged = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        newer_aged = now - timedelta(days=FREE_RETENTION_DAYS + 2)
+
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=1, created_at=old_aged,
+        ))
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=2, created_at=old_aged,
+        ))
+        db_session.add(create_audit_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            action=ActionType.ARCHIVE, created_at=newer_aged,
+        ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        # v1 deleted (v2 higher). Audit deleted. v2 preserved (latest versioned).
+        assert stats.expired_deleted == 2
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].version == 2
+
+    async def test_preservation_is_per_entity_not_per_user(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """
+        One user, two entities: each entity independently retains its own
+        latest versioned row. Partition is per (user_id, entity_type, entity_id).
+        """
+        now = datetime.now(UTC)
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        bookmark_id, note_id = uuid4(), uuid4()
+        for entity_type, entity_id in [
+            (EntityType.BOOKMARK, bookmark_id),
+            (EntityType.NOTE, note_id),
+        ]:
+            for version in [1, 2]:
+                db_session.add(create_history_record(
+                    user_id=user.id, entity_type=entity_type,
+                    entity_id=entity_id,
+                    version=version, created_at=aged_at,
+                ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        # Each entity preserves its v2; each v1 deleted. 2 deleted, 2 preserved.
+        assert stats.expired_deleted == 2
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert len(rows) == 2
+        assert {r.entity_id for r in rows} == {bookmark_id, note_id}
+        assert all(r.version == 2 for r in rows)
+
+    async def test_preservation_respects_tier_boundaries(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """
+        Users in different tiers: each user's entity retains exactly its
+        latest versioned row, even when all rows are aged past both tier
+        cutoffs. Confirms the per-tier DELETE loop interacts correctly with
+        the preservation rule.
+        """
+        now = datetime.now(UTC)
+        # Aged well past PRO's 15-day retention (and FREE's 1-day).
+        aged_at = now - timedelta(days=100)
+
+        free_user = User(
+            auth0_id=f"free-{uuid4()}", email=f"free-{uuid4()}@test.com",
+            tier=Tier.FREE.value,
+        )
+        pro_user = User(
+            auth0_id=f"pro-{uuid4()}", email=f"pro-{uuid4()}@test.com",
+            tier=Tier.PRO.value,
+        )
+        db_session.add_all([free_user, pro_user])
+        await db_session.flush()
+
+        free_entity_id, pro_entity_id = uuid4(), uuid4()
+        for u, entity_id in [(free_user, free_entity_id), (pro_user, pro_entity_id)]:
+            for version in [1, 2]:
+                db_session.add(create_history_record(
+                    user_id=u.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+                    version=version, created_at=aged_at,
+                ))
+        await db_session.commit()
+
+        await cleanup_expired_history(db_session, now=now)
+
+        for u, entity_id in [(free_user, free_entity_id), (pro_user, pro_entity_id)]:
+            rows = (await db_session.execute(
+                select(ContentHistory).where(ContentHistory.user_id == u.id),
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].version == 2
+            assert rows[0].entity_id == entity_id
+
+    async def test_soft_deleted_entity_history_preserved_like_active(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """
+        Soft-deleted (but not yet permanently deleted) entities: the latest
+        versioned history row is still preserved by time-based cleanup.
+        Permanent deletion via cleanup_soft_deleted_items cascades all
+        history — covered by TestCleanupSoftDeletedItems.
+        """
+        now = datetime.now(UTC)
+        note = Note(
+            user_id=user.id,
+            title="Soft deleted",
+            content="Content",
+            deleted_at=now - timedelta(days=5),  # inside 30-day cutoff
+        )
+        db_session.add(note)
+        await db_session.flush()
+
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        for version in [1, 2]:
+            db_session.add(create_history_record(
+                user_id=user.id, entity_type=EntityType.NOTE, entity_id=note.id,
+                version=version, created_at=aged_at,
+            ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        # v1 deleted; v2 preserved (latest versioned).
+        assert stats.expired_deleted == 1
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].version == 2
+
+    async def test_boundary_exactly_at_cutoff_unchanged(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """
+        Strict `<` comparison preserves rows exactly at the cutoff, and this
+        interacts correctly with the preservation rule. A row at cutoff
+        that would otherwise be a non-latest version (and thus deletable)
+        is preserved because it is not aged by strict `<`.
+        """
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        at_cutoff = now - timedelta(days=FREE_RETENTION_DAYS)  # not aged (strict <)
+        aged = now - timedelta(days=FREE_RETENTION_DAYS, seconds=1)
+
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=1, created_at=at_cutoff,
+        ))
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=2, created_at=aged,
+        ))
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=3, created_at=aged,
+        ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        # v1 at cutoff: not aged → preserved.
+        # v2 aged; v3 higher exists → deleted.
+        # v3 aged; no higher versioned row → preserved (latest).
+        assert stats.expired_deleted == 1
+        rows = (await db_session.execute(
+            select(ContentHistory)
+            .where(ContentHistory.user_id == user.id)
+            .order_by(ContentHistory.version),
+        )).scalars().all()
+        assert [r.version for r in rows] == [1, 3]
+
+    async def test_preservation_follows_latest_across_runs(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """
+        Preservation re-evaluates "latest" on each run. After one cleanup
+        preserves the current latest, inserting a higher-versioned aged row
+        and re-running deletes the previously preserved row and preserves
+        the new latest.
+        """
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+
+        for version in [1, 2, 3]:
+            db_session.add(create_history_record(
+                user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+                version=version, created_at=aged_at,
+            ))
+        await db_session.commit()
+
+        await cleanup_expired_history(db_session, now=now)
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert [r.version for r in rows] == [3]
+
+        # Insert a higher-versioned aged row.
+        db_session.add(create_history_record(
+            user_id=user.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+            version=4, created_at=aged_at,
+        ))
+        await db_session.commit()
+
+        await cleanup_expired_history(db_session, now=now)
+
+        # v3 now deleted (v4 higher exists). v4 preserved.
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert [r.version for r in rows] == [4]
+
+    async def test_same_tier_users_isolated(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """
+        Two users in the same tier: the tier-batched DELETE preserves each
+        user's own latest versioned row. Partition is per
+        (user_id, entity_type, entity_id); users don't bleed into each other.
+        """
+        now = datetime.now(UTC)
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        user_a = User(
+            auth0_id=f"a-{uuid4()}", email=f"a-{uuid4()}@test.com",
+            tier=Tier.FREE.value,
+        )
+        user_b = User(
+            auth0_id=f"b-{uuid4()}", email=f"b-{uuid4()}@test.com",
+            tier=Tier.FREE.value,
+        )
+        db_session.add_all([user_a, user_b])
+        await db_session.flush()
+
+        entity_a, entity_b = uuid4(), uuid4()
+        for u, entity_id in [(user_a, entity_a), (user_b, entity_b)]:
+            for version in [1, 2]:
+                db_session.add(create_history_record(
+                    user_id=u.id, entity_type=EntityType.NOTE, entity_id=entity_id,
+                    version=version, created_at=aged_at,
+                ))
+        await db_session.commit()
+
+        await cleanup_expired_history(db_session, now=now)
+
+        for u, entity_id in [(user_a, entity_a), (user_b, entity_b)]:
+            rows = (await db_session.execute(
+                select(ContentHistory).where(ContentHistory.user_id == u.id),
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].version == 2
+            assert rows[0].entity_id == entity_id
+
+    @pytest.mark.parametrize(
+        ("preserved_version", "has_snapshot"),
+        [
+            (5, False),   # non-modulo-10: diff only, no snapshot
+            (10, True),   # modulo-10: snapshot set
+        ],
+    )
+    async def test_view_content_at_preserved_version(
+        self,
+        db_session: AsyncSession,
+        user: User,
+        preserved_version: int,
+        has_snapshot: bool,
+    ) -> None:
+        """
+        After cleanup leaves a single preserved row, reconstruction at that
+        version returns correct content. Pins both shapes: modulo-10
+        (snapshot present) and non-modulo (diff only, entity.content anchor).
+
+        When target_version == latest_version (single-row post-cleanup),
+        reconstruction short-circuits: returns content_snapshot if present,
+        else entity.content. Both should equal the entity's current content.
+        """
+        now = datetime.now(UTC)
+        entity_content = "current content"
+        note = Note(user_id=user.id, title="Test", content=entity_content)
+        db_session.add(note)
+        await db_session.flush()
+
+        aged_at = now - timedelta(days=FREE_RETENTION_DAYS + 10)
+        # UPDATE row at `preserved_version` with a real reverse diff
+        # (preserved_version -> preserved_version-1). content_snapshot is set
+        # only for modulo-10 versions per real-system semantics. Generating
+        # a valid diff here (instead of a placeholder) makes the test robust
+        # if reconstruction ever changes to apply the target row's own diff —
+        # a failure would then point at the preservation rule, not a cryptic
+        # diff parser error.
+        reverse_diff = history_service.dmp.patch_toText(
+            history_service.dmp.patch_make(entity_content, "prior content"),
+        )
+        db_session.add(create_versioned_history_record(
+            user_id=user.id,
+            entity_type=EntityType.NOTE,
+            entity_id=note.id,
+            version=preserved_version,
+            action=ActionType.UPDATE,
+            content_snapshot=entity_content if has_snapshot else None,
+            content_diff=reverse_diff,
+            created_at=aged_at,
+        ))
+        await db_session.commit()
+
+        await cleanup_expired_history(db_session, now=now)
+
+        # Single row preserved.
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].version == preserved_version
+        assert (rows[0].content_snapshot is not None) is has_snapshot
+
+        # Reconstruction at the preserved version returns entity.content.
+        result = await history_service.reconstruct_content_at_version(
+            db_session, user.id, EntityType.NOTE, note.id, preserved_version,
+        )
+        assert result.found is True
+        assert result.content == entity_content
+
+    async def test_create_only_entity_preserved_when_aged(
+        self,
+        db_session: AsyncSession,
+        user: User,
+    ) -> None:
+        """
+        Entity with exactly one history record — a CREATE (action='create',
+        version=1, content_snapshot set, content_diff None) — aged past
+        cutoff is preserved. CREATE rows are first-class preservation-eligible
+        rows; not excluded by any check that assumes content_diff is set.
+        """
+        now = datetime.now(UTC)
+        entity_id = uuid4()
+        db_session.add(create_versioned_history_record(
+            user_id=user.id,
+            entity_type=EntityType.NOTE,
+            entity_id=entity_id,
+            version=1,
+            action=ActionType.CREATE,
+            content_snapshot="Initial content",
+            content_diff=None,
+            created_at=now - timedelta(days=FREE_RETENTION_DAYS + 10),
+        ))
+        await db_session.commit()
+
+        stats = await cleanup_expired_history(db_session, now=now)
+
+        assert stats.expired_deleted == 0
+        rows = (await db_session.execute(
+            select(ContentHistory).where(ContentHistory.user_id == user.id),
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].action == ActionType.CREATE.value
+        assert rows[0].version == 1
+        assert rows[0].content_snapshot == "Initial content"
+        assert rows[0].content_diff is None
 
 
 class TestCleanupOrphanedHistory:
@@ -985,7 +1625,13 @@ class TestRunCleanupIntegration:
         self,
         db_session: AsyncSession,
     ) -> None:
-        """Verify detailed breakdown in stats matches actual deletions."""
+        """
+        Verify detailed breakdown in stats matches actual deletions.
+
+        Three aged v1 rows share one entity_id so they're non-latest relative
+        to a fresh v4 anchor; this keeps them deletable under the preservation
+        rule while still exercising the tier DELETE stats.
+        """
         now = datetime.now(UTC)
 
         user = User(
@@ -996,15 +1642,27 @@ class TestRunCleanupIntegration:
         db_session.add(user)
         await db_session.flush()
 
-        # Create 3 old history records
-        for v in range(1, 4):
+        # One real entity with 3 aged rows (v1, v2, v3) and a fresh v4 anchor.
+        # The real Note prevents the preserved v4 anchor from being caught by
+        # orphan cleanup later in run_cleanup.
+        real_note = Note(user_id=user.id, title="Real", content="Content")
+        db_session.add(real_note)
+        await db_session.flush()
+        for v in [1, 2, 3]:
             db_session.add(create_history_record(
                 user_id=user.id,
                 entity_type=EntityType.NOTE,
-                entity_id=uuid4(),
+                entity_id=real_note.id,
                 version=v,
                 created_at=now - timedelta(days=60),
             ))
+        db_session.add(create_history_record(
+            user_id=user.id,
+            entity_type=EntityType.NOTE,
+            entity_id=real_note.id,
+            version=4,
+            created_at=now - timedelta(hours=1),
+        ))
 
         # Add orphans of different types
         db_session.add(create_history_record(
@@ -1036,7 +1694,7 @@ class TestRunCleanupIntegration:
         assert stats.soft_deleted_expired == 2
         assert stats.soft_deleted_by_type["notes"] == 2
 
-        # Verify expired breakdown
+        # Verify expired breakdown: 3 aged rows deleted, v4 anchor preserved.
         assert stats.expired_by_tier[Tier.FREE.value] == 3
         assert stats.expired_deleted == 3
 
@@ -1074,12 +1732,25 @@ class TestRunCleanupIntegration:
         db_session.add(deleted_note)
         await db_session.flush()
 
-        # 2. Old history record
+        # 2. Old history record (v1 aged) + fresh v2 anchor so v1 is deletable
+        #    under the preservation rule. Anchor to a real Note so the v2
+        #    anchor isn't swept up as an orphan by step 3 of run_cleanup.
+        real_note = Note(user_id=user.id, title="Real", content="Content")
+        db_session.add(real_note)
+        await db_session.flush()
         db_session.add(create_history_record(
             user_id=user.id,
             entity_type=EntityType.NOTE,
-            entity_id=uuid4(),
+            entity_id=real_note.id,
+            version=1,
             created_at=now - timedelta(days=60),
+        ))
+        db_session.add(create_history_record(
+            user_id=user.id,
+            entity_type=EntityType.NOTE,
+            entity_id=real_note.id,
+            version=2,
+            created_at=now - timedelta(hours=1),
         ))
 
         # 3. Orphaned history

--- a/docs/content-versioning.md
+++ b/docs/content-versioning.md
@@ -251,6 +251,8 @@ A nightly cron job:
 2. Deletes history records older than each tier's `history_retention_days`
 3. Also permanently deletes soft-deleted entities older than 30 days (with their history)
 
+**Preservation rule:** The most recent versioned history record per entity is always retained, regardless of age. Audit records (DELETE/UNDELETE/ARCHIVE/UNARCHIVE) are not exempted. This guarantees that diff and restore remain functional after long idle periods.
+
 ### Hard Delete Cascade
 
 When an entity is permanently deleted:
@@ -335,8 +337,8 @@ Optimistic concurrency control (ETags/If-Match) is a separate feature that may b
 ### Inactive Entities and Time-Based Cleanup
 
 If an entity hasn't been edited for longer than `history_retention_days`:
-- All history records may be deleted by time-based cleanup
+- All history records **except the most recent versioned record** may be deleted by time-based cleanup. The retained record serves as the anchor for diff and restore on the next edit.
+- Audit records (DELETE/UNDELETE/ARCHIVE/UNARCHIVE) are not exempted and remain fully subject to time-based pruning.
 - The entity itself remains (with current content)
-- History simply starts fresh if the entity is edited again
 
 ---

--- a/docs/implementation_plans/2026-04-20-history-keep-last-record.md
+++ b/docs/implementation_plans/2026-04-20-history-keep-last-record.md
@@ -204,6 +204,19 @@ Do **not** make `EXPLAIN ANALYZE` a gating requirement. Both shapes plan well in
 10. **`test_preservation_follows_latest_across_runs`**
     Seed an entity with multiple aged versioned rows, run cleanup (leaves the latest preserved), then insert a *new* aged versioned row with a higher `version`, then run cleanup again. Assert: the previously-preserved row is now deleted (it is no longer the latest), and the new row is preserved. This catches bugs where preservation was cached, where `rn = 1` was computed against a stale view, or where the NOT EXISTS predicate was written against the wrong partition.
 
+11. **`test_same_tier_users_isolated`**
+    Two users **in the same tier**, each with their own entity and aged versioned rows → each user's entity retains exactly its own latest versioned row (2 rows preserved total). Distinct from #7 (which crosses tiers) and #6 (which uses a single user). The tier-batched DELETE runs one statement across all users in the tier; this test confirms the `(user_id, entity_type, entity_id)` partition keeps users isolated within a tier.
+
+12. **`test_view_content_at_preserved_version`** *(parameterized)*
+    After cleanup preserves a single versioned row, confirm `reconstruct_content_at_version` (the path used by the view-at-version endpoint) returns correct content for that version. **Parameterize over two shapes of the preserved row:**
+    - Preserved row is at a non-modulo-10 version (e.g., v5) → `content_snapshot` is None, row has `content_diff` only. Reconstruction must anchor on `entity.content` and skip the diff (target == latest, no diffs to apply).
+    - Preserved row is at a modulo-10 version (e.g., v10) → `content_snapshot` is set. Reconstruction can anchor on the snapshot.
+
+    Assert the returned content equals the entity's current content in both shapes. This pins the reconstruction path through a single-row post-cleanup history, which is a distinct code path from restore and from the diff endpoint.
+
+13. **`test_create_only_entity_preserved_when_aged`**
+    Entity with exactly one history record — a CREATE action (`action='create'`, `version=1`, `content_snapshot` set, `content_diff` None) — aged past cutoff → the CREATE record is preserved. Confirms CREATE records are first-class preservation-eligible rows (not accidentally excluded by a check that assumes `content_diff IS NOT NULL`).
+
 ### Symptom-level regression test (REQUIRED — the highest-value test in this milestone)
 
 The tests above prove rows survive/die correctly. This test proves the **user-visible bug is actually fixed**: that after cleanup, the next edit through the normal service path produces a working diff and a restorable anchor.
@@ -214,7 +227,7 @@ The tests above prove rows survive/die correctly. This test proves the **user-vi
 
 **Parameterize over both starting states** (use `pytest.mark.parametrize`):
 
-- **`versioned-aged`**: entity has multiple aged versioned history rows, all past cutoff.
+- **`versioned-aged`**: entity has multiple aged versioned history rows, all past cutoff. Seed so the preserved (latest versioned) row ends up at a version > 1 with a populated `metadata_snapshot` that differs from the post-edit state (so we can assert the diff endpoint reads the right `before_metadata`).
 - **`audit-only-aged`**: entity has only aged audit rows (e.g., ARCHIVE/UNARCHIVE), all past cutoff, no versioned rows.
 
 For each starting state:
@@ -223,10 +236,15 @@ For each starting state:
 2. Run `cleanup_expired_history` with an injected `now` that makes all seeded rows aged.
 3. Verify the expected surviving set (versioned-aged → exactly the latest versioned row survives; audit-only-aged → zero history rows survive).
 4. Perform an update on the entity **through the service layer** (e.g., `BookmarkService.update` / the path that calls `record_action`).
-5. Assert:
-   - A new `ContentHistory` row is written with a non-null `content_diff` when a predecessor exists; for `audit-only-aged`, the first post-cleanup edit behaves like a fresh CREATE (snapshot, no diff, version allocation is sensible — whatever `_get_next_version` yields here is the contract, pin it explicitly).
-   - `get_version_diff` for the new version returns non-null `before_metadata` when a predecessor exists (versioned-aged case); for audit-only-aged, the diff endpoint behaves as it does for a genuine CREATE.
-   - Restore to the preserved prior version succeeds (versioned-aged case only; nothing to restore to in audit-only-aged).
+5. Assert (versioned-aged):
+   - A new `ContentHistory` row is written with a non-null `content_diff`.
+   - `get_version_diff` for the new version returns non-null `before_metadata`, **and its contents equal the preserved row's `metadata_snapshot` field-for-field** (title, tags, url/name as applicable). This pins that the diff endpoint reads the right predecessor, not just that *some* predecessor exists.
+   - `GET /history` for the entity (the list endpoint) returns the preserved row plus the new row — exactly the set we expect post-cleanup + post-edit. This confirms the history list endpoint reflects the post-cleanup state correctly.
+   - Restore to the preserved prior version succeeds and returns the preserved row's content.
+6. Assert (audit-only-aged):
+   - The first post-cleanup edit behaves like a fresh CREATE: `content_snapshot` set, `content_diff` None, version allocation is sensible — pin whatever `_get_next_version` yields here as the contract.
+   - The diff endpoint behaves as it does for a genuine CREATE (no predecessor metadata).
+   - `GET /history` returns exactly the one new row.
 
 Parameterizing this way subsumes the audit-only-edge concern without needing a separate test.
 
@@ -280,4 +298,3 @@ These don't belong inside the milestone work. Include them in the PR description
 
 - **Behavior change, not bugfix framing:** previously-documented behavior in `docs/content-versioning.md` (history starts fresh after long idle) is being changed, not restored. Doc updated in same PR.
 - **Storage footprint shift:** `content_history` row count now scales with live-entity count (one retained row per entity for long-idle entities), not strictly with retention days. Still bounded — one row per entity is tiny, and hard-delete cascades still clean up. Noting so future "why is this table growing" investigations land here.
-- **Telemetry check before merging:** if any Grafana/Railway alert watches `expired_deleted` volume, confirm it won't false-alarm on the expected drop for tiers with many long-idle entities. Quick check with whoever owns cleanup telemetry.

--- a/docs/implementation_plans/2026-04-20-history-keep-last-record.md
+++ b/docs/implementation_plans/2026-04-20-history-keep-last-record.md
@@ -106,17 +106,14 @@ Two shapes are equally correct. **Prefer `NOT EXISTS` as the primary form** — 
 #### Primary: NOT EXISTS
 
 ```python
-# Bind the tier-users subquery once and reuse, so the planner sees one scan.
-tier_users = (
-    select(User.id)
-    .where(func.coalesce(User.tier, Tier.FREE.value) == tier.value)
-    .subquery()
-)
-
 newer = aliased(ContentHistory)
 
 delete_stmt = delete(ContentHistory).where(
-    ContentHistory.user_id.in_(select(tier_users.c.id)),
+    ContentHistory.user_id.in_(
+        select(User.id).where(
+            func.coalesce(User.tier, Tier.FREE.value) == tier.value,
+        ),
+    ),
     ContentHistory.created_at < cutoff,
     # Preserve the single latest versioned row per entity: delete only if
     # this row is an audit row (version IS NULL), OR a higher-versioned row
@@ -148,8 +145,7 @@ Same semantics via a CTE that ranks versioned rows per entity, then deletes aged
 #### Notes (apply to either shape)
 
 - Audit rows (`version IS NULL`) are never "latest" for preservation purposes. They remain fully subject to `created_at < cutoff`.
-- Keep the existing `coalesce(User.tier, Tier.FREE.value)` tier resolution.
-- Bind the tier-users subquery once per tier iteration and reuse it, so the planner sees a single scan rather than two.
+- Keep the existing inline `coalesce(User.tier, Tier.FREE.value)` tier resolution — mirror the existing style in the file. Do **not** wrap it in a separate `.subquery()` binding: with the NOT EXISTS shape, the tier-users select is only referenced once (in the outer `user_id.in_(...)`), so the binding adds indirection without planner benefit.
 - Preserve the existing `result.rowcount`, `CleanupStats`, and log line. The semantics of `expired_deleted` are unchanged ("rows deleted by this function").
 - Update the function docstring (`cleanup.py:127`) to reflect the new invariant: it no longer "deletes all history records older than retention period" — it deletes all such records *except the most recent versioned record per entity*.
 
@@ -241,10 +237,11 @@ For each starting state:
    - `get_version_diff` for the new version returns non-null `before_metadata`, **and its contents equal the preserved row's `metadata_snapshot` field-for-field** (title, tags, url/name as applicable). This pins that the diff endpoint reads the right predecessor, not just that *some* predecessor exists.
    - `GET /history` for the entity (the list endpoint) returns the preserved row plus the new row — exactly the set we expect post-cleanup + post-edit. This confirms the history list endpoint reflects the post-cleanup state correctly.
    - Restore to the preserved prior version succeeds and returns the preserved row's content.
-6. Assert (audit-only-aged):
-   - The first post-cleanup edit behaves like a fresh CREATE: `content_snapshot` set, `content_diff` None, version allocation is sensible — pin whatever `_get_next_version` yields here as the contract.
-   - The diff endpoint behaves as it does for a genuine CREATE (no predecessor metadata).
+6. Assert (audit-only-aged) — **this is NOT a CREATE path, despite being v1. Pin the shape explicitly:**
+   - The new row is an UPDATE-at-v1: `action == 'update'`, `version == 1`, `content_diff is not None`, `content_snapshot is None`. `_get_next_version` returns 1 because `max(version)` over non-null versions is None with only audit rows present; `record_action` then follows the UPDATE branch since the entity already exists with differing content.
+   - `get_version_diff` for the new version returns `before_metadata is None` (no v0 record to read metadata from) and `action == 'update'`. The frontend "Previous metadata unavailable" branch is the expected, acceptable UX for this case.
    - `GET /history` returns exactly the one new row.
+   - **Do not attempt to "fix" the v1-update-with-diff shape in this PR.** File as a follow-up observation in the milestone summary (see §1.5). Semantic context: this state only arises for *legacy data* whose CREATE record was deleted by pre-fix cleanup runs. New entities always have their CREATE preserved by this fix, so they never reach audit-only-aged. The legacy cohort ages out over time; no ongoing gap.
 
 Parameterizing this way subsumes the audit-only-edge concern without needing a separate test.
 
@@ -287,8 +284,9 @@ No other docs should need updating. Specifically:
 
 After implementation + tests + doc updates are complete and `make backend-verify` passes, **stop and wait for human review.** Do not commit. Summarize:
 - Final query approach chosen (NOT EXISTS vs ranked CTE vs other).
-- Any test surprises, especially in the symptom-level regression test (version allocation behavior for audit-only-aged starting state is the most likely surprise).
+- Any test surprises.
 - Any assumption you had to make that wasn't explicitly answered in §"Questions the Agent Should Raise."
+- **Follow-up observation (do not fix in this PR):** the audit-only-aged starting state produces a v1 UPDATE-with-diff-no-snapshot row — unusual shape, but semantically consistent and bounded to pre-fix legacy data. Note whether the `GET /history` and diff-endpoint behavior for this row was as expected.
 
 ---
 

--- a/docs/implementation_plans/2026-04-20-history-keep-last-record.md
+++ b/docs/implementation_plans/2026-04-20-history-keep-last-record.md
@@ -1,0 +1,240 @@
+# Implementation Plan: Preserve Most Recent Versioned History Record During Time-Based Cleanup
+
+**Ticket:** [KAN-123](https://tiddly.atlassian.net/browse/KAN-123)
+**Date:** 2026-04-20
+**Scope:** Backend only. Single file change + tests + doc update.
+
+---
+
+## Background
+
+### The Problem
+
+The nightly time-based history cleanup (`cleanup_expired_history` in `backend/src/tasks/cleanup.py`) deletes any `ContentHistory` row older than the user's tier `history_retention_days` (FREE=1, STANDARD=5, PRO=15).
+
+If an entity (bookmark/note/prompt) is idle longer than that window, **all** of its history is deleted. On the next user edit:
+
+1. A new history record is written with a `content_diff` against an entity snapshot, but with **no predecessor record** to show the "before" state.
+2. The frontend renders `Previous metadata unavailable` (see `frontend/src/components/MetadataChanges.tsx:295`) — no diff, no "before" metadata.
+3. The **Restore** button is effectively dead: it restores to the *previous* version record, which no longer exists.
+
+This is a degraded, confusing UX for any user on a short retention window who revisits an older item.
+
+### The Fix (chosen approach)
+
+Modify `cleanup_expired_history` so it always preserves the **single most recent versioned record** (highest `version`, `version IS NOT NULL`) per `(user_id, entity_type, entity_id)` regardless of age. Audit records (`version IS NULL` — DELETE/UNDELETE/ARCHIVE/UNARCHIVE) remain fully eligible for time-based pruning because they carry no diff/restore value.
+
+Once this fix lands:
+- Diff/Restore on the "first edit after long idle" works because there's always a prior anchor record.
+- Worst-case storage is bounded (≤1 extra row per entity, cleaned automatically on hard delete via existing cascade).
+- No schema migration, no API change, no frontend change.
+
+### Out of Scope
+
+- Count-based inline pruning (`history_service._prune_to_limit`) already preserves the N most recent versions correctly; do not touch it.
+- `cleanup_soft_deleted_items` (permanent-delete flow) should behave exactly as before — when the entity is hard-deleted, **all** history goes with it via the existing cascade.
+- Synthesizing predecessor records on save (Option B in the review) — explicitly rejected.
+- Frontend "Undo" alternative — explicitly rejected.
+
+---
+
+## Prerequisite Reading
+
+Before implementing, the agent MUST read:
+
+1. `docs/content-versioning.md` — full spec, especially §"Retention and Cleanup" and §"Inactive Entities and Time-Based Cleanup".
+2. `backend/src/tasks/cleanup.py` — the entire file, to understand the three cleanup functions and how they compose.
+3. `backend/src/models/content_history.py` — the `ContentHistory` model, noting that `version` is nullable (audit actions) and the unique constraint `(user_id, entity_type, entity_id, version)` treats NULL as exempt.
+4. `backend/src/core/tier_limits.py` — tier retention config.
+5. `backend/tests/tasks/test_cleanup.py` — existing cleanup tests, especially the boundary-condition tests around `cleanup_expired_history`. Mirror the fixture style there.
+6. The Jira ticket description on KAN-123 (use `mcp__atlassian__getJiraIssue`).
+
+**PostgreSQL docs to skim before writing the new query:**
+- Window functions: https://www.postgresql.org/docs/17/tutorial-window.html
+- `ROW_NUMBER()` over `PARTITION BY`: https://www.postgresql.org/docs/17/functions-window.html
+- `DELETE ... USING` / CTE-in-DELETE: https://www.postgresql.org/docs/17/sql-delete.html
+
+**SQLAlchemy 2.0 docs:**
+- Window functions via `over()`: https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.over
+- CTEs with DELETE: https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.CTE
+
+---
+
+## Questions the Agent Should Raise Before Coding
+
+If any of these are unclear after reading the above, stop and ask:
+
+1. **Scope of "most recent"**: confirm the rule is **per `(user_id, entity_type, entity_id)`** (not per user, not per entity type). The plan assumes per-entity.
+2. **Audit records**: confirm that audit records (NULL `version`) should remain subject to time-based deletion and are **not** counted as the "most recent record to preserve." The plan assumes yes.
+3. **Soft-deleted entities**: should we still preserve the latest history row for a soft-deleted entity that is not yet permanently deleted? The plan assumes yes — history lookups work for soft-deleted entities (per spec), and treating them specially adds complexity for little gain. The 30-day soft-delete cascade will clean them up anyway.
+4. **Tier batching**: the current loop batches DELETE per tier for efficiency. The plan preserves this — each tier still gets a single DELETE. Confirm this is fine.
+
+---
+
+# Milestone 1: Preserve Latest Versioned Record in Time-Based Cleanup
+
+**Scope:** one source file, one test file, one doc file. Agent should stop after this milestone for human review.
+
+## 1.1 Goal & Outcome
+
+**Goal:** Ensure `cleanup_expired_history` never deletes the most recent versioned `ContentHistory` row for any entity, even if that row is older than the tier's retention window.
+
+**Outcomes after this milestone:**
+- A user who edits a bookmark/note/prompt that has been idle longer than `history_retention_days` sees a proper diff and working Restore button on the first edit.
+- Each entity retains at least its most recent versioned history record indefinitely (until the entity is hard-deleted, at which point the existing cascade removes it).
+- Audit records (DELETE/UNDELETE/ARCHIVE/UNARCHIVE) continue to be time-pruned as before.
+- `cleanup_soft_deleted_items` and `cleanup_orphaned_history` behavior is unchanged.
+- New tests cover the preservation rule explicitly; existing cleanup tests continue to pass.
+
+## 1.2 Implementation Outline
+
+### What changes
+
+**File:** `backend/src/tasks/cleanup.py`
+
+Rewrite the DELETE inside `cleanup_expired_history` (currently lines 156–163) so that, per tier, it excludes each entity's most recent versioned record. Everything else in the function (tier loop, cutoff computation, stats accounting, logging, commit) stays the same.
+
+### Query shape (guidance, not a copy-paste)
+
+The new query needs to, per tier:
+
+1. Identify the latest *versioned* row per `(user_id, entity_type, entity_id)` among rows owned by users in this tier.
+2. Delete rows in this tier older than `cutoff` **except** those identified in step 1.
+
+A clean way to express this in SQLAlchemy 2.0 is a CTE that ranks rows via `ROW_NUMBER()`:
+
+```python
+from sqlalchemy import case, delete, func, select
+from sqlalchemy.sql import literal_column
+
+# Rank versioned rows per entity; NULL-version rows get rank 0 (never "preserved").
+ranked = (
+    select(
+        ContentHistory.id.label("id"),
+        func.row_number().over(
+            partition_by=(
+                ContentHistory.user_id,
+                ContentHistory.entity_type,
+                ContentHistory.entity_id,
+            ),
+            order_by=ContentHistory.version.desc(),
+        ).label("rn"),
+    )
+    .where(
+        ContentHistory.user_id.in_(
+            select(User.id).where(
+                func.coalesce(User.tier, Tier.FREE.value) == tier.value,
+            ),
+        ),
+        ContentHistory.version.is_not(None),  # only rank versioned rows
+    )
+    .cte("ranked_history")
+)
+
+latest_ids = select(ranked.c.id).where(ranked.c.rn == 1)
+
+delete_stmt = delete(ContentHistory).where(
+    ContentHistory.user_id.in_(
+        select(User.id).where(
+            func.coalesce(User.tier, Tier.FREE.value) == tier.value,
+        ),
+    ),
+    ContentHistory.created_at < cutoff,
+    ContentHistory.id.not_in(latest_ids),
+)
+```
+
+Notes:
+- Do not use `ORDER BY version DESC NULLS LAST` — we explicitly filter `version IS NOT NULL` in the CTE, so ordering is unambiguous.
+- The exclusion set only includes versioned rows. Audit rows (`version IS NULL`) are never in `latest_ids`, so they remain fully subject to `created_at < cutoff`.
+- Keep the existing `coalesce(User.tier, ...)` tier resolution.
+- Preserve the existing `result.rowcount` / stats / logging. The log line can stay the same; the semantics of "expired_deleted" are unchanged (it's still "rows deleted by this function").
+
+If the agent finds a measurably simpler or more idiomatic SQLAlchemy expression (e.g., correlated subquery with `MAX(version)`) that passes all tests and stays inside a single DELETE per tier, that's acceptable. Do not break the "one DELETE per tier" efficiency property.
+
+### What does NOT change
+
+- `cleanup_soft_deleted_items` — untouched.
+- `cleanup_orphaned_history` — untouched.
+- `history_service.py` count-based pruning — untouched.
+- `CleanupStats` shape — untouched.
+- The function signature of `cleanup_expired_history` — untouched.
+- Any migration — none needed.
+
+## 1.3 Testing Strategy
+
+**File:** `backend/tests/tasks/test_cleanup.py` — add tests alongside the existing `cleanup_expired_history` suite. Follow the existing fixture/helper style; do not introduce new testing frameworks or patterns.
+
+**Do NOT mock the database.** Per project convention, history/cleanup tests hit the real test DB. Use the same session/fixture the existing cleanup tests use.
+
+### Required new tests (each as a separate `async def test_...` with type hints)
+
+1. **`test_preserves_only_versioned_record_when_aged`**
+   One entity with a single versioned history row, `created_at` well past the tier cutoff → row is **preserved**. `expired_deleted == 0`.
+
+2. **`test_preserves_latest_and_deletes_older_aged_records`**
+   One entity with several aged versioned rows (all past cutoff) → only the row with the highest `version` is preserved; all others deleted.
+
+3. **`test_mixed_aged_and_fresh_records`**
+   One entity with a mix of aged and fresh (within retention) versioned rows → all fresh rows preserved; aged rows deleted except for the latest aged one *only if* no fresh row with a higher version exists. (If a fresh row with a higher version exists, it is already the latest and no aged row is preserved.) Assert exact surviving set.
+
+4. **`test_audit_records_still_deleted_when_aged`**
+   Entity with aged audit records (NULL `version`) and no versioned rows → all audit records deleted. Confirms audit rows don't get preserved by the new rule.
+
+5. **`test_audit_record_does_not_count_as_latest`**
+   Entity with aged versioned rows plus a *newer* aged audit row → the audit row is deleted and the latest *versioned* row is preserved. This is the key rule: "latest versioned," not "latest row."
+
+6. **`test_preservation_is_per_entity_not_per_user`**
+   One user, two entities (e.g., a bookmark and a note), both with all rows aged past cutoff → each entity retains its own latest versioned row (2 rows preserved total).
+
+7. **`test_preservation_respects_tier_boundaries`**
+   Two users in different tiers (e.g., FREE and PRO), each with an entity whose rows are all aged past *both* cutoffs → each user's entity retains exactly its latest versioned row. Verifies the per-tier DELETE loop still interacts correctly with the preservation rule.
+
+8. **`test_soft_deleted_entity_history_preserved_like_active`**
+   Entity with `deleted_at` set but not yet past the 30-day permanent-delete cutoff → latest versioned history row still preserved by `cleanup_expired_history`. (Permanent deletion via `cleanup_soft_deleted_items` is a separate codepath; confirm that function still cascades all history when the entity is permanently removed — either by reusing an existing test or adding a smoke assertion.)
+
+9. **`test_boundary_exactly_at_cutoff_unchanged`**
+   Re-confirm the existing boundary behavior: a row with `created_at == cutoff` is preserved (strict `<` comparison), and this interacts correctly with the new preservation rule. Likely the existing boundary test still passes; if not, adjust or add.
+
+10. **`test_idempotent_second_run`**
+    Run `cleanup_expired_history` twice in a row on the same seeded data → second run deletes zero rows and leaves the preserved set intact. Guards against a bug where the preservation predicate is computed inconsistently across runs.
+
+### Regression check
+
+Run the full existing `test_cleanup.py` module to make sure no boundary/tier test regresses.
+
+### Local verification command
+
+```bash
+PYTHONPATH=backend/src uv run pytest backend/tests/tasks/test_cleanup.py -v
+```
+
+Then `make backend-verify` before declaring the milestone done.
+
+## 1.4 Documentation Updates
+
+**File:** `docs/content-versioning.md`
+
+Two small edits in §"Retention and Cleanup":
+
+1. In the "Time-Based Pruning (Scheduled)" subsection, add a bullet:
+   > The most recent versioned history record per entity is always retained, regardless of age. Audit records (DELETE/UNDELETE/ARCHIVE/UNARCHIVE) are not exempted. This guarantees that diff and restore remain functional after long idle periods.
+
+2. In §"Inactive Entities and Time-Based Cleanup", correct the current text:
+   > All history records may be deleted by time-based cleanup
+
+   to:
+   > All history records **except the most recent versioned record** may be deleted by time-based cleanup. The retained record serves as the anchor for diff and restore on the next edit.
+
+No other docs should need updating. Specifically:
+- `AGENTS.md` — no change (no new commands, no architectural shift).
+- `docs/architecture.md` — no change (service topology unchanged). If the agent disagrees, flag it before editing.
+- `README.md`, `llms.txt`, pricing/features pages — no change (no user-visible feature change; the bugfix restores documented behavior).
+- No changelog entry unless the user explicitly asks for one.
+
+## 1.5 Stop Here
+
+After implementation + tests + doc updates are complete and `make backend-verify` passes, **stop and wait for human review.** Do not commit. Summarize:
+- Final query approach chosen (CTE vs correlated subquery vs other).
+- Any test surprises.
+- Any assumption you had to make that wasn't explicitly answered in §"Questions the Agent Should Raise."

--- a/docs/implementation_plans/2026-04-20-history-keep-last-record.md
+++ b/docs/implementation_plans/2026-04-20-history-keep-last-record.md
@@ -101,56 +101,61 @@ The new query needs to, per tier:
 1. Identify the latest *versioned* row per `(user_id, entity_type, entity_id)` among rows owned by users in this tier.
 2. Delete rows in this tier older than `cutoff` **except** those identified in step 1.
 
-A clean way to express this in SQLAlchemy 2.0 is a CTE that ranks rows via `ROW_NUMBER()`:
+Two shapes are equally correct. **Prefer `NOT EXISTS` as the primary form** — it reads directly as the rule we want: "delete an aged row unless a higher-versioned row exists for the same entity." Fall back to the ranked CTE only if the generated SQL is clearer in that form for a particular reader.
+
+#### Primary: NOT EXISTS
 
 ```python
-from sqlalchemy import case, delete, func, select
-from sqlalchemy.sql import literal_column
-
-# Rank versioned rows per entity; NULL-version rows get rank 0 (never "preserved").
-ranked = (
-    select(
-        ContentHistory.id.label("id"),
-        func.row_number().over(
-            partition_by=(
-                ContentHistory.user_id,
-                ContentHistory.entity_type,
-                ContentHistory.entity_id,
-            ),
-            order_by=ContentHistory.version.desc(),
-        ).label("rn"),
-    )
-    .where(
-        ContentHistory.user_id.in_(
-            select(User.id).where(
-                func.coalesce(User.tier, Tier.FREE.value) == tier.value,
-            ),
-        ),
-        ContentHistory.version.is_not(None),  # only rank versioned rows
-    )
-    .cte("ranked_history")
+# Bind the tier-users subquery once and reuse, so the planner sees one scan.
+tier_users = (
+    select(User.id)
+    .where(func.coalesce(User.tier, Tier.FREE.value) == tier.value)
+    .subquery()
 )
 
-latest_ids = select(ranked.c.id).where(ranked.c.rn == 1)
+newer = aliased(ContentHistory)
 
 delete_stmt = delete(ContentHistory).where(
-    ContentHistory.user_id.in_(
-        select(User.id).where(
-            func.coalesce(User.tier, Tier.FREE.value) == tier.value,
+    ContentHistory.user_id.in_(select(tier_users.c.id)),
+    ContentHistory.created_at < cutoff,
+    # Preserve the single latest versioned row per entity: delete only if
+    # this row is an audit row (version IS NULL), OR a higher-versioned row
+    # exists for the same entity.
+    #
+    # IMPORTANT — foot-gun warning for future readers: do NOT narrow the
+    # `newer` subquery by adding `newer.created_at < cutoff` or similar.
+    # We must rank/compare across ALL versioned rows, aged or not. Narrowing
+    # to aged-only would preserve a stale aged anchor even when a fresh
+    # higher-versioned row already exists — which reintroduces the original
+    # bug in a different shape.
+    or_(
+        ContentHistory.version.is_(None),
+        exists().where(
+            newer.user_id == ContentHistory.user_id,
+            newer.entity_type == ContentHistory.entity_type,
+            newer.entity_id == ContentHistory.entity_id,
+            newer.version.is_not(None),
+            newer.version > ContentHistory.version,
         ),
     ),
-    ContentHistory.created_at < cutoff,
-    ContentHistory.id.not_in(latest_ids),
 )
 ```
 
-Notes:
-- Do not use `ORDER BY version DESC NULLS LAST` — we explicitly filter `version IS NOT NULL` in the CTE, so ordering is unambiguous.
-- The exclusion set only includes versioned rows. Audit rows (`version IS NULL`) are never in `latest_ids`, so they remain fully subject to `created_at < cutoff`.
-- Keep the existing `coalesce(User.tier, ...)` tier resolution.
-- Preserve the existing `result.rowcount` / stats / logging. The log line can stay the same; the semantics of "expired_deleted" are unchanged (it's still "rows deleted by this function").
+#### Alternative: ranked CTE with `ROW_NUMBER()`
 
-If the agent finds a measurably simpler or more idiomatic SQLAlchemy expression (e.g., correlated subquery with `MAX(version)`) that passes all tests and stays inside a single DELETE per tier, that's acceptable. Do not break the "one DELETE per tier" efficiency property.
+Same semantics via a CTE that ranks versioned rows per entity, then deletes aged rows whose id is not in `rn = 1`. Acceptable if the implementer finds it clearer. If you choose this form, carry the same foot-gun comment: the ranking must span all versioned rows, not aged-only.
+
+#### Notes (apply to either shape)
+
+- Audit rows (`version IS NULL`) are never "latest" for preservation purposes. They remain fully subject to `created_at < cutoff`.
+- Keep the existing `coalesce(User.tier, Tier.FREE.value)` tier resolution.
+- Bind the tier-users subquery once per tier iteration and reuse it, so the planner sees a single scan rather than two.
+- Preserve the existing `result.rowcount`, `CleanupStats`, and log line. The semantics of `expired_deleted` are unchanged ("rows deleted by this function").
+- Update the function docstring (`cleanup.py:127`) to reflect the new invariant: it no longer "deletes all history records older than retention period" — it deletes all such records *except the most recent versioned record per entity*.
+
+#### Benchmarking
+
+Do **not** make `EXPLAIN ANALYZE` a gating requirement. Both shapes plan well in PostgreSQL 17 for realistic cardinalities. Only benchmark if the choice between shapes is otherwise a coin flip for you and you have a realistic local dataset; otherwise ship the clearer one.
 
 ### What does NOT change
 
@@ -196,8 +201,34 @@ If the agent finds a measurably simpler or more idiomatic SQLAlchemy expression 
 9. **`test_boundary_exactly_at_cutoff_unchanged`**
    Re-confirm the existing boundary behavior: a row with `created_at == cutoff` is preserved (strict `<` comparison), and this interacts correctly with the new preservation rule. Likely the existing boundary test still passes; if not, adjust or add.
 
-10. **`test_idempotent_second_run`**
-    Run `cleanup_expired_history` twice in a row on the same seeded data → second run deletes zero rows and leaves the preserved set intact. Guards against a bug where the preservation predicate is computed inconsistently across runs.
+10. **`test_preservation_follows_latest_across_runs`**
+    Seed an entity with multiple aged versioned rows, run cleanup (leaves the latest preserved), then insert a *new* aged versioned row with a higher `version`, then run cleanup again. Assert: the previously-preserved row is now deleted (it is no longer the latest), and the new row is preserved. This catches bugs where preservation was cached, where `rn = 1` was computed against a stale view, or where the NOT EXISTS predicate was written against the wrong partition.
+
+### Symptom-level regression test (REQUIRED — the highest-value test in this milestone)
+
+The tests above prove rows survive/die correctly. This test proves the **user-visible bug is actually fixed**: that after cleanup, the next edit through the normal service path produces a working diff and a restorable anchor.
+
+**File:** `backend/tests/services/test_history_service.py` (preferred — service layer is where the predecessor-selection logic lives) or `backend/tests/api/test_history.py` if source/auth plumbing is relevant.
+
+**Critical: drive the update through the real service path.** The new edit must go through `HistoryService.record_action` (via the entity service's update path that calls it in production), **not** via a direct ORM insert of a `ContentHistory` row. The whole point of this test is proving the service correctly reads the preserved predecessor when computing the next diff. An ORM-direct test would pass even if `record_action` had a regression in predecessor selection.
+
+**Parameterize over both starting states** (use `pytest.mark.parametrize`):
+
+- **`versioned-aged`**: entity has multiple aged versioned history rows, all past cutoff.
+- **`audit-only-aged`**: entity has only aged audit rows (e.g., ARCHIVE/UNARCHIVE), all past cutoff, no versioned rows.
+
+For each starting state:
+
+1. Seed the entity and the aged history rows.
+2. Run `cleanup_expired_history` with an injected `now` that makes all seeded rows aged.
+3. Verify the expected surviving set (versioned-aged → exactly the latest versioned row survives; audit-only-aged → zero history rows survive).
+4. Perform an update on the entity **through the service layer** (e.g., `BookmarkService.update` / the path that calls `record_action`).
+5. Assert:
+   - A new `ContentHistory` row is written with a non-null `content_diff` when a predecessor exists; for `audit-only-aged`, the first post-cleanup edit behaves like a fresh CREATE (snapshot, no diff, version allocation is sensible — whatever `_get_next_version` yields here is the contract, pin it explicitly).
+   - `get_version_diff` for the new version returns non-null `before_metadata` when a predecessor exists (versioned-aged case); for audit-only-aged, the diff endpoint behaves as it does for a genuine CREATE.
+   - Restore to the preserved prior version succeeds (versioned-aged case only; nothing to restore to in audit-only-aged).
+
+Parameterizing this way subsumes the audit-only-edge concern without needing a separate test.
 
 ### Regression check
 
@@ -206,7 +237,7 @@ Run the full existing `test_cleanup.py` module to make sure no boundary/tier tes
 ### Local verification command
 
 ```bash
-PYTHONPATH=backend/src uv run pytest backend/tests/tasks/test_cleanup.py -v
+PYTHONPATH=backend/src uv run pytest backend/tests/tasks/test_cleanup.py backend/tests/services/test_history_service.py -v
 ```
 
 Then `make backend-verify` before declaring the milestone done.
@@ -226,15 +257,27 @@ Two small edits in §"Retention and Cleanup":
    to:
    > All history records **except the most recent versioned record** may be deleted by time-based cleanup. The retained record serves as the anchor for diff and restore on the next edit.
 
+Framing: this is a **behavior change + doc correction**, not a restoration of previously-documented behavior. `docs/content-versioning.md` currently documents the opposite of what we want (history starts fresh after long idle). The edits above correct that.
+
 No other docs should need updating. Specifically:
 - `AGENTS.md` — no change (no new commands, no architectural shift).
 - `docs/architecture.md` — no change (service topology unchanged). If the agent disagrees, flag it before editing.
-- `README.md`, `llms.txt`, pricing/features pages — no change (no user-visible feature change; the bugfix restores documented behavior).
+- `README.md`, `llms.txt`, pricing/features pages — no change (no new user-visible feature; this corrects degraded UX).
 - No changelog entry unless the user explicitly asks for one.
 
 ## 1.5 Stop Here
 
 After implementation + tests + doc updates are complete and `make backend-verify` passes, **stop and wait for human review.** Do not commit. Summarize:
-- Final query approach chosen (CTE vs correlated subquery vs other).
-- Any test surprises.
+- Final query approach chosen (NOT EXISTS vs ranked CTE vs other).
+- Any test surprises, especially in the symptom-level regression test (version allocation behavior for audit-only-aged starting state is the most likely surprise).
 - Any assumption you had to make that wasn't explicitly answered in §"Questions the Agent Should Raise."
+
+---
+
+## Merge Notes (not implementation steps — for the PR description)
+
+These don't belong inside the milestone work. Include them in the PR description / commit message for reviewer context and future archaeology:
+
+- **Behavior change, not bugfix framing:** previously-documented behavior in `docs/content-versioning.md` (history starts fresh after long idle) is being changed, not restored. Doc updated in same PR.
+- **Storage footprint shift:** `content_history` row count now scales with live-entity count (one retained row per entity for long-idle entities), not strictly with retention days. Still bounded — one row per entity is tiny, and hard-delete cascades still clean up. Noting so future "why is this table growing" investigations land here.
+- **Telemetry check before merging:** if any Grafana/Railway alert watches `expired_deleted` volume, confirm it won't false-alarm on the expected drop for tiers with many long-idle entities. Quick check with whoever owns cleanup telemetry.


### PR DESCRIPTION
## Summary

Fixes [KAN-123](https://tiddly.atlassian.net/browse/KAN-123). Time-based history cleanup now preserves the single most recent versioned `ContentHistory` record per `(user_id, entity_type, entity_id)` regardless of age. Audit records (`DELETE`/`UNDELETE`/`ARCHIVE`/`UNARCHIVE`, identified by `version IS NULL`) remain fully subject to time-based pruning.

Before this change, any entity that went idle longer than its tier's `history_retention_days` lost **all** of its history. On the next edit, the frontend showed "Previous metadata unavailable" on the diff view and the Restore button was effectively dead because the prior-version anchor had been pruned. After this change, each entity retains at least its latest versioned record indefinitely — serving as the anchor for diff and restore on the next edit.

This is a **behavior change + doc correction**, not a restoration of previously documented behavior. `docs/content-versioning.md` previously described history as starting fresh after long idle; that text is updated in this PR to reflect the new invariant.

## Changes

- **`backend/src/tasks/cleanup.py`**: Rewrite the per-tier DELETE in `cleanup_expired_history` using a `NOT EXISTS` correlated self-alias that excludes each entity's latest versioned row. The self-alias compares across *all* versioned rows for the entity (aged or fresh) — narrowing it by age would reintroduce the bug in a different shape; a foot-gun comment warns future readers. `cleanup_soft_deleted_items` and `cleanup_orphaned_history` are unchanged.
- **`docs/content-versioning.md`**: Update §"Retention and Cleanup" and §"Inactive Entities and Time-Based Cleanup" to document the preservation rule.
- **`backend/tests/tasks/test_cleanup.py`**: 13 new tests (14 cases with parameterization) covering preservation mechanics — single-row preservation, multi-row latest-only, mixed aged/fresh, audit rows still prunable, audit-vs-latest interaction, per-entity partitioning, tier boundaries, soft-deleted entities, cutoff boundary, cross-run "latest moves forward," same-tier user isolation, reconstruction at the preserved version (snapshot + non-snapshot), and `CREATE`-only entity preservation.
- **`backend/tests/services/test_history_integration.py`**: 1 new parameterized symptom-level regression test driving post-cleanup edits through `BookmarkService.update` (not direct ORM insert) to prove `record_action` correctly reads the preserved predecessor when computing the next diff. Covers both `versioned-aged` and `audit-only-aged` (legacy-data edge) starting states.
- **7 existing boundary/tier/integration tests**: Updated to seed fresh higher-versioned anchors so aged rows remain deletable under the new rule. Original test intent (boundary semantics, tier batching, run_cleanup integration) preserved.

## Impact

- **No schema migration, no API change, no frontend change.**
- **No breaking changes.** Existing count-based inline pruning (`history_service._prune_to_limit`) is untouched; permanent-delete cascade behavior (`cleanup_soft_deleted_items`) is untouched.
- **Storage footprint shift**: `content_history` row count now scales with live-entity count (one retained row per long-idle entity), not strictly with retention days. Still bounded — one row per entity is negligible, and hard-delete cascades continue to clean up when entities are permanently removed. Noting so future "why is this table growing" investigations land here.
- **Legacy-data edge case** (pinned in a test, not fixed in this PR): entities whose pre-fix cleanup deleted their `CREATE` record may still reach an "audit-only-aged" state. The first post-cleanup edit on such an entity lands at v1 with `action='update'`, `content_diff` set, `content_snapshot` None — not a `CREATE` path. `before_metadata` is None on the diff endpoint, triggering the frontend's "Previous metadata unavailable" branch. Bounded to pre-fix data; self-heals over time.
- **Deployment**: Railway Postgres has daily backups; rollback posture confirmed. First nightly cron run after deploy should show reduced `expired_deleted` counts vs. pre-change (expected — preservation rule shrinks deletes).

## Test plan

- [x] `make backend-verify` — 3036 passed
- [x] New preservation suite in `test_cleanup.py` — 14 cases pass
- [x] Symptom-level regression in `test_history_integration.py` — both parametrizations pass
- [x] 7 updated existing tests pass with original intent preserved