### PR TITLE
Fix editor list prefix toggles for indented lines

### DIFF
--- a/frontend/src/utils/editorFormatting.test.ts
+++ b/frontend/src/utils/editorFormatting.test.ts
@@ -300,11 +300,6 @@ describe('toggleLinePrefix — inline formatting is untouched', () => {
     expect(runToggle('**bold** at start', BULLET).text).toBe('- **bold** at start')
   })
 
-  it('leaves indented list items alone (not at column 0 — treated as nested content)', () => {
-    // Regex is anchored to line start and does not allow leading whitespace,
-    // so indented bullets are treated as plain text (prefix prepended).
-    expect(runToggle('  - nested', BULLET).text).toBe('-   - nested')
-  })
 })
 
 // ---------------------------------------------------------------------------
@@ -423,17 +418,16 @@ describe('toggleLinePrefix — selection adjustment', () => {
     expect(result.head).toBe(13)
   })
 
-  it('normalizes a reverse selection (head < anchor) after the change', () => {
-    // CodeMirror permits backward selections; pin current behavior.
-    // The implementation reads from/to (always min/max) and dispatches
-    // anchor=newSelectionStart, head=newSelectionEnd — so the resulting
-    // selection ends up forward-oriented. This test documents that so a
-    // future change to preserve directionality is caught rather than
-    // silently breaking callers that depend on it.
+  it('preserves a reverse selection (head < anchor) across the change', () => {
+    // CodeMirror permits backward selections. The toggle dispatches the
+    // changes without an explicit selection, letting CodeMirror map the
+    // current selection through them — which preserves direction. So an
+    // anchor=5, head=0 selection over `- hello` ends up anchor=3, head=0
+    // (still backward) after the `- ` is removed.
     const result = runToggle('- hello', BULLET, { anchor: 5, head: 0 })
     expect(result.text).toBe('hello')
-    expect(result.anchor).toBe(0)
-    expect(result.head).toBe(3)
+    expect(result.anchor).toBe(3)
+    expect(result.head).toBe(0)
   })
 })
 
