### PR TITLE
Speed up backend tests and harden MCP fixtures

### DIFF
--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,4 +1,5 @@
 """SQLAlchemy models."""
+from models.ai_usage import AiUsage
 from models.api_token import ApiToken
 from models.base import ArchivableMixin, Base, TimestampMixin
 from models.bookmark import Bookmark
@@ -15,6 +16,7 @@ from models.user_settings import UserSettings
 
 __all__ = [
     "ActionType",
+    "AiUsage",
     "ApiToken",
     "ArchivableMixin",
     "Base",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest fixtures for testing."""
+import asyncio
 import os
 from collections.abc import AsyncGenerator, Generator
 from unittest.mock import patch
@@ -20,9 +21,24 @@ from core.auth_cache import AuthCache, set_auth_cache
 from core.config import Settings, get_settings
 from core.redis import RedisClient, set_redis_client
 from core.tier_limits import Tier, TierLimits, get_tier_limits
-from models.ai_usage import AiUsage  # noqa: F401 - registers model with Base.metadata
 from models.base import Base
 from services.llm_service import LLMService, set_llm_service
+
+def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
+    """Pin env vars that shadow local .env so tests are hermetic.
+
+    Runs once at session start, before any fixture or test, regardless of
+    which subset of tests is selected. Container-dependent env vars
+    (DATABASE_URL, REDIS_URL) stay in the database_url fixture because they
+    need the testcontainers running first.
+
+    The MCP server respx mocks (in mcp_server/conftest.py and
+    prompt_mcp_server/conftest.py) read VITE_API_URL from os.environ, so
+    pinning it here means the mock base_url and the URL the server code
+    actually requests cannot drift.
+    """
+    os.environ["VITE_DEV_MODE"] = "true"
+    os.environ["VITE_API_URL"] = "http://localhost:8000"
 
 
 @pytest.fixture(scope="session")
@@ -55,10 +71,7 @@ def database_url(postgres_container: PostgresContainer, redis_container: RedisCo
     """
     url = postgres_container.get_connection_url()
     os.environ["DATABASE_URL"] = url
-    # Set Redis URL from container
     os.environ["REDIS_URL"] = get_redis_url(redis_container)
-    # Ensure tests run in dev mode (bypasses auth) regardless of local .env
-    os.environ["VITE_DEV_MODE"] = "true"
     return url
 
 
@@ -153,21 +166,45 @@ _SEARCH_VECTOR_TRIGGER_STATEMENTS = [
 ]
 
 
+@pytest.fixture(scope="session")
+def _schema_setup(database_url: str) -> None:
+    """Run schema DDL once per test session.
+
+    Saves ~45s across the ~3000-test suite by hoisting Base.metadata.create_all
+    and the search-vector trigger DDL out of the per-test path. The Postgres
+    container is session-scoped and all DDL here is idempotent (CREATE OR
+    REPLACE / IF NOT EXISTS / DROP TRIGGER IF EXISTS + CREATE TRIGGER), so
+    running once per session is behaviorally equivalent to running per-test.
+
+    Sync wrapper using asyncio.run() avoids the pytest-asyncio loop-scope
+    coupling: this fixture's event loop is created and torn down inside
+    asyncio.run() before any test runs, so it never interacts with the
+    per-test loops used by async_engine / db_connection / db_session.
+    """
+    async def _setup() -> None:
+        engine = create_async_engine(database_url, echo=False)
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+                # Trigger functions, triggers, and GIN indexes are defined in the
+                # Alembic migration but not in SQLAlchemy model metadata, so
+                # create_all doesn't include them.
+                for stmt in _SEARCH_VECTOR_TRIGGER_STATEMENTS:
+                    await conn.execute(text(stmt))
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_setup())
+
+
 @pytest.fixture
