### PR TITLE
Relationship chip improvements: Safari tooltip fix + Shift+click to open bookmark in Tiddly

### DIFF
--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -264,6 +264,7 @@ If you need scripted access to these, authenticate with an Auth0 session.
 - `Cmd+Shift+S`: Save and close.
 - `Cmd+Click` on a card: Open in new tab.
 - `Shift+Cmd+Click` on a bookmark: Open the URL without tracking usage.
+- `Shift+Click` on a bookmark relationship chip: Open the bookmark entity in Tiddly (default click opens the URL in a new tab).
 - `w`: Toggle full-width layout.
 
 ### Markdown Editor

--- a/frontend/src/components/Bookmark.tsx
+++ b/frontend/src/components/Bookmark.tsx
@@ -14,7 +14,7 @@
  * - Fetch metadata functionality
  */
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import type { ReactNode, FormEvent } from 'react'
+import type { ReactNode, FormEvent, MouseEvent as ReactMouseEvent } from 'react'
 import axios from 'axios'
 import toast from 'react-hot-toast'
 import { InlineEditableUrl } from './InlineEditableUrl'
@@ -132,7 +132,7 @@ interface BookmarkProps {
   /** Called when history button is clicked */
   onShowHistory?: () => void
   /** Called when a linked content item is clicked for navigation */
-  onNavigateToLinked?: (item: LinkedItem) => void
+  onNavigateToLinked?: (item: LinkedItem, event?: ReactMouseEvent) => void
   /** Pre-populated relationships from navigation state (quick-create linked) */
   initialRelationships?: RelationshipInputPayload[]
   /** Pre-populated linked item display cache from navigation state */

--- a/frontend/src/components/LinkedContentChips.test.tsx
+++ b/frontend/src/components/LinkedContentChips.test.tsx
@@ -5,7 +5,7 @@
  * items + callbacks. These tests verify display, callbacks, and inline search.
  */
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, act, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRef } from 'react'
@@ -85,6 +85,21 @@ function setupSearchMock(searchItems: ContentListItem[]): void {
 }
 
 const noop = vi.fn()
+
+// Tooltip component gates rendering on `matchMedia('(hover: hover)')` — jsdom returns false by
+// default which would skip tooltip rendering entirely. Mock true so tooltip-content tests can run.
+beforeEach(() => {
+  window.matchMedia = vi.fn((query: string) => ({
+    matches: query === '(hover: hover)',
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  })) as unknown as typeof window.matchMedia
+})
 
 describe('LinkedContentChips', () => {
   beforeEach(() => {
@@ -296,11 +311,36 @@ describe('LinkedContentChips', () => {
         { wrapper: createWrapper() },
       )
 
-      await userEvent.click(screen.getByLabelText('Go to Bookmark: My Bookmark'))
+      await userEvent.click(screen.getByLabelText('Open in new tab: My Bookmark'))
 
       expect(onNavigate).toHaveBeenCalledOnce()
       expect(onNavigate).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'bookmark', id: 'bm-1', title: 'My Bookmark' }),
+        expect.objectContaining({ shiftKey: false }),
+      )
+    })
+
+    it('should pass shiftKey in event when chip is shift+clicked', () => {
+      const items = [makeLinkedItem()]
+      const onNavigate = vi.fn()
+
+      render(
+        <LinkedContentChips
+          contentType="note"
+          contentId="note-1"
+          items={items}
+          onAdd={noop}
+          onRemove={noop}
+          onNavigate={onNavigate}
+        />,
+        { wrapper: createWrapper() },
+      )
+
+      fireEvent.click(screen.getByLabelText('Open in new tab: My Bookmark'), { shiftKey: true })
+
+      expect(onNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'bookmark', id: 'bm-1' }),
+        expect.objectContaining({ shiftKey: true }),
       )
     })
 
