### PR TITLE
Fix new PAT not appearing at top of list (KAN-145)

### DIFF
--- a/backend/src/services/token_service.py
+++ b/backend/src/services/token_service.py
@@ -104,6 +104,8 @@ async def get_tokens(
     Returns:
         List of ApiToken models (without plaintext tokens).
     """
+    # Frontend optimistic insert in frontend/src/stores/tokensStore.ts:createToken
+    # assumes newest-first ordering. Update both if you change this ORDER BY.
     result = await db.execute(
         select(ApiToken)
         .where(ApiToken.user_id == user_id)

--- a/frontend/src/pages/settings/SettingsTokens.test.tsx
+++ b/frontend/src/pages/settings/SettingsTokens.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Integration smoke test for the SettingsTokens create flow.
+ *
+ * Verifies that opening the modal, submitting, and clicking Done leaves
+ * the new token visible in the list. The ordering invariant (KAN-145)
+ * is verified directly in stores/tokensStore.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SettingsTokens } from './SettingsTokens'
+import { useTokensStore } from '../../stores/tokensStore'
+
+vi.mock('../../config', () => ({
+  config: {
+    apiUrl: 'http://localhost:8000',
+  },
+}))
+
+const mockApiGet = vi.fn()
+const mockApiPost = vi.fn()
+const mockApiPatch = vi.fn()
+const mockApiDelete = vi.fn()
+vi.mock('../../services/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: (...args: unknown[]) => mockApiPost(...args),
+    patch: (...args: unknown[]) => mockApiPatch(...args),
+    delete: (...args: unknown[]) => mockApiDelete(...args),
+  },
+}))
+
+const mockWriteText = vi.fn().mockResolvedValue(undefined)
+
+beforeAll(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      writeText: mockWriteText,
+      readText: vi.fn().mockResolvedValue(''),
+    },
+    configurable: true,
+  })
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useTokensStore.setState({ tokens: [], isLoading: false, error: null })
+  mockApiGet.mockResolvedValue({ data: [] })
+})
+
+describe('SettingsTokens', () => {
+  it('shows the new token in the list after the create-and-done flow', async () => {
+    const user = userEvent.setup()
+    mockApiPost.mockResolvedValueOnce({
+      data: {
+        id: 'new-token-id',
+        name: 'My CLI Token',
+        token: 'bm_secret_plaintext_value',
+        token_prefix: 'bm_secret_p',
+        expires_at: null,
+        created_at: '2026-05-09T12:00:00Z',
+      },
+    })
+
+    render(<SettingsTokens />)
+    await screen.findByText(/no tokens created yet/i)
+
+    await user.click(screen.getByRole('button', { name: /create token/i }))
+
+    const dialog = await screen.findByRole('dialog')
+    await user.type(within(dialog).getByLabelText(/token name/i), 'My CLI Token')
+    await user.click(within(dialog).getByRole('button', { name: 'Create Token' }))
+
+    await screen.findByText(/token created/i)
+    await user.click(screen.getByRole('button', { name: 'Done' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('My CLI Token')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/stores/tokensStore.test.ts
+++ b/frontend/src/stores/tokensStore.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Direct unit tests for tokensStore actions.
+ *
+ * The ordering invariant in createToken (KAN-145) is verified here rather
+ * than at the page level — it's a pure state transition and shouldn't
+ * depend on modal markup, focus management, or button labels to test.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useTokensStore } from './tokensStore'
+
+const mockApiGet = vi.fn()
+const mockApiPost = vi.fn()
+const mockApiPatch = vi.fn()
+const mockApiDelete = vi.fn()
+vi.mock('../services/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: (...args: unknown[]) => mockApiPost(...args),
+    patch: (...args: unknown[]) => mockApiPatch(...args),
+    delete: (...args: unknown[]) => mockApiDelete(...args),
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useTokensStore.setState({ tokens: [], isLoading: false, error: null })
+})
+
+describe('tokensStore.fetchTokens', () => {
+  it('populates tokens and clears isLoading on success', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: [
+        {
+          id: 't1',
+          name: 'CLI',
+          token_prefix: 'bm_xxx',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ],
+    })
+
+    await useTokensStore.getState().fetchTokens()
+
+    const state = useTokensStore.getState()
+    expect(state.tokens).toHaveLength(1)
+    expect(state.tokens[0].name).toBe('CLI')
+    expect(state.isLoading).toBe(false)
+    expect(state.error).toBeNull()
+  })
+
+  it('sets error and clears isLoading on failure', async () => {
+    mockApiGet.mockRejectedValueOnce(new Error('network down'))
+
+    await useTokensStore.getState().fetchTokens()
+
+    const state = useTokensStore.getState()
+    expect(state.tokens).toEqual([])
+    expect(state.isLoading).toBe(false)
+    expect(state.error).toBe('network down')
+  })
+})
+
+describe('tokensStore.createToken', () => {
+  const newTokenResponse = {
+    id: 'new-id',
+    name: 'Brand New',
+    token: 'bm_secret_plaintext',
+    token_prefix: 'bm_brand_xxx',
+    expires_at: null,
+    created_at: '2026-05-09T00:00:00Z',
+  }
+
+  it('prepends the new token to the list (matches backend newest-first ordering — KAN-145)', async () => {
+    useTokensStore.setState({
+      tokens: [
+        {
+          id: 'old-1',
+          name: 'Old A',
+          token_prefix: 'bm_oldA_xxx',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+        {
+          id: 'old-2',
+          name: 'Old B',
+          token_prefix: 'bm_oldB_xxx',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-04-15T00:00:00Z',
+        },
+      ],
+    })
+    mockApiPost.mockResolvedValueOnce({ data: newTokenResponse })
+
+    await useTokensStore.getState().createToken({ name: 'Brand New' })
+
+    const names = useTokensStore.getState().tokens.map((t) => t.name)
+    expect(names).toEqual(['Brand New', 'Old A', 'Old B'])
+  })
+
+  it('maps TokenCreateResponse → Token, dropping plaintext and defaulting last_used_at to null', async () => {
+    mockApiPost.mockResolvedValueOnce({ data: newTokenResponse })
+
+    await useTokensStore.getState().createToken({ name: 'Brand New' })
+
+    const token = useTokensStore.getState().tokens[0]
+    expect(token).toEqual({
+      id: 'new-id',
+      name: 'Brand New',
+      token_prefix: 'bm_brand_xxx',
+      last_used_at: null,
+      expires_at: null,
+      created_at: '2026-05-09T00:00:00Z',
+    })
+    expect(token).not.toHaveProperty('token')
+  })
+
+  it('returns the full response (with plaintext) so the caller can reveal it', async () => {
+    mockApiPost.mockResolvedValueOnce({ data: newTokenResponse })
+
+    const response = await useTokensStore.getState().createToken({ name: 'Brand New' })
+
+    expect(response.token).toBe('bm_secret_plaintext')
+  })
+
+  it('propagates errors and does not modify the list on failure', async () => {
+    useTokensStore.setState({
+      tokens: [
+        {
+          id: 'old-1',
+          name: 'Old A',
+          token_prefix: 'bm_oldA_xxx',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ],
+    })
+    mockApiPost.mockRejectedValueOnce(new Error('quota exceeded'))
+
+    await expect(
+      useTokensStore.getState().createToken({ name: 'Brand New' }),
+    ).rejects.toThrow('quota exceeded')
+
+    const names = useTokensStore.getState().tokens.map((t) => t.name)
+    expect(names).toEqual(['Old A'])
+  })
+})
+
+describe('tokensStore.renameToken', () => {
+  it('updates the name in place without reordering', async () => {
+    useTokensStore.setState({
+      tokens: [
+        {
+          id: 't1',
+          name: 'Old Name',
+          token_prefix: 'bm_xxx',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+        {
+          id: 't2',
+          name: 'Other',
+          token_prefix: 'bm_yyy',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-04-01T00:00:00Z',
+        },
+      ],
+    })
+    mockApiPatch.mockResolvedValueOnce({
+      data: {
+        id: 't1',
+        name: 'New Name',
+        token_prefix: 'bm_xxx',
+        last_used_at: null,
+        expires_at: null,
+        created_at: '2026-05-01T00:00:00Z',
+      },
+    })
+
+    await useTokensStore.getState().renameToken('t1', 'New Name')
+
+    const tokens = useTokensStore.getState().tokens
+    expect(tokens.map((t) => [t.id, t.name])).toEqual([
+      ['t1', 'New Name'],
+      ['t2', 'Other'],
+    ])
+  })
+})
+
+describe('tokensStore.deleteToken', () => {
+  it('removes the token from the list', async () => {
+    useTokensStore.setState({
+      tokens: [
+        {
+          id: 't1',
+          name: 'A',
+          token_prefix: 'bm_a',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+        {
+          id: 't2',
+          name: 'B',
+          token_prefix: 'bm_b',
+          last_used_at: null,
+          expires_at: null,
+          created_at: '2026-04-01T00:00:00Z',
+        },
+      ],
+    })
+    mockApiDelete.mockResolvedValueOnce({})
+
+    await useTokensStore.getState().deleteToken('t1')
+
+    const ids = useTokensStore.getState().tokens.map((t) => t.id)
+    expect(ids).toEqual(['t2'])
+  })
+})

--- a/frontend/src/stores/tokensStore.ts
+++ b/frontend/src/stores/tokensStore.ts
@@ -52,7 +52,8 @@ export const useTokensStore = create<TokensStore>((set, get) => ({
       expires_at: newToken.expires_at,
       created_at: newToken.created_at,
     }
-    set({ tokens: [...get().tokens, tokenForList] })
+    // Prepend matches backend ORDER BY in services/token_service.py:get_tokens.
+    set({ tokens: [tokenForList, ...get().tokens] })
     return newToken
   },
 


### PR DESCRIPTION
## Summary

After creating a Personal Access Token, the new token was rendered at the bottom of the list and only moved to the top after a page refresh. Users with existing tokens reported it as "the new token doesn't show until I refresh." Linked: [KAN-145](https://tiddly.atlassian.net/browse/KAN-145).

## Root cause

The frontend's optimistic insert in `tokensStore.createToken` appended the new token to the end of the list, but the backend's `list_tokens` returns rows ordered by `created_at DESC` (newest first). Pre-refresh the new entry sat at the bottom; post-refresh it jumped to the top.

## Changes

- `frontend/src/stores/tokensStore.ts` — prepend the new token instead of appending; matches the backend's newest-first ordering.
- `backend/src/services/token_service.py` and `frontend/src/stores/tokensStore.ts` — cross-reference comments on each side of the implicit ordering contract so a future change to either is visible from the other file.
- `frontend/src/stores/tokensStore.test.ts` — new direct unit tests for `tokensStore` (8 tests): the ordering invariant, response→store shape mapping, error propagation, plus rename, delete, and fetch (success + failure) paths.
- `frontend/src/pages/settings/SettingsTokens.test.tsx` — new integration smoke test for the create flow end-to-end.

## Impact

No breaking changes. No new dependencies. No deployment considerations. Pure frontend behavior fix plus test coverage; the backend touch is comment-only.

## Test plan

- [x] `make frontend-verify` — 2991 tests pass
- [x] Backend token tests (`test_token_service.py` + `test_tokens.py`) — 52 pass
- [x] Manual: create a token in the UI, verify it appears at the top of the list immediately (no refresh needed)