### PR TITLE
Refine bookmark card desktop layout and auto-archive dropdown UX

### DIFF
--- a/frontend/src/components/BookmarkCard.test.tsx
+++ b/frontend/src/components/BookmarkCard.test.tsx
@@ -157,6 +157,31 @@ describe('BookmarkCard', () => {
     // Note: URL display now uses native anchor tags for proper link semantics
     // (middle-click, right-click menu, etc). Navigation is handled by the browser.
 
+    it('renders the desktop title and URL as a single link cluster when a title exists', () => {
+      const { container } = render(
+        <BookmarkCard
+          bookmark={mockBookmark}
+          onDelete={vi.fn()}
+        />
+      )
+
+      const desktopLayout = container.querySelector('.hidden.md\\:block.relative')
+      expect(desktopLayout).toBeInTheDocument()
+
+      const titleLink = Array.from(desktopLayout!.querySelectorAll('a')).find(
+        (link) => link.textContent?.includes('Example Article') && link.textContent?.includes('https://example.com/article')
+      )
+
+      expect(titleLink).toHaveClass('link-area', 'flex', 'flex-col', 'w-full', 'overflow-hidden')
+      expect(titleLink?.querySelector('span')).toHaveClass('block', 'truncate')
+      expect(titleLink?.querySelector('span')).toHaveClass('w-full')
+      expect(titleLink?.querySelector('span')).toHaveTextContent('Example Article')
+      expect(titleLink?.querySelectorAll('span')[1]).toHaveClass('block', 'truncate')
+      expect(titleLink?.querySelectorAll('span')[1]).toHaveClass('w-full')
+      expect(titleLink?.querySelectorAll('span')[1]).toHaveTextContent('https://example.com/article')
+      expect(desktopLayout!.querySelector('a[aria-hidden="true"]')).not.toBeInTheDocument()
+    })
+
     it('calls onLinkClick when URL line is clicked', async () => {
       const onLinkClick = vi.fn()
 

--- a/frontend/src/components/BookmarkCard.tsx
+++ b/frontend/src/components/BookmarkCard.tsx
@@ -318,77 +318,77 @@ export function BookmarkCard({
         {/* Desktop layout - horizontal with hover actions */}
         <div className="hidden md:block relative" onMouseOver={handleLinkMouseOver} onMouseOut={handleLinkMouseOut}>
           {/* Row 1: Title + tags + date */}
-          <div className="flex items-baseline gap-2">
-            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 min-w-0 flex-1">
-              {hasTitle ? (
-                <a
-                  href={bookmark.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={handleUrlClick}
-                  className="link-area text-base font-medium text-gray-900 truncate group-has-[.link-area:hover]/link:text-blue-600 transition-colors"
-                >
-                  {displayTitle}
-                </a>
-              ) : (
-                <Tooltip content="Open URL in new tab" compact delay={500}>
+          {/* Reserve a real metadata column so title/URL truncate before reaching tags/date. */}
+          <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2">
+            {hasTitle ? (
+              <div className="min-w-0 overflow-hidden">
+                <Tooltip content="Open URL in new tab" compact show={linkHovered} className="flex min-w-0 w-full max-w-full">
                   <a
                     href={bookmark.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={handleUrlClick}
-                    className="link-area text-base font-medium text-gray-900 truncate group-has-[.link-area:hover]/link:text-blue-600 transition-colors"
+                    className="link-area flex w-full min-w-0 flex-col overflow-hidden"
+                  >
+                    <span className="block w-full truncate text-base font-medium text-gray-900 group-has-[.link-area:hover]/link:text-blue-600 transition-colors">
+                      {displayTitle}
+                    </span>
+                    <span className="block w-full truncate pt-0.5 text-[13px] text-gray-400 group-has-[.link-area:hover]/link:text-blue-500 transition-colors duration-150">
+                      {displayUrl}
+                    </span>
+                  </a>
+                </Tooltip>
+              </div>
+            ) : (
+              <div className="min-w-0 overflow-hidden">
+                <Tooltip content="Open URL in new tab" compact delay={500} className="flex min-w-0 w-full max-w-full">
+                  <a
+                    href={bookmark.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={handleUrlClick}
+                    className="link-area block w-full truncate text-base font-medium text-gray-900 group-has-[.link-area:hover]/link:text-blue-600 transition-colors"
                   >
                     {displayTitle}
                   </a>
                 </Tooltip>
-              )}
-              <ContentCard.Tags
-                tags={bookmark.tags}
-                onTagClick={onTagClick}
-                onTagRemove={onTagRemove ? (tag) => onTagRemove(bookmark, tag) : undefined}
-              />
-            </div>
-
-            {/* Right: Scheduled archive + Date */}
-            {(onCancelScheduledArchive || showArchivedIndicator) && (
-              <ContentCard.ArchiveStatus
-                archivedAt={bookmark.archived_at}
-                onCancel={onCancelScheduledArchive ? () => onCancelScheduledArchive(bookmark) : undefined}
-                showArchivedIndicator={showArchivedIndicator}
-              />
+              </div>
             )}
-            {/* flex prevents Tooltip's inline-flex wrapper from inflating height via inherited line-height */}
-            {showDate && (
-              <span className="shrink-0 flex">
-                <ContentCard.DateDisplay
-                  sortBy={sortBy}
-                  createdAt={bookmark.created_at}
-                  updatedAt={bookmark.updated_at}
-                  lastUsedAt={bookmark.last_used_at}
-                  archivedAt={bookmark.archived_at}
-                  deletedAt={bookmark.deleted_at}
+
+            <div className="shrink-0 flex items-center gap-2">
+              <div className="relative top-px">
+                <ContentCard.Tags
+                  tags={bookmark.tags}
+                  onTagClick={onTagClick}
+                  onTagRemove={onTagRemove ? (tag) => onTagRemove(bookmark, tag) : undefined}
                 />
-              </span>
-            )}
-          </div>
-
-          {/* Row 2: URL */}
-          {hasTitle && (
-            <div className="link-area pt-0.5 overflow-hidden">
-              <Tooltip content="Open URL in new tab" compact show={linkHovered}>
-                <a
-                  href={bookmark.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={handleUrlClick}
-                  className="link-area text-[13px] text-gray-400 truncate block group-has-[.link-area:hover]/link:text-blue-500 transition-colors duration-150"
-                >
-                  {displayUrl}
-                </a>
-              </Tooltip>
+              </div>
+              {/* Right: Scheduled archive + Date */}
+              {(onCancelScheduledArchive || showArchivedIndicator) && (
+                <div className={bookmark.tags.length === 0 ? 'relative top-1' : ''}>
+                  <ContentCard.ArchiveStatus
+                    archivedAt={bookmark.archived_at}
+                    onCancel={onCancelScheduledArchive ? () => onCancelScheduledArchive(bookmark) : undefined}
+                    showArchivedIndicator={showArchivedIndicator}
+                  />
+                </div>
+              )}
+              {/* flex prevents Tooltip's inline-flex wrapper from inflating height via inherited line-height */}
+              {showDate && (
+                /* No-tag cards need a small visual nudge so date/status align with the title baseline. */
+                <span className={`shrink-0 flex ${bookmark.tags.length === 0 ? 'relative top-1' : ''}`}>
+                  <ContentCard.DateDisplay
+                    sortBy={sortBy}
+                    createdAt={bookmark.created_at}
+                    updatedAt={bookmark.updated_at}
+                    lastUsedAt={bookmark.last_used_at}
+                    archivedAt={bookmark.archived_at}
+                    deletedAt={bookmark.deleted_at}
+                  />
+                </span>
+              )}
             </div>
-          )}
+          </div>
 
           {/* Row 3: Description/preview */}
           {(bookmark.description || bookmark.content_preview) && (

--- a/frontend/src/components/ContentCard/ContentCardArchiveStatus.tsx
+++ b/frontend/src/components/ContentCard/ContentCardArchiveStatus.tsx
@@ -49,7 +49,7 @@ export function ContentCardArchiveStatus({
     const tooltipText = `Archived: ${shortDate}`
     return (
       <span className="flex items-center gap-1 text-xs text-amber-500">
-        <Tooltip content={tooltipText} compact position="left">
+        <Tooltip content={tooltipText} compact position="left" delay={500}>
           <span className="flex items-baseline gap-1">
             <ArchiveIcon className="w-3 h-3 self-center" />
             <span>{shortDate}</span>
@@ -63,14 +63,14 @@ export function ContentCardArchiveStatus({
   const tooltipText = `Archiving: ${shortDate}`
   return (
     <span className="flex items-center gap-1 text-xs text-gray-400">
-      <Tooltip content={tooltipText} compact position="left">
+      <Tooltip content={tooltipText} compact position="left" delay={500}>
         <span className="flex items-baseline gap-1">
           <ArchiveIcon className="w-3 h-3 self-center" />
           <span>{shortDate}</span>
         </span>
       </Tooltip>
       {onCancel && (
-        <Tooltip content="Cancel" compact>
+        <Tooltip content="Cancel" compact delay={500}>
           <button
             onClick={(e) => { e.stopPropagation(); onCancel() }}
             className="text-gray-400 hover:text-red-500 transition-colors p-0.5 -m-0.5"

--- a/frontend/src/components/ContentCard/ContentCardDateDisplay.tsx
+++ b/frontend/src/components/ContentCard/ContentCardDateDisplay.tsx
@@ -74,7 +74,7 @@ export function ContentCardDateDisplay({
   }
 
   return (
-    <Tooltip content={tooltipText} compact position="left">
+    <Tooltip content={tooltipText} compact position="left" delay={500}>
       <span className="text-xs text-gray-400">
         {shortDate}
       </span>

--- a/frontend/src/components/InlineEditableArchiveSchedule.tsx
+++ b/frontend/src/components/InlineEditableArchiveSchedule.tsx
@@ -7,13 +7,17 @@
  * Features:
  * - View mode shows current schedule as text
  * - Click to edit reveals preset dropdown
- * - Custom date option shows datetime-local input
+ * - Custom date option shows date input
  * - Looks integrated with other inline editable components
  */
 import { useState, useRef, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import { calculateArchivePresetDate } from '../utils'
 import type { ArchivePreset } from '../utils'
+import { DropdownPortal } from './ui'
+import type { DropdownPortalHandle } from './ui/DropdownPortal'
+
+const ARCHIVE_DROPDOWN_WIDTH = 240
 
 interface InlineEditableArchiveScheduleProps {
   /** Current archived_at ISO string or empty */
@@ -29,25 +33,24 @@ interface InlineEditableArchiveScheduleProps {
 }
 
 /**
- * Convert ISO string to datetime-local format for input element.
+ * Convert ISO string to yyyy-mm-dd format for date input.
  */
-function toDatetimeLocalFormat(isoString: string): string {
+function toDateInputFormat(isoString: string): string {
   if (!isoString) return ''
   const date = new Date(isoString)
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
-  const hours = String(date.getHours()).padStart(2, '0')
-  const minutes = String(date.getMinutes()).padStart(2, '0')
-  return `${year}-${month}-${day}T${hours}:${minutes}`
+  return `${year}-${month}-${day}`
 }
 
 /**
- * Convert datetime-local format to ISO string.
+ * Convert yyyy-mm-dd format to ISO string at 8:00 AM local time.
  */
-function fromDatetimeLocalFormat(localString: string): string {
-  if (!localString) return ''
-  return new Date(localString).toISOString()
+function fromDateInputFormat(dateString: string): string {
+  if (!dateString) return ''
+  const [year, month, day] = dateString.split('-').map(Number)
+  return new Date(year, month - 1, day, 8, 0, 0).toISOString()
 }
 
 /**
@@ -76,11 +79,17 @@ export function InlineEditableArchiveSchedule({
 }: InlineEditableArchiveScheduleProps): ReactNode {
   const [isEditing, setIsEditing] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const dropdownPortalRef = useRef<DropdownPortalHandle>(null)
 
   // Close dropdown when clicking outside
   useEffect(() => {
     function handleClickOutside(event: MouseEvent): void {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+      const target = event.target as Node
+      if (containerRef.current?.contains(target) || dropdownPortalRef.current?.contains(target)) {
+        return
+      }
+      if (containerRef.current) {
         setIsEditing(false)
       }
     }
@@ -112,8 +121,8 @@ export function InlineEditableArchiveSchedule({
     }
   }
 
-  const handleCustomDateChange = (localString: string): void => {
-    onChange(fromDatetimeLocalFormat(localString))
+  const handleCustomDateChange = (dateString: string): void => {
+    onChange(fromDateInputFormat(dateString))
   }
 
   const handleViewClick = (): void => {
@@ -128,6 +137,7 @@ export function InlineEditableArchiveSchedule({
   return (
     <div ref={containerRef} className="relative inline-block">
       <button
+        ref={triggerRef}
         type="button"
         onClick={handleViewClick}
         disabled={disabled}
@@ -145,48 +155,55 @@ export function InlineEditableArchiveSchedule({
       </button>
 
       {isEditing && (
-        <div className="absolute top-full left-0 z-50 mt-1 flex flex-col gap-2 p-2 bg-white border border-gray-200 rounded-lg shadow-sm min-w-[200px]">
-          <select
-            value={preset}
-            onChange={(e) => handlePresetChange(e.target.value as ArchivePreset)}
-            disabled={disabled}
-            className="text-xs px-2 py-1.5 bg-gray-50 border border-gray-200 rounded outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400/20"
-            autoFocus
-          >
-            <option value="none">None</option>
-            <option value="1-week">In 1 week</option>
-            <option value="1-month">In 1 month</option>
-            <option value="end-of-month">End of month</option>
-            <option value="3-months">In 3 months</option>
-            <option value="6-months">In 6 months</option>
-            <option value="1-year">In 1 year</option>
-            <option value="custom">Custom date...</option>
-          </select>
-
-          {preset === 'custom' && (
-            <input
-              type="datetime-local"
-              value={toDatetimeLocalFormat(value)}
-              onChange={(e) => handleCustomDateChange(e.target.value)}
+        <DropdownPortal
+          ref={dropdownPortalRef}
+          anchorRef={triggerRef}
+          open={isEditing}
+          dropdownWidth={ARCHIVE_DROPDOWN_WIDTH}
+        >
+          <div className="mt-1 flex w-[240px] flex-col gap-2 rounded-lg border border-gray-200 bg-white p-2 shadow-sm">
+            <select
+              value={preset}
+              onChange={(e) => handlePresetChange(e.target.value as ArchivePreset)}
               disabled={disabled}
-              className="text-xs px-2 py-1.5 bg-gray-50 border border-gray-200 rounded outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400/20"
-            />
-          )}
+              className="select text-xs"
+              autoFocus
+            >
+              <option value="none">None</option>
+              <option value="1-week">In 1 week</option>
+              <option value="1-month">In 1 month</option>
+              <option value="end-of-month">End of month</option>
+              <option value="3-months">In 3 months</option>
+              <option value="6-months">In 6 months</option>
+              <option value="1-year">In 1 year</option>
+              <option value="custom">Custom date...</option>
+            </select>
 
-          {value && preset !== 'custom' && (
-            <p className="text-xs text-gray-500">
-              {formatScheduleDisplay(value)}
-            </p>
-          )}
+            {preset === 'custom' && (
+              <input
+                type="date"
+                value={toDateInputFormat(value)}
+                onChange={(e) => handleCustomDateChange(e.target.value)}
+                disabled={disabled}
+                className="input text-xs"
+              />
+            )}
 
-          <button
-            type="button"
-            onClick={() => setIsEditing(false)}
-            className="text-xs text-gray-500 hover:text-gray-700 self-end"
-          >
-            Done
-          </button>
-        </div>
+            {value && preset !== 'custom' && (
+              <p className="text-xs text-gray-500">
+                {formatScheduleDisplay(value)}
+              </p>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setIsEditing(false)}
+              className="text-xs text-gray-500 hover:text-gray-700 self-end"
+            >
+              Done
+            </button>
+          </div>
+        </DropdownPortal>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

This PR fixes the desktop bookmark card interaction/layout issues behind KAN-129 and cleans up related bookmark-detail UI issues. It removes the desktop dead zone between bookmark title and URL by treating the desktop title/URL area as a single link cluster, stabilizes metadata placement/truncation in list view, and updates the bookmark detail auto-archive editor so its dropdown is no longer clipped and the custom picker is date-only.

Related issue: [KAN-129](https://tiddly.atlassian.net/browse/KAN-129)

## Changes

- Refactor desktop  title/URL rendering into a single external-link cluster so clicks in the visible link area no longer fall through to the card detail navigation
- Reserve a real desktop metadata column for bookmark tags, archive status, and date, and tune the no-tag alignment so bookmark cards render consistently with and without tags
- Add/adjust bookmark card test coverage to lock in the single desktop link-cluster structure and prevent regression to the earlier split title/URL layout
- Switch the bookmark detail auto-archive dropdown to the shared portal-based dropdown pattern so it is not clipped when page content is collapsed
- Update the auto-archive custom picker to use a date-only input while still normalizing to the existing timestamp convention sent to the API
- Align auto-archive nested controls with shared form control styling and add the standard tooltip delay to shared card date/archive metadata tooltips

## Impact

No breaking changes. No new dependencies or deployment changes. Tested with targeted frontend Vitest runs for , , and , plus manual browser verification of the bookmark card layout/interaction and the bookmark detail auto-archive dropdown behavior.