-async def async_engine(database_url: str) -> AsyncGenerator[AsyncEngine]:
-    """Create an async engine for testing."""
+async def async_engine(
+    database_url: str,
+    _schema_setup: None,
+) -> AsyncGenerator[AsyncEngine]:
+    """Create an async engine for testing. DDL is handled by _schema_setup."""
     engine = create_async_engine(database_url, echo=False)
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-        # Create search_vector trigger functions, triggers, and GIN indexes.
-        # These are defined in the Alembic migration but not in SQLAlchemy model
-        # metadata, so create_all doesn't include them.
-        for stmt in _SEARCH_VECTOR_TRIGGER_STATEMENTS:
-            await conn.execute(text(stmt))
-
     yield engine
-
     await engine.dispose()
 
 

--- a/backend/tests/mcp_server/conftest.py
+++ b/backend/tests/mcp_server/conftest.py
@@ -1,5 +1,6 @@
 """Test fixtures for MCP server tests."""
 
+import os
 from typing import Any
 from unittest.mock import patch
 
@@ -11,10 +12,15 @@ from mcp_server import server
 
 @pytest.fixture
 def mock_api() -> respx.MockRouter:
-    """Context manager for mocking API responses."""
+    """Context manager for mocking API responses.
+
+    Reads VITE_API_URL from env (pinned by top-level conftest's
+    pytest_configure) so the mock base_url matches the URL the MCP server
+    code reads via the same env var. Single source of truth, no drift.
+    """
     # Reset the module-level HTTP client to ensure respx captures requests
     server._http_client = None
-    with respx.mock(base_url="http://localhost:8000") as respx_mock:
+    with respx.mock(base_url=os.environ["VITE_API_URL"]) as respx_mock:
         yield respx_mock
     # Clean up after test
     server._http_client = None

--- a/backend/tests/prompt_mcp_server/conftest.py
+++ b/backend/tests/prompt_mcp_server/conftest.py
@@ -1,5 +1,6 @@
 """Test fixtures for Prompt MCP server tests."""
 
+import os
 from typing import Any
 from collections.abc import AsyncGenerator
 from unittest.mock import patch
@@ -35,10 +36,15 @@ class _LowLevelServerWrapper:
 
 @pytest.fixture
 async def mock_api() -> AsyncGenerator[respx.MockRouter]:
-    """Context manager for mocking API responses."""
+    """Context manager for mocking API responses.
+
+    Reads VITE_API_URL from env (pinned by top-level conftest's
+    pytest_configure) so the mock base_url matches the URL the MCP server
+    code reads via the same env var. Single source of truth, no drift.
+    """
     # Reset the module-level HTTP client to ensure respx captures requests
     server_module._http_client = None
-    with respx.mock(base_url="http://localhost:8000") as respx_mock:
+    with respx.mock(base_url=os.environ["VITE_API_URL"]) as respx_mock:
         # Initialize HTTP client within respx context so it uses the mock transport
         await server_module.init_http_client()
         yield respx_mock


### PR DESCRIPTION
- Hoist schema DDL to a session-scoped `_schema_setup` fixture (uses `asyncio.run()` to sidestep pytest-asyncio loop-scope coupling). The DDL is idempotent and the Postgres container is session-scoped, so running once per session is equivalent. Saves ~45s across the ~3000-test suite.
- Move `VITE_API_URL` and `VITE_DEV_MODE` env pins from the `database_url` fixture to `pytest_configure`. Previously these only fired when a `database_url`-using test ran, so partial-suite invocations (e.g. `pytest backend/tests/prompt_mcp_server`) inherited whatever the local `.env` had — on machines with a non-default `VITE_API_URL`, every MCP test failed in isolation despite passing in the full suite.
- Have both MCP conftests read `base_url` from `os.environ["VITE_API_URL"]` instead of hardcoding the URL. The production server code reads the same env var, so respx mocks and the requesting code share a single source of truth.
- Add `AiUsage` to `models/__init__.py` so the package import registers all models; drop the explicit `from models.ai_usage` workaround in conftest.