@@ -450,5 +444,376 @@ describe('toggleLinePrefix — nested blockquote', () => {
 
   it('swapping `> > x` to bullet replaces the outer marker only', () => {
     expect(runToggle('> > x', BULLET).text).toBe('- > x')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Indent handling (KAN-128)
+//
+// Sub-bullets and any other indented prefixes must be detected and toggled
+// the same way as their column-0 equivalents, with leading whitespace
+// preserved across swap and toggle-off.
+// ---------------------------------------------------------------------------
+
+describe('toggleLinePrefix — indent: toggle on (no existing prefix)', () => {
+  it.each([
+    [BULLET, '  - hello'],
+    [NUMBERED, '  1. hello'],
+    [CHECKLIST, '  - [ ] hello'],
+    [BLOCKQUOTE, '  > hello'],
+    [H1, '  # hello'],
+    [H2, '  ## hello'],
+    [H3, '  ### hello'],
+  ])('inserts %j after a 2-space indent', (prefix: BlockLinePrefix, expected: string) => {
+    expect(runToggle('  hello', prefix).text).toBe(expected)
+  })
+
+  it('preserves a 4-space indent', () => {
+    expect(runToggle('    hello', BULLET).text).toBe('    - hello')
+  })
+
+  it('preserves a 1-space indent (unusual but legal)', () => {
+    expect(runToggle(' hello', BULLET).text).toBe(' - hello')
+  })
+
+  it('preserves a deep 8-space indent', () => {
+    expect(runToggle('        hello', CHECKLIST).text).toBe('        - [ ] hello')
+  })
+
+  it('preserves a tab indent', () => {
+    expect(runToggle('\thello', BULLET).text).toBe('\t- hello')
+  })
+
+  it('preserves a mixed tab+space indent', () => {
+    expect(runToggle('\t  hello', CHECKLIST).text).toBe('\t  - [ ] hello')
+  })
+})
+
+describe('toggleLinePrefix — indent: toggle off (same kind preserves indent)', () => {
+  it.each([
+    ['  - foo', BULLET, '  foo'],
+    ['  - [ ] foo', CHECKLIST, '  foo'],
+    ['  - [x] foo', CHECKLIST, '  foo'],
+    ['  - [X] foo', CHECKLIST, '  foo'],
+    ['  1. foo', NUMBERED, '  foo'],
+    ['  2. foo', NUMBERED, '  foo'],
+    ['  42. foo', NUMBERED, '  foo'],
+    ['  > foo', BLOCKQUOTE, '  foo'],
+    ['  # foo', H1, '  foo'],
+    ['  ## foo', H2, '  foo'],
+    ['  ### foo', H3, '  foo'],
+  ])('toggles %j off with %j → %j', (input: string, prefix: BlockLinePrefix, expected: string) => {
+    expect(runToggle(input, prefix).text).toBe(expected)
+  })
+
+  it('preserves a tab indent on toggle off', () => {
+    expect(runToggle('\t- foo', BULLET).text).toBe('\tfoo')
+  })
+
+  it('preserves a deep 6-space indent on toggle off', () => {
+    expect(runToggle('      - [ ] foo', CHECKLIST).text).toBe('      foo')
+  })
+})
+
+describe('toggleLinePrefix — indent: cross-family swap (KAN-128 ticket scenarios)', () => {
+  // Exact scenarios from the reopened ticket comment: indented sub-bullets
+  // must swap cleanly, not duplicate.
+  it('KAN-128: indented checklist → bullet drops `[ ]` and keeps indent', () => {
+    expect(runToggle('  - [ ] My List', BULLET).text).toBe('  - My List')
+  })
+
+  it('KAN-128: indented bullet → checklist does not duplicate `- ` and keeps indent', () => {
+    expect(runToggle('  - My List', CHECKLIST).text).toBe('  - [ ] My List')
+  })
+
+  it('KAN-128: indented numbered → bullet keeps indent', () => {
+    expect(runToggle('  1. My List', BULLET).text).toBe('  - My List')
+  })
+
+  // Full pairwise matrix at 2-space indent.
+  it.each([
+    ['  - x', NUMBERED, '  1. x'],
+    ['  - x', CHECKLIST, '  - [ ] x'],
+    ['  - x', BLOCKQUOTE, '  > x'],
+    ['  - x', H1, '  # x'],
+    ['  - x', H2, '  ## x'],
+    ['  1. x', BULLET, '  - x'],
+    ['  1. x', CHECKLIST, '  - [ ] x'],
+    ['  1. x', BLOCKQUOTE, '  > x'],
+    ['  - [ ] x', BULLET, '  - x'],
+    ['  - [ ] x', NUMBERED, '  1. x'],
+    ['  - [ ] x', BLOCKQUOTE, '  > x'],
+    ['  - [ ] x', H1, '  # x'],
+    ['  - [x] x', BULLET, '  - x'],
+    ['  > x', BULLET, '  - x'],
+    ['  > x', NUMBERED, '  1. x'],
+    ['  > x', CHECKLIST, '  - [ ] x'],
+    ['  # x', BULLET, '  - x'],
+    ['  # x', H2, '  ## x'],
+    ['  ### x', H1, '  # x'],
+    ['  ###### x', BULLET, '  - x'],
+  ])('swaps %j with target %j → %j', (input: string, prefix: BlockLinePrefix, expected: string) => {
+    expect(runToggle(input, prefix).text).toBe(expected)
+  })
+
+  it('preserves a tab indent across a swap', () => {
+    expect(runToggle('\t- foo', CHECKLIST).text).toBe('\t- [ ] foo')
+  })
+})
+
+describe('toggleLinePrefix — indent: negative cases (regex must NOT detect)', () => {
+  // Patterns that look list-ish but lack the required separator/character —
+  // the prefix group must fail to match, so we add (not swap) and the
+  // existing content stays intact behind the indent.
+  it('does not treat `  1.foo` (no space) as numbered — adds bullet', () => {
+    expect(runToggle('  1.foo', BULLET).text).toBe('  - 1.foo')
+  })
+
+  it('does not treat `  -foo` (no space) as bullet — adds bullet', () => {
+    expect(runToggle('  -foo', BULLET).text).toBe('  - -foo')
+  })
+
+  it('does not treat 7 hashes as a heading — adds bullet', () => {
+    expect(runToggle('  ####### foo', BULLET).text).toBe('  - ####### foo')
+  })
+
+  it('does not misinterpret leading `**` as a list marker', () => {
+    expect(runToggle('  **bold** at start', BULLET).text).toBe('  - **bold** at start')
+  })
+
+  it('does not match a heading with no trailing space (`  #foo`)', () => {
+    expect(runToggle('  #foo', BULLET).text).toBe('  - #foo')
+  })
+})
+
+describe('toggleLinePrefix — indent: line-content edge cases', () => {
+  it('preserves indent when toggling off a prefix-only indented line', () => {
+    expect(runToggle('  - ', BULLET).text).toBe('  ')
+  })
+
+  it('preserves indent when swapping a prefix-only indented line', () => {
+    expect(runToggle('  - ', CHECKLIST).text).toBe('  - [ ] ')
+  })
+
+  it('inserts the prefix after the indent on a whitespace-only line', () => {
+    // Line is just three spaces — there is no content but indent is kept.
+    expect(runToggle('   ', BULLET).text).toBe('   - ')
+  })
+
+  it('treats `  ###### x` (h6) as a valid heading and toggles to bullet', () => {
+    expect(runToggle('  ###### x', BULLET).text).toBe('  - x')
+  })
+})
+
+describe('toggleLinePrefix — indent: selection adjustment', () => {
+  it('shifts cursor forward by prefix length when adding behind an indent', () => {
+    // `  hello` (length 7); cursor at position 5 (between 'l' and 'l').
+    // Inserting `- ` at position 2 shifts cursor by +2 → position 7.
+    const result = runToggle('  hello', BULLET, { anchor: 5 })
+    expect(result.text).toBe('  - hello')
+    expect(result.anchor).toBe(7)
+  })
+
+  it('shifts cursor back by prefix length when toggling off with indent', () => {
+    // `  - hello` (length 9); cursor at position 7 (between 'e' and 'l').
+    // Removing `- ` at position 2 shifts cursor by -2 → position 5.
+    const result = runToggle('  - hello', BULLET, { anchor: 7 })
+    expect(result.text).toBe('  hello')
+    expect(result.anchor).toBe(5)
+  })
+
+  it('snaps cursor to the start of the deletion when it lands inside the deleted prefix', () => {
+    // Cursor at position 3 (inside `- `) of `  - hello`. The prefix is
+    // deleted; CodeMirror maps the cursor to the start of the deletion,
+    // which is also the start of the post-indent content in the new doc.
+    const result = runToggle('  - hello', BULLET, { anchor: 3 })
+    expect(result.text).toBe('  hello')
+    expect(result.anchor).toBe(2)
+  })
+
+  it('adjusts cursor on indented swap that shortens the prefix', () => {
+    // Cursor after 'h' in `  - [ ] hello` (position 9). Swap checklist→bullet,
+    // delta = -4 → anchor = 5.
+    const result = runToggle('  - [ ] hello', BULLET, { anchor: 9 })
+    expect(result.text).toBe('  - hello')
+    expect(result.anchor).toBe(5)
+  })
+
+  it('adjusts cursor on indented swap that lengthens the prefix', () => {
+    // Cursor after 'h' in `  - hello` (position 5). Swap bullet→checklist,
+    // delta = +4 → anchor = 9.
+    const result = runToggle('  - hello', CHECKLIST, { anchor: 5 })
+    expect(result.text).toBe('  - [ ] hello')
+    expect(result.anchor).toBe(9)
+  })
+
+  it('preserves a range selection across the indented swap', () => {
+    // Select 'hello' in `  - [ ] hello` (positions 8..13).
+    const result = runToggle('  - [ ] hello', BULLET, { anchor: 8, head: 13 })
+    expect(result.text).toBe('  - hello')
+    expect(result.anchor).toBe(4)
+    expect(result.head).toBe(9)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cursor-at-line-start regression: toggle off must not pull the cursor
+// onto the previous line.
+//
+// The previous implementation naively applied `delta` to every selection
+// endpoint, which underflowed when the cursor sat at column 0 of a list
+// line (or at the indent boundary just before the prefix). The cursor
+// would land on the previous line, ~prefix-width characters in.
+// ---------------------------------------------------------------------------
+
+describe('toggleLinePrefix — cursor at line start (regression)', () => {
+  it('keeps the cursor on its own line when toggling off at column 0 of a bullet line', () => {
+    // Doc: `ABCD\n- text` (line 2 starts at position 5). Cursor at line.from
+    // of line 2 — i.e., the very start of `- text`.
+    const result = runToggle('ABCD\n- text', BULLET, { anchor: 5 })
+    expect(result.text).toBe('ABCD\ntext')
+    // Cursor must stay at position 5 (start of `text`), NOT jump back to
+    // position 3 (`ABC|D`) on the previous line.
+    expect(result.anchor).toBe(5)
+  })
+
+  it('keeps the cursor on its own line when toggling off at the indent of a sub-bullet', () => {
+    // Doc: `ABCD\n    - text`. Cursor at line.from of line 2 (just after the
+    // newline, before the indent).
+    const result = runToggle('ABCD\n    - text', BULLET, { anchor: 5 })
+    expect(result.text).toBe('ABCD\n    text')
+    expect(result.anchor).toBe(5)
+  })
+
+  it('keeps the cursor at the indent boundary when toggling off a sub-bullet from prefixStart', () => {
+    // Doc: `ABCD\n    - text`. Cursor at position 9 (`    |- text`), the
+    // boundary between the indent and the `- ` prefix.
+    const result = runToggle('ABCD\n    - text', BULLET, { anchor: 9 })
+    expect(result.text).toBe('ABCD\n    text')
+    // After `- ` is deleted at positions 9-11, the cursor at position 9
+    // sits at the boundary and stays at 9 (start of `text` in the new doc).
+    expect(result.anchor).toBe(9)
+  })
+
+  it('keeps the cursor on its own line when toggling off at column 0 of a checklist line', () => {
+    const result = runToggle('ABCD\n- [ ] task', CHECKLIST, { anchor: 5 })
+    expect(result.text).toBe('ABCD\ntask')
+    expect(result.anchor).toBe(5)
+  })
+
+  it('keeps the cursor on its own line when toggling off at column 0 of a numbered line', () => {
+    const result = runToggle('ABCD\n1. item', NUMBERED, { anchor: 5 })
+    expect(result.text).toBe('ABCD\nitem')
+    expect(result.anchor).toBe(5)
+  })
+
+  it('keeps the cursor on its own line when toggling off at column 0 of an indented checklist', () => {
+    const result = runToggle('ABCD\n  - [ ] task', CHECKLIST, { anchor: 5 })
+    expect(result.text).toBe('ABCD\n  task')
+    expect(result.anchor).toBe(5)
+  })
+
+  it('does not pull the cursor up across a blank line', () => {
+    // Cursor at column 0 of line 3 (a bullet line); line 2 is blank.
+    const doc = 'ABCD\n\n- text'
+    // Line 3 starts at position 6.
+    const result = runToggle(doc, BULLET, { anchor: 6 })
+    expect(result.text).toBe('ABCD\n\ntext')
+    expect(result.anchor).toBe(6)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cursor at insertion boundary on toggle-on: the cursor follows the inserted
+// prefix so the user can keep typing in the content position. Selection is
+// mapped with assoc=1, so a cursor sitting exactly at the insertion point
+// ends up after the new marker rather than before it.
+// ---------------------------------------------------------------------------
+
+describe('toggleLinePrefix — cursor at insertion boundary (toggle-on)', () => {
+  it('cursor at column 0 follows the inserted bullet marker', () => {
+    // Cursor at position 0 of `hello`. Insert `- ` at 0. With assoc=1 the
+    // cursor maps to position 2, leaving the user at `- |hello`.
+    const result = runToggle('hello', BULLET, { anchor: 0 })
+    expect(result.text).toBe('- hello')
+    expect(result.anchor).toBe(2)
+  })
+
+  it('cursor at the indent boundary follows the inserted bullet marker', () => {
+    // `  hello`, cursor at position 2 (between the indent and the content).
+    // Insert `- ` at position 2. With assoc=1 the cursor maps to 4.
+    const result = runToggle('  hello', BULLET, { anchor: 2 })
+    expect(result.text).toBe('  - hello')
+    expect(result.anchor).toBe(4)
+  })
+
+  it('cursor before the indent stays before the indent on toggle-on', () => {
+    // assoc only affects positions exactly at the change point; a cursor at
+    // column 0 (before a 2-space indent) is strictly less than the insertion
+    // point at position 2, so it stays put.
+    const result = runToggle('  hello', BULLET, { anchor: 0 })
+    expect(result.text).toBe('  - hello')
+    expect(result.anchor).toBe(0)
+  })
+
+  it('cursor at column 0 follows the inserted checklist marker', () => {
+    const result = runToggle('hello', CHECKLIST, { anchor: 0 })
+    expect(result.text).toBe('- [ ] hello')
+    expect(result.anchor).toBe(6)
+  })
+
+  it('toggle-off behavior at boundary is unaffected by assoc=1', () => {
+    // Sanity check: at a pure-delete boundary both assocs collapse to `from`,
+    // so the column-0 toggle-off regression test still holds with assoc=1.
+    const result = runToggle('ABCD\n- text', BULLET, { anchor: 5 })
+    expect(result.text).toBe('ABCD\ntext')
+    expect(result.anchor).toBe(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Intentional design choice: this command is line-based, not Markdown-AST-
+// aware. CodeMirror is the source view, so toolbar/shortcut commands operate
+// on whatever line the cursor sits on. A 4-space indented `- literal` (which
+// CommonMark would parse as code-block content) is still treated as an
+// indented bullet here — that's the right call for a source editor where
+// the user explicitly invoked a list-toggle command.
+// ---------------------------------------------------------------------------
+
+describe('toggleLinePrefix — line-based semantics (not Markdown-AST aware)', () => {
+  it('toggles a 4-space indented `- literal` as an indented bullet (not as code)', () => {
+    // In rendered Markdown a 4-space indent could mean a code block. We
+    // intentionally do not consult the parsed syntax tree — line-based
+    // toggling is the contract. If this assumption changes, this test is
+    // the canary.
+    expect(runToggle('    - literal', BULLET).text).toBe('    literal')
+  })
+})
+
+describe('toggleLinePrefix — indent: multi-line selection with heterogeneous indents', () => {
+  it('toggles a mix of unindented and indented lines independently', () => {
+    // Three lines: column-0 bullet, 2-space indented bullet, 4-space indented bullet.
+    // All are bullet-kind, so toggling bullet should remove the prefix on each
+    // while preserving each line's own indent.
+    const doc = '- a\n  - b\n    - c'
+    const result = runToggle(doc, BULLET, { anchor: 0, head: doc.length })
+    expect(result.text).toBe('a\n  b\n    c')
+  })
+
+  it('swaps a heterogeneous mix to checklist while preserving each indent', () => {
+    const doc = '- a\n  1. b\n    > c'
+    const result = runToggle(doc, CHECKLIST, { anchor: 0, head: doc.length })
+    expect(result.text).toBe('- [ ] a\n  - [ ] b\n    - [ ] c')
+  })
+
+  it('accumulates selection-end delta correctly across heterogeneous indents', () => {
+    // Doc: `- a\n  - b` → select all → toggle bullet off.
+    // Line 1 delta = -2 (removes `- `). Line 2 delta = -2 (removes `- ` after indent).
+    // Resulting text: `a\n  b` (length 5). Head should land at end (5).
+    const doc = '- a\n  - b'
+    const result = runToggle(doc, BULLET, { anchor: 0, head: doc.length })
+    expect(result.text).toBe('a\n  b')
+    expect(result.anchor).toBe(0)
+    expect(result.head).toBe(5)
   })
 })

--- a/frontend/src/utils/editorFormatting.ts
+++ b/frontend/src/utils/editorFormatting.ts
@@ -148,14 +148,22 @@ export function insertCodeBlock(view: EditorView): boolean {
 }
 
 /**
- * Matches any known block-level line prefix at the start of a line.
- * Alternation is ordered from most-specific to most-generic so that e.g.
- * `- [ ] ` is matched as a checklist and not as a bullet followed by `[ ] `.
+ * Matches optional indentation followed by an optional block-level line
+ * prefix at the start of a line. Two capture groups, both optional:
  *
- * Supported prefixes: ATX headings (h1–h6), blockquote, checklist (checked
- * or unchecked), bullet, numbered list.
+ * - Group 1 (`[ \t]*`): leading whitespace, so callers can preserve indent
+ *   across swaps and toggle-offs (KAN-128: indented sub-bullets like
+ *   `  - foo` must swap cleanly without duplicate prefixes).
+ * - Group 2: the prefix — ATX heading (h1–h6), blockquote, checklist
+ *   (checked or unchecked), bullet, or numbered list. Alternation is
+ *   ordered most-specific to most-generic so `- [ ] ` is read as a
+ *   checklist, not as a bullet followed by `[ ] `.
+ *
+ * Both groups can be empty, so the regex always succeeds; group 2 may
+ * still be undefined (no prefix on the line). Callers default both via
+ * `?? ''`.
  */
-const BLOCK_PREFIX_RE = /^(?:#{1,6} |> |- \[[ xX]\] |- |\d+\. )/
+const BLOCK_PREFIX_RE = /^([ \t]*)(#{1,6} |> |- \[[ xX]\] |- |\d+\. )?/
 
 /**
  * Collapse prefix variants to a single "kind" for toggle comparison.
@@ -180,11 +188,19 @@ function normalizeBlockPrefixKind(prefix: string): string {
 /**
  * Toggle a block-level line prefix on each line of the current selection.
  *
+ * Indent-aware: leading whitespace (spaces or tabs) is preserved across
+ * every operation. Prefix detection runs against the line content after
+ * the indent, so `  - foo` is recognized as a bullet and toggles cleanly
+ * to `  - [ ] foo` / `  foo` rather than getting a duplicate prefix
+ * prepended at column 0 (KAN-128).
+ *
  * Behavior per line:
- * - No existing block prefix: prepend the target prefix.
- * - Existing prefix of the same kind as the target: remove it (toggle off).
- *   "Kind" treats `- [ ] ` and `- [x] ` as equal, and all `\d+\. ` as equal.
- * - Existing prefix of a different kind: replace it with the target (swap).
+ * - No existing block prefix: insert the target prefix after the indent.
+ * - Existing prefix of the same kind as the target: remove it (toggle off);
+ *   indent is kept. "Kind" treats `- [ ] ` and `- [x] ` as equal, and all
+ *   `\d+\. ` as equal.
+ * - Existing prefix of a different kind: replace it with the target (swap);
+ *   indent is kept.
  */
 export function toggleLinePrefix(view: EditorView, prefix: BlockLinePrefix): boolean {
   const { state } = view
@@ -194,29 +210,34 @@ export function toggleLinePrefix(view: EditorView, prefix: BlockLinePrefix): boo
 
   const targetKind = normalizeBlockPrefixKind(prefix)
   const changes: { from: number; to: number; insert: string }[] = []
-  let newSelectionStart = from
-  let newSelectionEnd = to
 
   for (let lineNum = startLine.number; lineNum <= endLine.number; lineNum++) {
     const line = state.doc.line(lineNum)
     const match = line.text.match(BLOCK_PREFIX_RE)
-    const existing = match ? match[0] : ''
+    const indent = match?.[1] ?? ''
+    const existing = match?.[2] ?? ''
     const existingKind = normalizeBlockPrefixKind(existing)
     const replacement = existing !== '' && existingKind === targetKind ? '' : prefix
-    const delta = replacement.length - existing.length
+    const prefixStart = line.from + indent.length
 
-    changes.push({ from: line.from, to: line.from + existing.length, insert: replacement })
-
-    if (lineNum === startLine.number) newSelectionStart += delta
-    newSelectionEnd += delta
+    changes.push({ from: prefixStart, to: prefixStart + existing.length, insert: replacement })
   }
 
+  // Map the prior selection through the changes with assoc=1 ("track
+  // right"). Two policies fall out of this:
+  //   - Toggle-off (pure delete): a cursor at the start of the removed
+  //     prefix stays on the same line at the start of the new content;
+  //     it does NOT jump backward onto the previous line. (For pure
+  //     deletes both assocs collapse to `from`, so this would also work
+  //     with assoc=-1.)
+  //   - Toggle-on (insertion at the line/indent boundary): a cursor sitting
+  //     exactly at the insertion point follows the inserted prefix, so
+  //     subsequent typing lands in the content position rather than
+  //     before the marker.
+  const changeSet = state.changes(changes)
   view.dispatch({
-    changes,
-    selection: {
-      anchor: Math.max(0, newSelectionStart),
-      head: Math.max(0, newSelectionEnd),
-    },
+    changes: changeSet,
+    selection: state.selection.map(changeSet, 1),
   })
   return true
 }


### PR DESCRIPTION
## Summary

Updates CodeMirror line-prefix toggling so indented list-like lines (sub-bullets, indented checklists, etc.) behave consistently with top-level lines. Previously, toggling a prefix on an indented line like `  - foo` produced a duplicate marker at column 0 (`-   - foo`) instead of swapping in place.

## Changes

- Indent-aware prefix detection: regex now captures leading whitespace and the prefix as separate groups, so indentation is preserved across add, remove, and swap operations
- Cursor placement now uses CodeMirror's selection mapping (`assoc=1`) instead of hand-rolled delta math, fixing a regression where a cursor at column 0 of a list line would jump to the previous line on toggle-off
- Reverse selections (head < anchor) now retain their direction across the toggle
- Adds regression coverage for indented toggles, cursor boundary behavior, heterogeneous multi-line indents, and the intentional line-based (non-AST-aware) source-editor semantics

## Impact

Frontend-only; no breaking changes, no new dependencies, no deployment considerations. Behavior change is limited to the markdown source editor's list/heading/blockquote toggle commands.