@@ -320,7 +360,48 @@ describe('LinkedContentChips', () => {
         { wrapper: createWrapper() },
       )
 
-      expect(screen.queryByLabelText('Go to Bookmark: My Bookmark')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Open in new tab: My Bookmark')).not.toBeInTheDocument()
+    })
+
+    it('should show Shift+click hint in tooltip for bookmark chips', async () => {
+      const items = [makeLinkedItem()]
+
+      render(
+        <LinkedContentChips
+          contentType="note"
+          contentId="note-1"
+          items={items}
+          onAdd={noop}
+          onRemove={noop}
+          onNavigate={vi.fn()}
+        />,
+        { wrapper: createWrapper() },
+      )
+
+      await userEvent.hover(screen.getByLabelText('Open in new tab: My Bookmark'))
+
+      expect(await screen.findByText(/Shift\+click to open in Tiddly/)).toBeInTheDocument()
+    })
+
+    it('should not show Shift+click hint in tooltip for note chips', async () => {
+      const items = [makeLinkedItem({ type: 'note', id: 'note-x', title: 'My Note', url: null })]
+
+      render(
+        <LinkedContentChips
+          contentType="bookmark"
+          contentId="bm-1"
+          items={items}
+          onAdd={noop}
+          onRemove={noop}
+          onNavigate={vi.fn()}
+        />,
+        { wrapper: createWrapper() },
+      )
+
+      await userEvent.hover(screen.getByLabelText('Go to Note: My Note'))
+
+      await screen.findByText(/Go to note: My Note/)
+      expect(screen.queryByText(/Shift\+click to open in Tiddly/)).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/LinkedContentChips.tsx
+++ b/frontend/src/components/LinkedContentChips.tsx
@@ -323,7 +323,8 @@ export const LinkedContentChips = forwardRef(function LinkedContentChips(
         const chipContent = (
           <span className={`inline-flex items-center gap-1 rounded-md px-1.5 py-px text-xs font-normal border ${chipStyle} ${item.deleted ? 'opacity-60' : ''} ${item.archived ? 'opacity-60' : ''}`}>
             <Icon className="h-3 w-3" />
-            <span className={`max-w-[120px] truncate ${item.deleted ? 'line-through' : ''}`}>
+            {/* `after:content-[''] after:block` suppresses Safari's automatic native tooltip on CSS-truncated text (WebKit bug 114304: https://bugs.webkit.org/show_bug.cgi?id=114304). The generated block child breaks the heuristic; it has zero size so layout is unaffected. Without this, Safari shows a second, unstyled tooltip alongside our custom <Tooltip>. */}
+            <span className={`max-w-[120px] truncate after:content-[''] after:block ${item.deleted ? 'line-through' : ''}`}>
               {displayTitle}
             </span>
           </span>

--- a/frontend/src/components/LinkedContentChips.tsx
+++ b/frontend/src/components/LinkedContentChips.tsx
@@ -14,7 +14,7 @@
  * Exposes startAdding() via ref for external triggers (same pattern as InlineEditableTags).
  */
 import { useState, useRef, useEffect, useImperativeHandle, forwardRef, useMemo, useCallback } from 'react'
-import type { ReactNode, KeyboardEvent, ChangeEvent, Ref } from 'react'
+import type { ReactNode, KeyboardEvent, ChangeEvent, MouseEvent as ReactMouseEvent, Ref } from 'react'
 import { useContentSearch } from '../hooks/useContentSearch'
 import { LinkIcon, PlusIcon } from './icons'
 import { Tooltip, DropdownPortal } from './ui'
@@ -34,7 +34,7 @@ interface LinkedContentChipsProps {
   onAdd: (item: ContentListItem) => void
   /** Called when user clicks remove on a chip */
   onRemove: (item: LinkedItem) => void
-  onNavigate?: (item: LinkedItem) => void
+  onNavigate?: (item: LinkedItem, event?: ReactMouseEvent) => void
   disabled?: boolean
   /** Whether to show the inline add button (default: true). Set false when using an external trigger. */
   showAddButton?: boolean
@@ -71,16 +71,17 @@ function getDisplayTitle(title: string | null, type: string, url?: string | null
 }
 
 /**
- * Resolve tooltip text for a linked chip.
+ * Resolve tooltip content for a linked chip.
  *
  * When navigable: actionable label ("Open in new tab: URL" for bookmarks, "Go to note: Title" for others).
+ * Bookmark tooltips include a Shift+click hint for navigating to the entity in Tiddly.
  * When not navigable (deleted or no onNavigate): show the full title/URL/name for context, or null.
  */
-function getTooltipText(
+function getTooltipContent(
   item: LinkedItem,
   typeLabel: string,
   isNavigable: boolean,
-): string | null {
+): ReactNode {
   const fullTitle = item.title
     || (item.type === 'bookmark' ? item.url : null)
     || (item.type === 'prompt' ? item.promptName : null)
@@ -88,7 +89,12 @@ function getTooltipText(
   if (!isNavigable) return fullTitle
 
   if (item.type === 'bookmark' && item.url) {
-    return `Open in new tab: ${item.url}`
+    return (
+      <>
+        Open in new tab: {item.url}
+        <div className="mt-1 text-gray-300">Shift+click to open in Tiddly</div>
+      </>
+    )
   }
   return fullTitle ? `Go to ${typeLabel.toLowerCase()}: ${fullTitle}` : null
 }
@@ -334,14 +340,18 @@ export const LinkedContentChips = forwardRef(function LinkedContentChips(
         const key = item.relationshipId || `${item.type}:${item.id}`
 
         const isNavigable = !!onNavigate && !item.deleted
-        const tooltipText = getTooltipText(item, typeLabel, isNavigable)
+        const tooltipContent = getTooltipContent(item, typeLabel, isNavigable)
+        // aria-label describes the default action (no modifier). For bookmarks the default is to open the URL in a new tab; Shift+click (which navigates to the entity) is a power-user shortcut surfaced visually in the tooltip.
+        const ariaLabel = item.type === 'bookmark' && item.url
+          ? `Open in new tab: ${displayTitle}`
+          : `Go to ${typeLabel}: ${displayTitle}`
 
         const chipWithAction = onNavigate && !item.deleted ? (
           <button
             type="button"
-            onClick={() => onNavigate(item)}
+            onClick={(e) => onNavigate(item, e)}
             className="cursor-pointer"
-            aria-label={`Go to ${typeLabel}: ${displayTitle}`}
+            aria-label={ariaLabel}
           >
             {chipContent}
           </button>
@@ -351,8 +361,8 @@ export const LinkedContentChips = forwardRef(function LinkedContentChips(
 
         return (
           <div key={key} className="group/link relative inline-flex items-baseline">
-            {tooltipText ? (
-              <Tooltip content={tooltipText} delay={500}>
+            {tooltipContent ? (
+              <Tooltip content={tooltipContent} delay={500}>
                 {chipWithAction}
               </Tooltip>
             ) : chipWithAction}

--- a/frontend/src/components/Note.tsx
+++ b/frontend/src/components/Note.tsx
@@ -13,7 +13,7 @@
  * - Read-only mode for deleted items
  */
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import type { ReactNode, FormEvent } from 'react'
+import type { ReactNode, FormEvent, MouseEvent as ReactMouseEvent } from 'react'
 import axios from 'axios'
 import toast from 'react-hot-toast'
 import { InlineEditableTitle } from './InlineEditableTitle'
@@ -103,7 +103,7 @@ interface NoteProps {
   /** Called when history button is clicked */
   onShowHistory?: () => void
   /** Called when a linked content item is clicked for navigation */
-  onNavigateToLinked?: (item: LinkedItem) => void
+  onNavigateToLinked?: (item: LinkedItem, event?: ReactMouseEvent) => void
   /** Pre-populated relationships from navigation state (quick-create linked) */
   initialRelationships?: RelationshipInputPayload[]
   /** Pre-populated linked item display cache from navigation state */

--- a/frontend/src/components/Prompt.tsx
+++ b/frontend/src/components/Prompt.tsx
@@ -14,7 +14,7 @@
  * - Read-only mode for deleted items
  */
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import type { ReactNode, FormEvent } from 'react'
+import type { ReactNode, FormEvent, MouseEvent as ReactMouseEvent } from 'react'
 import axios from 'axios'
 import toast from 'react-hot-toast'
 import { InlineEditableTitle } from './InlineEditableTitle'
@@ -151,7 +151,7 @@ interface PromptProps {
   /** Called when history button is clicked */
   onShowHistory?: () => void
   /** Called when a linked content item is clicked for navigation */
-  onNavigateToLinked?: (item: LinkedItem) => void
+  onNavigateToLinked?: (item: LinkedItem, event?: ReactMouseEvent) => void
   /** Pre-populated relationships from navigation state (quick-create linked) */
   initialRelationships?: RelationshipInputPayload[]
   /** Pre-populated linked item display cache from navigation state */

--- a/frontend/src/components/ShortcutsDialog.tsx
+++ b/frontend/src/components/ShortcutsDialog.tsx
@@ -39,6 +39,7 @@ const leftColumnGroups: ShortcutGroup[] = [
       { keys: ['s'], description: 'Focus page search' },
       { keys: ['\u2318', '\u21E7', 'P'], description: 'Command palette' },
       { keys: ['\u2318', 'Click'], description: 'Open card in new tab' },
+      { keys: ['\u21E7', 'Click'], description: 'Open bookmark relationship in Tiddly (instead of URL)' },
       { keys: ['Esc'], description: 'Close modal / Unfocus search' },
     ],
   },

--- a/frontend/src/hooks/useLinkedNavigation.test.tsx
+++ b/frontend/src/hooks/useLinkedNavigation.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { useLinkedNavigation } from './useLinkedNavigation'
 import type { LinkedItem } from '../utils/relationships'
@@ -105,5 +105,49 @@ describe('useLinkedNavigation', () => {
     expect(mockTrackBookmarkUsage).not.toHaveBeenCalled()
 
     windowOpen.mockRestore()
+  })
+
+  it('should navigate to bookmark detail page on shift+click instead of opening URL', () => {
+    const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const { result } = renderHook(() => useLinkedNavigation(), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current(
+        makeLinkedItem({ type: 'bookmark', id: 'bm-789', url: 'https://example.com' }),
+        { shiftKey: true } as ReactMouseEvent,
+      )
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/bookmarks/bm-789')
+    expect(windowOpen).not.toHaveBeenCalled()
+    expect(mockTrackBookmarkUsage).not.toHaveBeenCalled()
+
+    windowOpen.mockRestore()
+  })
+
+  it('should ignore shift modifier for notes (still navigates normally)', () => {
+    const { result } = renderHook(() => useLinkedNavigation(), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current(
+        makeLinkedItem({ type: 'note', id: 'note-123' }),
+        { shiftKey: true } as ReactMouseEvent,
+      )
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/notes/note-123')
+  })
+
+  it('should ignore shift modifier for prompts (still navigates normally)', () => {
+    const { result } = renderHook(() => useLinkedNavigation(), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current(
+        makeLinkedItem({ type: 'prompt', id: 'prompt-456' }),
+        { shiftKey: true } as ReactMouseEvent,
+      )
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/prompts/prompt-456')
   })
 })

--- a/frontend/src/hooks/useLinkedNavigation.ts
+++ b/frontend/src/hooks/useLinkedNavigation.ts
@@ -2,21 +2,30 @@
  * Hook for navigating to linked content items.
  *
  * Bookmarks open their URL in a new tab (with usage tracking).
- * Notes and prompts navigate to their detail pages.
+ * Shift+click on a bookmark navigates to its detail page in Tiddly instead — power-user
+ * shortcut for the less common case where the user wants the entity, not the URL.
+ * `trackBookmarkUsage` is intentionally NOT called on the Shift+click path: the user isn't
+ * visiting the URL, so counting it would inflate usage metrics.
+ * Notes and prompts always navigate to their detail pages (no modifier needed).
  */
 import { useCallback } from 'react'
+import type { MouseEvent as ReactMouseEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useBookmarks } from './useBookmarks'
 import type { LinkedItem } from '../utils/relationships'
 
-export function useLinkedNavigation(): (item: LinkedItem) => void {
+export function useLinkedNavigation(): (item: LinkedItem, event?: ReactMouseEvent) => void {
   const navigate = useNavigate()
   const { trackBookmarkUsage } = useBookmarks()
 
-  return useCallback((item: LinkedItem): void => {
+  return useCallback((item: LinkedItem, event?: ReactMouseEvent): void => {
     if (item.type === 'bookmark' && item.url) {
-      trackBookmarkUsage(item.id)
-      window.open(item.url, '_blank', 'noopener,noreferrer')
+      if (event?.shiftKey) {
+        navigate(`/app/bookmarks/${item.id}`)
+      } else {
+        trackBookmarkUsage(item.id)
+        window.open(item.url, '_blank', 'noopener,noreferrer')
+      }
     } else if (item.type === 'note') {
       navigate(`/app/notes/${item.id}`)
     } else if (item.type === 'prompt') {

--- a/frontend/src/pages/docs/DocsShortcuts.tsx
+++ b/frontend/src/pages/docs/DocsShortcuts.tsx
@@ -56,6 +56,7 @@ export function DocsShortcuts(): ReactNode {
           <ShortcutRow keys={['s']} description="Focus page search" />
           <ShortcutRow keys={['\u2318', '\u21E7', 'P']} description="Command palette" />
           <ShortcutRow keys={['\u2318', 'Click']} description="Open card in new tab" />
+          <ShortcutRow keys={['\u21E7', 'Click']} description="Open bookmark relationship in Tiddly (instead of URL)" />
           <ShortcutRow keys={['Esc']} description="Close modal / unfocus search" />
         </tbody>
       </table>


### PR DESCRIPTION
## Summary

Two independent user-visible improvements to bookmark/note/prompt relationship chips in the detail view.

## Changes

**Bug: duplicate native tooltip on relationship chips in Safari**
- Safari (WebKit) auto-renders a native tooltip with the full text of any element truncated via `text-overflow: ellipsis`, which appeared alongside our custom `<Tooltip>` — Chrome does not do this ([WebKit bug 114304](https://bugs.webkit.org/show_bug.cgi?id=114304), unresolved since 2013).
- Add `after:content-[''] after:block` to the truncated title span. The zero-size generated block child breaks the WebKit heuristic without affecting layout or other browsers. Inline comment links the bug for future maintainers.
- `title=""` was tried first and confirmed via Safari devtools not to suppress the auto-tooltip.

**Feature: Shift+click on a bookmark relationship chip opens the entity in Tiddly**
- Default click on a bookmark chip still opens the URL in a new tab (with usage tracking). Shift+click instead navigates to `/app/bookmarks/:id`. Usage tracking is deliberately skipped on the Shift path — the user isn't visiting the URL.
- Notes/prompts ignore the modifier.
- Bookmark chip tooltip now shows a second-line "Shift+click to open in Tiddly" hint.
- Bookmark chip `aria-label` corrected from "Go to Bookmark: …" to "Open in new tab: …" to match the default action (screen-reader correctness fix that rode along with this change).
- Shortcut documented in `ShortcutsDialog.tsx`, `DocsShortcuts.tsx`, and `llms.txt`.
- `onNavigateToLinked` prop type in `Note`/`Prompt`/`Bookmark` widened to include the optional event — TypeScript had accepted the narrower form via parameter bivariance, but the signature was lying about what it forwards.

## Impact

No breaking changes. No new dependencies. No migrations or env-var changes.

**Known scope limits (intentional):**
- Shift+click is a mouse-only shortcut. Keyboard users (Enter/Space on a focused chip can't carry a reliable shift modifier across browsers) and touch users have no equivalent. Treated as a power-user shortcut, not a primary affordance.