### PR TITLE
Fix runaway scroll loop on list hover near viewport edge

### DIFF
--- a/frontend/src/hooks/useListKeyboardNavigation.test.ts
+++ b/frontend/src/hooks/useListKeyboardNavigation.test.ts
@@ -323,6 +323,63 @@ describe('useListKeyboardNavigation', () => {
     expect(item.scrollIntoView).not.toHaveBeenCalled()
   })
 
+  it('scrollIntoView is NOT called when selection comes from mouse hover', () => {
+    // Regression: hover-triggered selection used to call scrollIntoView, which
+    // could scroll a partially-clipped item under a stationary cursor and fire
+    // mouseenter on the next item, creating a runaway scroll loop.
+    const container = document.createElement('div')
+    const item0 = document.createElement('div')
+    item0.setAttribute('data-nav-item', 'true')
+    const item1 = document.createElement('div')
+    item1.setAttribute('data-nav-item', 'true')
+    container.appendChild(item0)
+    container.appendChild(item1)
+
+    const { result } = renderNav({ initialIndex: -1 })
+    result.current.listRef.current = container
+
+    // Enter mouse mode and hover item 1
+    act(() => {
+      result.current.getListProps().onMouseMove()
+    })
+    act(() => {
+      result.current.getItemProps(1).onMouseEnter()
+    })
+
+    expect(result.current.selectedIndex).toBe(1)
+    expect(item1.scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it('scrollIntoView is called for keyboard nav even after a prior mouse hover', () => {
+    // Arrow keys flip mouseMoved back to false, so keyboard-driven selection
+    // must still scroll into view.
+    const container = document.createElement('div')
+    const item0 = document.createElement('div')
+    item0.setAttribute('data-nav-item', 'true')
+    const item1 = document.createElement('div')
+    item1.setAttribute('data-nav-item', 'true')
+    container.appendChild(item0)
+    container.appendChild(item1)
+
+    const { result } = renderNav({ initialIndex: -1 })
+    result.current.listRef.current = container
+
+    // Hover item 0 (mouse mode) — no scroll
+    act(() => {
+      result.current.getListProps().onMouseMove()
+    })
+    act(() => {
+      result.current.getItemProps(0).onMouseEnter()
+    })
+    expect(item0.scrollIntoView).not.toHaveBeenCalled()
+
+    // ArrowDown — keyboard mode, should scroll
+    act(() => {
+      result.current.getInputProps().onKeyDown(keyEvent('ArrowDown'))
+    })
+    expect(item1.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+  })
+
   // --- preventDefault ---
 
   it('Arrow keys are preventDefault-ed', () => {

--- a/frontend/src/hooks/useListKeyboardNavigation.ts
+++ b/frontend/src/hooks/useListKeyboardNavigation.ts
@@ -102,14 +102,19 @@ export function useListKeyboardNavigation({
     setSelectedIndex(clampedIndex)
   }
 
-  // Scroll selected item into view
+  // Scroll selected item into view (keyboard nav only).
+  // Skip when selection came from the mouse: the user can already see what
+  // they hovered, and scrolling a partially-clipped item moves the list under
+  // a stationary cursor, which fires mouseenter on the next item and creates
+  // a runaway hover→select→scroll loop (e.g., parking the cursor on the macOS dock).
   useEffect(() => {
     if (clampedIndex < 0) return
+    if (mouseMoved) return
     const list = listRef.current
     if (!list) return
     const items = list.querySelectorAll(itemSelector)
     items[clampedIndex]?.scrollIntoView({ block: 'nearest' })
-  }, [clampedIndex, itemSelector])
+  }, [clampedIndex, itemSelector, mouseMoved])
 
   const resetSelection = useCallback(() => {
     setSelectedIndex(effectiveResetIndex)


### PR DESCRIPTION
Skip the scrollIntoView side effect in useListKeyboardNavigation when the selection change came from the mouse (mouseMoved=true). Keyboard navigation still scrolls because ArrowUp/Down reset mouseMoved=false before changing the selection.

Without this gate, parking the cursor at the bottom of the viewport (e.g., over the macOS dock) caused the bookmark/note list to auto-scroll all the way to the end: a partially-clipped item under the stationary cursor fired mouseenter, scrollIntoView shifted the list, the next partially-clipped item slid under the cursor, mouseenter fired again, and so on.

- Add early return on mouseMoved in the scrollIntoView effect; include mouseMoved in the deps array.
- Add two regression tests: hover-driven selection does not scroll; keyboard nav after a prior hover still scrolls.