### PR TITLE
Fix lost-update race on str-replace endpoints via row locking

### DIFF
--- a/backend/src/api/routers/bookmarks.py
+++ b/backend/src/api/routers/bookmarks.py
@@ -577,6 +577,7 @@ async def str_replace_bookmark(
         metadata=metadata,
         context=context,
         limits=limits,
+        changed_fields=["content"],
     )
 
     if include_updated_entity:

--- a/backend/src/api/routers/bookmarks.py
+++ b/backend/src/api/routers/bookmarks.py
@@ -496,14 +496,12 @@ async def str_replace_bookmark(
       (includes match locations with context to help construct unique match)
     """
     context = get_request_context(request)
-    # Check for conflicts before modifying
-    await check_optimistic_lock(
-        db, bookmark_service, current_user.id, bookmark_id,
-        data.expected_updated_at, BookmarkResponse,
-    )
 
-    # Fetch the bookmark (include archived, exclude deleted)
-    bookmark = await bookmark_service.get(db, current_user.id, bookmark_id, include_archived=True)
+    # Row lock prevents lost updates from concurrent str-replace calls. Held
+    # until the request transaction commits at end-of-request.
+    bookmark = await bookmark_service.get_for_update(
+        db, current_user.id, bookmark_id, include_archived=True,
+    )
     if bookmark is None:
         raise HTTPException(status_code=404, detail="Bookmark not found")
 

--- a/backend/src/api/routers/notes.py
+++ b/backend/src/api/routers/notes.py
@@ -419,14 +419,12 @@ async def str_replace_note(
       (includes match locations with context to help construct unique match)
     """
     context = get_request_context(request)
-    # Check for conflicts before modifying
-    await check_optimistic_lock(
-        db, note_service, current_user.id, note_id,
-        data.expected_updated_at, NoteResponse,
-    )
 
-    # Fetch the note (include archived, exclude deleted)
-    note = await note_service.get(db, current_user.id, note_id, include_archived=True)
+    # Row lock prevents lost updates from concurrent str-replace calls. Held
+    # until the request transaction commits at end-of-request.
+    note = await note_service.get_for_update(
+        db, current_user.id, note_id, include_archived=True,
+    )
     if note is None:
         raise HTTPException(status_code=404, detail="Note not found")
 

--- a/backend/src/api/routers/notes.py
+++ b/backend/src/api/routers/notes.py
@@ -500,6 +500,7 @@ async def str_replace_note(
         metadata=metadata,
         context=context,
         limits=limits,
+        changed_fields=["content"],
     )
 
     if include_updated_entity:

--- a/backend/src/api/routers/prompts.py
+++ b/backend/src/api/routers/prompts.py
@@ -531,14 +531,10 @@ async def str_replace_prompt_by_name(
     strategy, atomic content + arguments updates, and error responses.
     """
     context = get_request_context(request)
-    # Check for conflicts before modifying
-    await check_optimistic_lock_by_name(
-        db, prompt_service, current_user.id, name,
-        data.expected_updated_at, PromptResponse,
-    )
 
-    # Look up by name (active prompts only)
-    prompt = await prompt_service.get_by_name(db, current_user.id, name)
+    # Row lock prevents lost updates from concurrent str-replace calls. Held
+    # until the request transaction commits at end-of-request.
+    prompt = await prompt_service.get_by_name_for_update(db, current_user.id, name)
     if prompt is None:
         raise HTTPException(status_code=404, detail="Prompt not found")
 
@@ -950,14 +946,12 @@ async def str_replace_prompt(
     - 400 with template validation error if result is invalid Jinja2
     """
     context = get_request_context(request)
-    # Check for conflicts before modifying
-    await check_optimistic_lock(
-        db, prompt_service, current_user.id, prompt_id,
-        data.expected_updated_at, PromptResponse,
-    )
 
-    # Fetch the prompt (include archived, exclude deleted)
-    prompt = await prompt_service.get(db, current_user.id, prompt_id, include_archived=True)
+    # Row lock prevents lost updates from concurrent str-replace calls. Held
+    # until the request transaction commits at end-of-request.
+    prompt = await prompt_service.get_for_update(
+        db, current_user.id, prompt_id, include_archived=True,
+    )
     if prompt is None:
         raise HTTPException(status_code=404, detail="Prompt not found")
 

--- a/backend/src/api/routers/prompts.py
+++ b/backend/src/api/routers/prompts.py
@@ -523,9 +523,11 @@ async def str_replace_prompt_by_name(
     This endpoint is primarily used by the MCP server for prompt edits.
     To edit archived prompts, restore them first via the API or web UI.
 
-    Note: There is a tiny race window where a prompt could be archived between
-    lookup and edit. This is accepted behavior given the extremely small window
-    and minimal impact (edit succeeds on now-archived prompt).
+    A concurrent archive of this prompt is resolved by the FOR UPDATE lock —
+    `get_by_name_for_update` re-evaluates the active-only predicate at lock
+    acquisition under READ COMMITTED, so an archive committing during the
+    request results in a deterministic 404 rather than an edit slipping
+    through onto a now-archived prompt.
 
     See PATCH /prompts/{id}/str-replace for full documentation on matching
     strategy, atomic content + arguments updates, and error responses.

--- a/backend/src/api/routers/prompts.py
+++ b/backend/src/api/routers/prompts.py
@@ -141,8 +141,20 @@ async def _perform_str_replace(
             ).model_dump(),
         )
 
-    # Check for no-op (content unchanged AND no argument update requested)
-    if result.new_content == previous_content and data.arguments is None:
+    # Serialize the proposed arguments once (used by the no-op check, validation,
+    # the actual write, and the history changed_fields list). Compare structurally
+    # against the existing arguments — sending the same arguments list must be a
+    # no-op, not a ghost write that bumps updated_at and records a history row
+    # claiming "arguments" changed when they didn't.
+    new_args = (
+        [arg.model_dump() for arg in data.arguments]
+        if data.arguments is not None
+        else None
+    )
+    content_changed = result.new_content != previous_content
+    arguments_changed = new_args is not None and new_args != (prompt.arguments or [])
+
+    if not content_changed and not arguments_changed:
         if include_updated_entity:
             await db.refresh(prompt, attribute_names=["tag_objects"])
             return StrReplaceSuccess(
@@ -157,13 +169,10 @@ async def _perform_str_replace(
         )
 
     # Determine which arguments to use for validation:
-    # - If data.arguments is provided, use it (enables atomic content + args update)
-    # - Otherwise, use the prompt's existing arguments
-    if data.arguments is not None:
-        # Convert PromptArgument models to dicts for validate_template
-        validation_arguments = [arg.model_dump() for arg in data.arguments]
-    else:
-        validation_arguments = prompt.arguments or []
+    # - If data.arguments is provided, validate against the new list (enables
+    #   atomic content + args updates)
+    # - Otherwise, validate against the prompt's existing arguments
+    validation_arguments = new_args if new_args is not None else (prompt.arguments or [])
 
     # Validate the new content as a Jinja2 template BEFORE applying changes
     try:
@@ -184,14 +193,23 @@ async def _perform_str_replace(
     prompt.content = result.new_content
 
     # If arguments were provided, update them atomically
-    if data.arguments is not None:
-        prompt.arguments = [arg.model_dump() for arg in data.arguments]
+    if new_args is not None:
+        prompt.arguments = new_args
 
     prompt.updated_at = func.clock_timestamp()
     await db.flush()
     await db.refresh(prompt)
 
-    # Record history for str-replace (content changed)
+    # changed_fields = the fields whose values actually differ from the prior
+    # version (used by the frontend version-diff UI). Non-empty by construction:
+    # the no-op early return above ensures at least one of content/arguments
+    # actually changed by the time we reach this point.
+    changed_fields: list[str] = []
+    if content_changed:
+        changed_fields.append("content")
+    if arguments_changed:
+        changed_fields.append("arguments")
+
     await db.refresh(prompt, attribute_names=["tag_objects"])
     metadata = await prompt_service.get_metadata_snapshot(db, prompt.user_id, prompt)
     await history_service.record_action(
@@ -205,6 +223,7 @@ async def _perform_str_replace(
         metadata=metadata,
         context=context,
         limits=limits,
+        changed_fields=changed_fields,
     )
 
     if include_updated_entity:

--- a/backend/src/schemas/errors.py
+++ b/backend/src/schemas/errors.py
@@ -16,7 +16,15 @@ from schemas.validators import check_duplicate_argument_names
 
 
 class StrReplaceRequest(BaseModel):
-    """Request body for str-replace operations (notes and bookmarks)."""
+    """
+    Request body for str-replace operations (notes and bookmarks).
+
+    str-replace is content-addressable: the operation succeeds as long as
+    `old_str` is still uniquely findable in the current content. The server
+    serializes concurrent calls against the same entity via `SELECT ... FOR
+    UPDATE` so optimistic locking is unnecessary here; the regular PATCH
+    endpoints (which carry a declarative payload) keep their `expected_updated_at`.
+    """
 
     old_str: str = Field(
         min_length=1,
@@ -24,11 +32,6 @@ class StrReplaceRequest(BaseModel):
     )
     new_str: str = Field(
         description="Replacement text (use empty string to delete)",
-    )
-    expected_updated_at: datetime | None = Field(
-        default=None,
-        description="For optimistic locking. If provided and the entity was modified after "
-                    "this timestamp, returns 409 Conflict with current server state.",
     )
 
 
@@ -39,6 +42,9 @@ class PromptStrReplaceRequest(BaseModel):
     Supports optional `arguments` field for atomic content + arguments updates.
     This solves the chicken-and-egg problem where adding/removing template variables
     requires updating both content and arguments together.
+
+    See `StrReplaceRequest` for the rationale on the absence of an
+    `expected_updated_at` field.
     """
 
     old_str: str = Field(
@@ -54,11 +60,6 @@ class PromptStrReplaceRequest(BaseModel):
         "If omitted, validation uses existing arguments. "
         "If provided, this list fully replaces current arguments (not a merge). "
         "Use this when adding/removing template variables to avoid validation errors.",
-    )
-    expected_updated_at: datetime | None = Field(
-        default=None,
-        description="For optimistic locking. If provided and the prompt was modified after "
-                    "this timestamp, returns 409 Conflict with current server state.",
     )
 
     @model_validator(mode="after")

--- a/backend/src/services/base_entity_service.py
+++ b/backend/src/services/base_entity_service.py
@@ -85,6 +85,21 @@ class BaseEntityService[T: TaggableEntity](ABC):
         await db.refresh(entity)
         await db.refresh(entity, attribute_names=["tag_objects"])
 
+    @staticmethod
+    def _attach_content_length(entity: Any) -> None:
+        """
+        Compute and attach `content_length` from the in-memory `content` field.
+
+        Used by read paths that already load full content (`get`,
+        `get_for_update`, and the prompt-by-name variants). Cheaper than a SQL
+        `length()` call when we have the bytes in Python already, and handles
+        empty strings correctly (len("") == 0, not None).
+        """
+        if entity is None:
+            return
+        content = getattr(entity, "content", None)
+        entity.content_length = len(content) if content is not None else None
+
     # --- Abstract Methods (entity-specific) ---
 
     @abstractmethod
@@ -288,16 +303,56 @@ class BaseEntityService[T: TaggableEntity](ABC):
 
         result = await db.execute(query)
         entity = result.scalar_one_or_none()
+        self._attach_content_length(entity)
+        return entity
 
-        if entity is not None:
-            # Compute content_length in Python since content is already loaded.
-            # This is more efficient than adding a SQL computed column when we're
-            # already fetching full content. Python len() and PostgreSQL length()
-            # both count characters for UTF-8 text, so results are consistent.
-            # Use `is not None` to correctly handle empty strings (len("") = 0, not None).
-            content = getattr(entity, "content", None)
-            entity.content_length = len(content) if content is not None else None
+    async def get_for_update(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        entity_id: UUID,
+        *,
+        include_archived: bool = False,
+    ) -> T | None:
+        """
+        Fetch an entity and acquire a `SELECT ... FOR UPDATE` row lock.
 
+        MUST be called inside a transaction. The lock is held until the
+        transaction commits or rolls back. Use only when the same request
+        will issue an UPDATE on the returned entity (e.g., the str-replace
+        endpoints). For read-only access use `get(...)` instead.
+
+        Soft-deleted entities are always excluded (str-replace never operates
+        on them). Tags are intentionally NOT eager-loaded: a `selectinload`
+        would issue a second SELECT outside the FOR UPDATE, which means the
+        tag set could be inconsistent with the locked content row. str-replace
+        handlers refresh `tag_objects` explicitly after the update if they
+        need to serialize them.
+
+        Args:
+            db: Database session (must be inside an open transaction).
+            user_id: User ID to scope the entity.
+            entity_id: ID of the entity to retrieve.
+            include_archived: If True, include archived entities. Default False.
+
+        Returns:
+            The entity if found and matches filters, None otherwise.
+        """
+        query = (
+            select(self.model)
+            .where(
+                self.model.id == entity_id,
+                self.model.user_id == user_id,
+                self.model.deleted_at.is_(None),
+            )
+            .with_for_update()
+        )
+        if not include_archived:
+            query = query.where(~self.model.is_archived)
+
+        result = await db.execute(query)
+        entity = result.scalar_one_or_none()
+        self._attach_content_length(entity)
         return entity
 
     async def get_metadata(

--- a/backend/src/services/base_entity_service.py
+++ b/backend/src/services/base_entity_service.py
@@ -323,11 +323,11 @@ class BaseEntityService[T: TaggableEntity](ABC):
         endpoints). For read-only access use `get(...)` instead.
 
         Soft-deleted entities are always excluded (str-replace never operates
-        on them). Tags are intentionally NOT eager-loaded: a `selectinload`
-        would issue a second SELECT outside the FOR UPDATE, which means the
-        tag set could be inconsistent with the locked content row. str-replace
-        handlers refresh `tag_objects` explicitly after the update if they
-        need to serialize them.
+        on them). Tags are intentionally NOT eager-loaded: str-replace does
+        not need `tag_objects` at fetch time. Handlers that serialize the
+        entity (or record metadata snapshots) call
+        `db.refresh(entity, attribute_names=["tag_objects"])` after the
+        write flush.
 
         Args:
             db: Database session (must be inside an open transaction).

--- a/backend/src/services/prompt_service.py
+++ b/backend/src/services/prompt_service.py
@@ -560,7 +560,8 @@ class PromptService(BaseEntityService[Prompt]):
         MUST be called inside a transaction. The lock is held until the
         transaction commits or rolls back. Tags are intentionally NOT
         eager-loaded — see `BaseEntityService.get_for_update` for the
-        rationale (consistency vs. the locked row).
+        rationale (fetch-time tag_objects are unused by str-replace; handlers
+        refresh them post-flush when they need to serialize).
 
         Args:
             db: Database session (must be inside an open transaction).

--- a/backend/src/services/prompt_service.py
+++ b/backend/src/services/prompt_service.py
@@ -541,13 +541,47 @@ class PromptService(BaseEntityService[Prompt]):
             ),
         )
         prompt = result.scalar_one_or_none()
+        self._attach_content_length(prompt)
+        return prompt
 
-        if prompt is not None:
-            # Compute content_length in Python since content is already loaded.
-            # Full content endpoints always include content_length per the API contract.
-            content = prompt.content
-            prompt.content_length = len(content) if content is not None else None
+    async def get_by_name_for_update(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        name: str,
+    ) -> Prompt | None:
+        """
+        Get a prompt by name and acquire a `SELECT ... FOR UPDATE` row lock.
 
+        Mirror of `get_by_name(...)`: returns only active prompts (excludes
+        deleted AND archived). Used by the by-name str-replace endpoint
+        (`PATCH /prompts/name/{name}/str-replace`).
+
+        MUST be called inside a transaction. The lock is held until the
+        transaction commits or rolls back. Tags are intentionally NOT
+        eager-loaded — see `BaseEntityService.get_for_update` for the
+        rationale (consistency vs. the locked row).
+
+        Args:
+            db: Database session (must be inside an open transaction).
+            user_id: User ID to scope the prompt.
+            name: Name of the prompt to find.
+
+        Returns:
+            The prompt if found and active, None otherwise.
+        """
+        result = await db.execute(
+            select(Prompt)
+            .where(
+                Prompt.user_id == user_id,
+                Prompt.name == name,
+                Prompt.deleted_at.is_(None),
+                ~Prompt.is_archived,
+            )
+            .with_for_update(),
+        )
+        prompt = result.scalar_one_or_none()
+        self._attach_content_length(prompt)
         return prompt
 
     async def get_updated_at_by_name(

--- a/backend/tests/api/test_optimistic_locking.py
+++ b/backend/tests/api/test_optimistic_locking.py
@@ -297,76 +297,15 @@ async def test__update__expected_updated_at__timezone_handling(
 
 
 # =============================================================================
-# Str-Replace Tests - Parametrized
-# =============================================================================
-
-
-@pytest.mark.parametrize("entity_setup", ENTITY_TYPES, indirect=True)
-async def test__str_replace__with_expected_updated_at__success(
-    client: AsyncClient,
-    entity_setup: dict[str, Any],
-) -> None:
-    """Str-replace succeeds when timestamps match exactly."""
-    response = await client.patch(
-        f"{entity_setup['endpoint']}/str-replace",
-        json={
-            "old_str": entity_setup["str_replace_old"],
-            "new_str": entity_setup["str_replace_new"],
-            "expected_updated_at": entity_setup["entity"]["updated_at"],
-        },
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("entity_setup", ENTITY_TYPES, indirect=True)
-async def test__str_replace__with_expected_updated_at__conflict_returns_409(
-    client: AsyncClient,
-    entity_setup: dict[str, Any],
-) -> None:
-    """Str-replace returns 409 when entity was modified after expected time."""
-    stale_timestamp = entity_setup["entity"]["updated_at"]
-
-    # Modify the entity
-    await asyncio.sleep(0.01)
-    await client.patch(entity_setup["endpoint"], json={"title": "Modified"})
-
-    # Try str-replace with stale timestamp
-    response = await client.patch(
-        f"{entity_setup['endpoint']}/str-replace",
-        json={
-            "old_str": entity_setup["str_replace_old"],
-            "new_str": entity_setup["str_replace_new"],
-            "expected_updated_at": stale_timestamp,
-        },
-    )
-    assert response.status_code == 409
-    detail = response.json()["detail"]
-    assert detail["error"] == "conflict"
-    assert detail["message"] == "This item was modified since you loaded it"
-    assert "server_state" in detail
-    assert detail["server_state"]["title"] == "Modified"
-    assert detail["server_state"]["id"] == entity_setup["id"]
-
-
-@pytest.mark.parametrize("entity_setup", ENTITY_TYPES, indirect=True)
-async def test__str_replace__without_expected_updated_at__allows_update(
-    client: AsyncClient,
-    entity_setup: dict[str, Any],
-) -> None:
-    """Str-replace without expected_updated_at succeeds (backwards compatible)."""
-    response = await client.patch(
-        f"{entity_setup['endpoint']}/str-replace",
-        json={
-            "old_str": entity_setup["str_replace_old"],
-            "new_str": entity_setup["str_replace_new"],
-        },
-    )
-    assert response.status_code == 200
-
-
-# =============================================================================
 # Prompt By-Name Endpoint Tests
 # =============================================================================
+#
+# The str-replace endpoints (id-based and by-name) no longer accept
+# `expected_updated_at`. They use server-side row locking (`SELECT ... FOR
+# UPDATE`) which is the natural fit for content-addressable operations; see
+# `docs/architecture.md` (Concurrency control for content edits). The regular
+# PATCH endpoints (which carry declarative payloads) still honor
+# `expected_updated_at` — those tests are covered above.
 
 
 @pytest.fixture
@@ -433,53 +372,6 @@ async def test__update_prompt_by_name__with_expected_updated_at__conflict_return
     assert detail["message"] == "This item was modified since you loaded it"
     assert "server_state" in detail
     assert detail["server_state"]["title"] == "First Update"
-    assert detail["server_state"]["name"] == setup["entity"]["name"]
-
-
-async def test__str_replace_prompt_by_name__with_expected_updated_at__success(
-    client: AsyncClient,
-    prompt_for_name_tests: dict[str, Any],
-) -> None:
-    """Str-replace by name succeeds when timestamps match exactly."""
-    setup = prompt_for_name_tests
-    response = await client.patch(
-        f"{setup['name_endpoint']}/str-replace",
-        json={
-            "old_str": "Hello",
-            "new_str": "Hi",
-            "expected_updated_at": setup["entity"]["updated_at"],
-        },
-    )
-    assert response.status_code == 200
-
-
-async def test__str_replace_prompt_by_name__with_expected_updated_at__conflict_returns_409(
-    client: AsyncClient,
-    prompt_for_name_tests: dict[str, Any],
-) -> None:
-    """Str-replace by name returns 409 when prompt was modified after expected time."""
-    setup = prompt_for_name_tests
-    stale_timestamp = setup["entity"]["updated_at"]
-
-    # Modify the prompt
-    await asyncio.sleep(0.01)
-    await client.patch(setup["name_endpoint"], json={"title": "Modified"})
-
-    # Try str-replace with stale timestamp
-    response = await client.patch(
-        f"{setup['name_endpoint']}/str-replace",
-        json={
-            "old_str": "Hello",
-            "new_str": "Hi",
-            "expected_updated_at": stale_timestamp,
-        },
-    )
-    assert response.status_code == 409
-    detail = response.json()["detail"]
-    assert detail["error"] == "conflict"
-    assert detail["message"] == "This item was modified since you loaded it"
-    assert "server_state" in detail
-    assert detail["server_state"]["title"] == "Modified"
     assert detail["server_state"]["name"] == setup["entity"]["name"]
 
 

--- a/backend/tests/api/test_optimistic_locking.py
+++ b/backend/tests/api/test_optimistic_locking.py
@@ -297,15 +297,51 @@ async def test__update__expected_updated_at__timezone_handling(
 
 
 # =============================================================================
-# Prompt By-Name Endpoint Tests
+# str-replace: expected_updated_at is silently ignored
 # =============================================================================
 #
-# The str-replace endpoints (id-based and by-name) no longer accept
-# `expected_updated_at`. They use server-side row locking (`SELECT ... FOR
-# UPDATE`) which is the natural fit for content-addressable operations; see
+# The str-replace endpoints no longer accept `expected_updated_at` — the
+# schemas were stripped of the field, but Pydantic v2's default `extra="ignore"`
+# means existing MCP/CLI clients still sending it won't error. The tests
+# below pin that silent-ignore behavior: if someone later adds
+# `extra="forbid"` to the request schemas as a hardening change, these tests
+# will fail and surface the backward-compatibility regression.
+#
+# str-replace uses server-side row locking (`SELECT ... FOR UPDATE`); see
 # `docs/architecture.md` (Concurrency control for content edits). The regular
-# PATCH endpoints (which carry declarative payloads) still honor
-# `expected_updated_at` — those tests are covered above.
+# PATCH endpoints still honor `expected_updated_at` — those tests are above.
+
+
+@pytest.mark.parametrize("entity_setup", ENTITY_TYPES, indirect=True)
+async def test__str_replace__expected_updated_at_silently_ignored(
+    client: AsyncClient,
+    entity_setup: dict[str, Any],
+) -> None:
+    """
+    Sending `expected_updated_at` to str-replace succeeds and applies the edit.
+
+    A stale timestamp would have triggered 409 under the previous optimistic-lock
+    behavior; under the row-locking design it should be silently ignored.
+    """
+    response = await client.patch(
+        f"{entity_setup['endpoint']}/str-replace",
+        json={
+            "old_str": entity_setup["str_replace_old"],
+            "new_str": entity_setup["str_replace_new"],
+            "expected_updated_at": "2020-01-01T00:00:00Z",  # intentionally stale
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    # Verify the edit was applied: the new_str must be present in current content.
+    get = await client.get(entity_setup["endpoint"])
+    assert get.status_code == 200
+    assert entity_setup["str_replace_new"] in get.json()["content"]
+
+
+# =============================================================================
+# Prompt By-Name Endpoint Tests
+# =============================================================================
 
 
 @pytest.fixture

--- a/backend/tests/api/test_prompts.py
+++ b/backend/tests/api/test_prompts.py
@@ -2986,6 +2986,131 @@ async def test__str_replace_by_name__with_arguments_update(client: AsyncClient) 
     ]
 
 
+async def test__str_replace_by_name__changed_fields_records_content_only(
+    client: AsyncClient,
+) -> None:
+    """Pure content edit (no arguments in payload) records changed_fields=['content']."""
+    create = await client.post("/prompts/", json={
+        "name": "kan148-changed-fields-content-only",
+        "content": "hello world",
+    })
+    prompt_id = create.json()["id"]
+
+    patch = await client.patch(
+        "/prompts/name/kan148-changed-fields-content-only/str-replace",
+        json={"old_str": "hello", "new_str": "hi"},
+    )
+    assert patch.status_code == 200
+
+    hist = await client.get(f"/history/prompt/{prompt_id}")
+    updates = [r for r in hist.json()["items"] if r["action"] == "update"]
+    assert len(updates) == 1
+    assert updates[0]["changed_fields"] == ["content"]
+
+
+async def test__str_replace_by_name__changed_fields_records_content_and_arguments(
+    client: AsyncClient,
+) -> None:
+    """Atomic content + arguments edit records changed_fields=['content', 'arguments']."""
+    create = await client.post("/prompts/", json={
+        "name": "kan148-changed-fields-both",
+        "content": "hello world",
+        "arguments": [],
+    })
+    prompt_id = create.json()["id"]
+
+    patch = await client.patch(
+        "/prompts/name/kan148-changed-fields-both/str-replace",
+        json={
+            "old_str": "world",
+            "new_str": "{{ name }}",
+            "arguments": [{"name": "name", "description": "user", "required": True}],
+        },
+    )
+    assert patch.status_code == 200
+
+    hist = await client.get(f"/history/prompt/{prompt_id}")
+    updates = [r for r in hist.json()["items"] if r["action"] == "update"]
+    assert len(updates) == 1
+    assert updates[0]["changed_fields"] == ["content", "arguments"]
+
+
+async def test__str_replace_by_name__changed_fields_records_arguments_only_when_content_unchanged(
+    client: AsyncClient,
+) -> None:
+    """
+    Content unchanged + arguments actually different → changed_fields == ['arguments'].
+
+    Edge case: a str-replace where `old_str == new_str` (or otherwise resolves to identical
+    content) AND the supplied `arguments` differ structurally from the existing arguments
+    bypasses the no-op early return and records a history row with only 'arguments' as the
+    changed field. (See the companion test that confirms identical arguments DO trigger
+    the no-op return.)
+    """
+    create = await client.post("/prompts/", json={
+        "name": "kan148-changed-fields-args-only",
+        "content": "hello {{ name }}",
+        "arguments": [{"name": "name", "required": True}],
+    })
+    prompt_id = create.json()["id"]
+
+    # Replace a substring with the same value so content is unchanged.
+    patch = await client.patch(
+        "/prompts/name/kan148-changed-fields-args-only/str-replace",
+        json={
+            "old_str": "hello",
+            "new_str": "hello",
+            "arguments": [{"name": "name", "description": "new desc", "required": True}],
+        },
+    )
+    assert patch.status_code == 200
+
+    hist = await client.get(f"/history/prompt/{prompt_id}")
+    updates = [r for r in hist.json()["items"] if r["action"] == "update"]
+    assert len(updates) == 1
+    assert updates[0]["changed_fields"] == ["arguments"]
+
+
+async def test__str_replace_by_name__no_op_when_content_unchanged_and_arguments_identical(
+    client: AsyncClient,
+) -> None:
+    """
+    True no-op: content unchanged AND arguments identical to existing → no history row,
+    no updated_at bump.
+
+    Without the structural equality check on arguments, sending the same arguments list
+    bypasses the no-op early-return and writes a ghost history row + bumps updated_at,
+    even though nothing actually changed. This test pins the corrected behavior.
+    """
+    create = await client.post("/prompts/", json={
+        "name": "kan148-no-op-same-args",
+        "content": "hello world",
+        "arguments": [],
+    })
+    prompt_id = create.json()["id"]
+    original_updated_at = create.json()["updated_at"]
+
+    # Same arguments list (empty), str-replace that resolves to identical content.
+    await asyncio.sleep(0.01)  # ensure any new write would have a distinguishable timestamp
+    patch = await client.patch(
+        "/prompts/name/kan148-no-op-same-args/str-replace",
+        json={
+            "old_str": "world",
+            "new_str": "world",
+            "arguments": [],
+        },
+    )
+    assert patch.status_code == 200
+    assert patch.json()["data"]["updated_at"] == original_updated_at
+
+    hist = await client.get(f"/history/prompt/{prompt_id}")
+    updates = [r for r in hist.json()["items"] if r["action"] == "update"]
+    assert updates == [], (
+        f"Expected no UPDATE history rows (true no-op), got {len(updates)}: "
+        f"{[r['changed_fields'] for r in updates]}"
+    )
+
+
 async def test__str_replace_by_name__template_validation(client: AsyncClient) -> None:
     """Test that str-replace by name validates resulting template."""
     await client.post(

--- a/backend/tests/api/test_prompts.py
+++ b/backend/tests/api/test_prompts.py
@@ -3071,6 +3071,37 @@ async def test__str_replace_by_name__changed_fields_records_arguments_only_when_
     assert updates[0]["changed_fields"] == ["arguments"]
 
 
+async def test__str_replace_by_id__changed_fields_records_content_and_arguments(
+    client: AsyncClient,
+) -> None:
+    """
+    The id-based prompt str-replace handler shares `_perform_str_replace`
+    with the by-name handler. The other `changed_fields` tests exercise the
+    by-name path; this one pins that the by-id path doesn't diverge.
+    """
+    create = await client.post("/prompts/", json={
+        "name": "kan148-by-id-changed-fields",
+        "content": "hello world",
+        "arguments": [],
+    })
+    prompt_id = create.json()["id"]
+
+    patch = await client.patch(
+        f"/prompts/{prompt_id}/str-replace",
+        json={
+            "old_str": "world",
+            "new_str": "{{ name }}",
+            "arguments": [{"name": "name", "description": "user", "required": True}],
+        },
+    )
+    assert patch.status_code == 200
+
+    hist = await client.get(f"/history/prompt/{prompt_id}")
+    updates = [r for r in hist.json()["items"] if r["action"] == "update"]
+    assert len(updates) == 1
+    assert updates[0]["changed_fields"] == ["content", "arguments"]
+
+
 async def test__str_replace_by_name__no_op_when_content_unchanged_and_arguments_identical(
     client: AsyncClient,
 ) -> None:

--- a/backend/tests/api/test_str_replace_concurrency.py
+++ b/backend/tests/api/test_str_replace_concurrency.py
@@ -1,0 +1,354 @@
+"""
+Endpoint-level concurrency tests for the str-replace PATCH endpoints.
+
+Parametrized over all four str-replace routes:
+  - PATCH /bookmarks/{id}/str-replace
+  - PATCH /notes/{id}/str-replace
+  - PATCH /prompts/{id}/str-replace
+  - PATCH /prompts/name/{name}/str-replace
+
+The endpoints are content-addressable: the operation succeeds as long as
+`old_str` is still uniquely findable in the current content. To prevent lost
+updates from concurrent calls against the same entity, each handler fetches
+the row with `SELECT ... FOR UPDATE`. These tests prove that lock is
+end-to-end effective: N parallel calls all succeed and the final content
+reflects every edit; overlapping calls return the expected `no_match`
+conflict; history records form a coherent chain.
+
+The tests are run against a custom client (`concurrent_client`, see
+backend/tests/conftest.py) that wires `get_async_session` to the
+`concurrent_session_factory` — each HTTP request gets its own DB session, so
+the requests actually contend at the database level. The standard `client`
+fixture cannot exercise this because it pins every request to a single
+shared session.
+"""
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from models.bookmark import Bookmark
+from models.content_history import ActionType, ContentHistory, EntityType
+from models.note import Note
+from models.prompt import Prompt
+from models.user import User
+
+
+# Number of parallel str-replace calls for the "N concurrent non-overlapping
+# edits" test. More than two (proves true parallel contention, not pairwise),
+# comfortably under PRO-tier write rate limits.
+N_CONCURRENT = 5
+
+# Five distinct non-overlapping markers. Each parallel task targets one
+# marker and replaces it with `EDITED-<i>`. After all N succeed the final
+# content must contain every EDITED-<i>.
+NON_OVERLAPPING_MARKERS = [f"marker-{i}" for i in range(N_CONCURRENT)]
+NON_OVERLAPPING_CONTENT = "\n".join(NON_OVERLAPPING_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint configuration table
+# ---------------------------------------------------------------------------
+#
+# Each `EndpointCase` describes one of the four str-replace routes. Tests are
+# parametrized over `CASES`; the table form keeps endpoint-specific quirks
+# (URL shape, model class, extra create kwargs, history entity_type) in one
+# place rather than scattered through test bodies.
+
+
+@dataclass(frozen=True)
+class EndpointCase:
+    """One str-replace endpoint under test: seed shape, URL, and history entity_type."""
+
+    label: str
+    model: type
+    entity_type_enum: EntityType
+    # Build SQLAlchemy model constructor kwargs given (user_id, content).
+    make_kwargs: Callable[[UUID, str], dict[str, Any]]
+    # Build the URL path given a seeded entity.
+    url: Callable[[Any], str]
+
+
+def _bookmark_kwargs(user_id: UUID, content: str) -> dict[str, Any]:
+    return {
+        "user_id": user_id,
+        "url": f"https://example.com/{uuid4().hex}",
+        "title": "concurrency-test",
+        "content": content,
+    }
+
+
+def _note_kwargs(user_id: UUID, content: str) -> dict[str, Any]:
+    return {
+        "user_id": user_id,
+        "title": "concurrency-test",
+        "content": content,
+    }
+
+
+def _prompt_kwargs(user_id: UUID, content: str) -> dict[str, Any]:
+    return {
+        "user_id": user_id,
+        "name": f"concurrency-test-{uuid4().hex[:8]}",
+        "title": "concurrency-test",
+        "content": content,
+        "arguments": [],
+    }
+
+
+CASES: list[EndpointCase] = [
+    EndpointCase(
+        label="bookmark",
+        model=Bookmark,
+        entity_type_enum=EntityType.BOOKMARK,
+        make_kwargs=_bookmark_kwargs,
+        url=lambda e: f"/bookmarks/{e.id}/str-replace",
+    ),
+    EndpointCase(
+        label="note",
+        model=Note,
+        entity_type_enum=EntityType.NOTE,
+        make_kwargs=_note_kwargs,
+        url=lambda e: f"/notes/{e.id}/str-replace",
+    ),
+    EndpointCase(
+        label="prompt-by-id",
+        model=Prompt,
+        entity_type_enum=EntityType.PROMPT,
+        make_kwargs=_prompt_kwargs,
+        url=lambda e: f"/prompts/{e.id}/str-replace",
+    ),
+    EndpointCase(
+        label="prompt-by-name",
+        model=Prompt,
+        entity_type_enum=EntityType.PROMPT,
+        make_kwargs=_prompt_kwargs,
+        url=lambda e: f"/prompts/name/{e.name}/str-replace",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_entity(
+    factory: async_sessionmaker,
+    case: EndpointCase,
+    user_id: UUID,
+    content: str,
+) -> Any:
+    """
+    Insert one entity directly via SQLAlchemy and return it.
+
+    Direct DB insert (not POST /<entity>) is deliberate — these tests should
+    fail when str-replace breaks, not when the create endpoint regresses.
+    """
+    async with factory() as session:
+        entity = case.model(**case.make_kwargs(user_id, content))
+        session.add(entity)
+        await session.commit()
+        await session.refresh(entity)
+        return entity
+
+
+async def _fetch_current_content(
+    factory: async_sessionmaker,
+    case: EndpointCase,
+    entity_id: UUID,
+) -> str | None:
+    async with factory() as session:
+        entity = await session.get(case.model, entity_id)
+        return entity.content if entity is not None else None
+
+
+async def _fetch_history_rows(
+    factory: async_sessionmaker,
+    case: EndpointCase,
+    entity_id: UUID,
+) -> list[ContentHistory]:
+    async with factory() as session:
+        result = await session.execute(
+            select(ContentHistory)
+            .where(
+                ContentHistory.entity_type == case.entity_type_enum.value,
+                ContentHistory.entity_id == entity_id,
+            )
+            .order_by(ContentHistory.version.asc().nullslast()),
+        )
+        return list(result.scalars().all())
+
+
+def _case_ids(cases: list[EndpointCase]) -> list[str]:
+    return [c.label for c in cases]
+
+
+# ---------------------------------------------------------------------------
+# Concurrent non-overlapping edits — load-bearing test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", CASES, ids=_case_ids(CASES))
+async def test_concurrent_non_overlapping_edits_all_succeed_and_compose(
+    case: EndpointCase,
+    concurrent_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """
+    N parallel str-replace calls with disjoint targets all succeed and compose.
+
+    The load-bearing assertion is that the final content contains every edit.
+    "All 5 returned 200" alone would not catch a silent-overwrite bug — the
+    losing writes would also return 200. Only checking final content proves
+    the row lock serialized the writes correctly.
+    """
+    entity = await _seed_entity(
+        concurrent_session_factory, case, concurrent_test_user.id,
+        NON_OVERLAPPING_CONTENT,
+    )
+
+    url = case.url(entity)
+    responses = await asyncio.gather(*[
+        concurrent_client.patch(url, json={"old_str": marker, "new_str": f"EDITED-{i}"})
+        for i, marker in enumerate(NON_OVERLAPPING_MARKERS)
+    ])
+
+    statuses = [r.status_code for r in responses]
+    assert all(s == 200 for s in statuses), (
+        f"Expected all 200, got {statuses}. Bodies: {[r.json() for r in responses]}"
+    )
+
+    final = await _fetch_current_content(concurrent_session_factory, case, entity.id)
+    assert final is not None
+    for i in range(N_CONCURRENT):
+        assert f"EDITED-{i}" in final, (
+            f"Missing EDITED-{i} in final content — silent overwrite. Final: {final!r}"
+        )
+    for marker in NON_OVERLAPPING_MARKERS:
+        assert marker not in final, (
+            f"Original marker {marker!r} still present — at least one edit was lost. "
+            f"Final: {final!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concurrent overlapping edits — conflict surfaces as no_match
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", CASES, ids=_case_ids(CASES))
+async def test_concurrent_overlapping_edits_return_no_match_for_loser(
+    case: EndpointCase,
+    concurrent_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """
+    When two parallel str-replaces both target the same unique substring,
+    one wins (200) and the other gets a 400 no_match — never a silent overwrite.
+    """
+    entity = await _seed_entity(
+        concurrent_session_factory, case, concurrent_test_user.id, "shared-target",
+    )
+    url = case.url(entity)
+
+    responses = await asyncio.gather(
+        concurrent_client.patch(url, json={"old_str": "shared-target", "new_str": "by-A"}),
+        concurrent_client.patch(url, json={"old_str": "shared-target", "new_str": "by-B"}),
+    )
+
+    statuses = sorted(r.status_code for r in responses)
+    assert statuses == [200, 400], f"Expected [200, 400], got {statuses}"
+
+    loser = next(r for r in responses if r.status_code == 400)
+    assert loser.json()["detail"]["error"] == "no_match"
+
+    final = await _fetch_current_content(concurrent_session_factory, case, entity.id)
+    assert final in {"by-A", "by-B"}
+
+    # Only the winning request should record a history row. A regression that
+    # logged history for the no_match path would show up as an extra UPDATE.
+    rows = await _fetch_history_rows(concurrent_session_factory, case, entity.id)
+    updates = [
+        r for r in rows
+        if r.action == ActionType.UPDATE.value and r.version is not None
+    ]
+    assert len(updates) == 1, (
+        f"Expected exactly 1 UPDATE row (the winner's), got {len(updates)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# History version allocation under contention
+# ---------------------------------------------------------------------------
+#
+# NOTE: This is NOT a content-chain coherence test. The load-bearing proof
+# that the row lock fixed the lost-update bug on entity content lives in
+# `test_concurrent_non_overlapping_edits_all_succeed_and_compose` above — if
+# the lock failed, missing markers would surface there. The test below is a
+# secondary check that history_service's version allocation also survives
+# contention (unique, dense version numbers).
+#
+# A real diff-chain coherence test belongs in `test_history_service.py`,
+# exercising the history service directly. KAN-148's scope is the lost-update
+# bug on entity content; this PR doesn't attempt to also test history-layer
+# content reconstruction.
+
+
+@pytest.mark.parametrize("case", CASES, ids=_case_ids(CASES))
+async def test_concurrent_edits_assign_unique_dense_history_versions(
+    case: EndpointCase,
+    concurrent_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """
+    Under N concurrent str-replaces, `history_service.record_action` produces
+    exactly N UPDATE rows with unique, dense version numbers.
+
+    history_service uses `db.begin_nested()` + a unique constraint on
+    `(entity_type, entity_id, version)` to retry version assignment on
+    contention. If that retry loop were broken, the sequence would show a
+    duplicate or a gap. This test is the regression catcher for that
+    history-layer property only — see module note above for what is and
+    isn't proven here.
+    """
+    entity = await _seed_entity(
+        concurrent_session_factory, case, concurrent_test_user.id,
+        NON_OVERLAPPING_CONTENT,
+    )
+
+    responses = await asyncio.gather(*[
+        concurrent_client.patch(
+            case.url(entity),
+            json={"old_str": marker, "new_str": f"EDITED-{i}"},
+        )
+        for i, marker in enumerate(NON_OVERLAPPING_MARKERS)
+    ])
+    assert all(r.status_code == 200 for r in responses)
+
+    rows = await _fetch_history_rows(concurrent_session_factory, case, entity.id)
+    updates = [
+        r for r in rows
+        if r.action == ActionType.UPDATE.value and r.version is not None
+    ]
+    assert len(updates) == N_CONCURRENT, (
+        f"Expected {N_CONCURRENT} UPDATEs, got {len(updates)}. "
+        f"Missing rows indicate a lost update at the history layer."
+    )
+
+    versions = [r.version for r in updates]
+    assert len(set(versions)) == N_CONCURRENT, (
+        f"Duplicate version numbers under contention: {sorted(versions)}."
+    )
+    assert max(versions) - min(versions) + 1 == N_CONCURRENT, (
+        f"Gap in version sequence: {sorted(versions)}."
+    )

--- a/backend/tests/api/test_str_replace_concurrency.py
+++ b/backend/tests/api/test_str_replace_concurrency.py
@@ -352,3 +352,11 @@ async def test_concurrent_edits_assign_unique_dense_history_versions(
     assert max(versions) - min(versions) + 1 == N_CONCURRENT, (
         f"Gap in version sequence: {sorted(versions)}."
     )
+
+    # Each str-replace UPDATE row should record what changed. str-replace only
+    # touches content (the prompt atomic-arguments path is exercised
+    # separately in test_prompts.py).
+    assert all(r.changed_fields == ["content"] for r in updates), (
+        f"Expected changed_fields=['content'] on every str-replace UPDATE row. "
+        f"Got: {[r.changed_fields for r in updates]}"
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,7 +25,8 @@ from models.base import Base
 from services.llm_service import LLMService, set_llm_service
 
 def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
-    """Pin env vars that shadow local .env so tests are hermetic.
+    """
+    Pin env vars that shadow local .env so tests are hermetic.
 
     Runs once at session start, before any fixture or test, regardless of
     which subset of tests is selected. Container-dependent env vars
@@ -168,7 +169,8 @@ _SEARCH_VECTOR_TRIGGER_STATEMENTS = [
 
 @pytest.fixture(scope="session")
 def _schema_setup(database_url: str) -> None:
-    """Run schema DDL once per test session.
+    """
+    Run schema DDL once per test session.
 
     Saves ~45s across the ~3000-test suite by hoisting Base.metadata.create_all
     and the search-vector trigger DDL out of the per-test path. The Postgres
@@ -252,6 +254,103 @@ def db_session_factory(db_connection: AsyncConnection) -> async_sessionmaker:
         expire_on_commit=False,
         join_transaction_mode="create_savepoint",
     )
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-session fixtures (real cross-transaction lock contention)
+# ---------------------------------------------------------------------------
+# These fixtures provide independent database connections suitable for
+# exercising real Postgres row-lock behavior (`SELECT ... FOR UPDATE`).
+#
+# Why they are separate from `db_session` / `db_session_factory`:
+#   - The standard fixtures bind every session to a single AsyncConnection
+#     wrapped in an outer transaction that is rolled back after each test
+#     (`join_transaction_mode="create_savepoint"`). All "concurrent" sessions
+#     therefore share one transaction and cannot contend for row locks.
+#   - To test FOR UPDATE we need independent backends/transactions, which
+#     requires a separate engine with no outer-transaction wrapper.
+#
+# Tests using `concurrent_session_factory` must clean up their data. Use
+# `concurrent_test_user` to get a fresh User scoped to the test; data created
+# under that user_id is removed automatically (ON DELETE CASCADE handles
+# bookmarks/notes/prompts/history).
+
+
+@pytest.fixture
+async def concurrent_engine(
+    database_url: str,
+    _schema_setup: None,
+) -> AsyncGenerator[AsyncEngine]:
+    """
+    Independent async engine for tests that need real lock contention.
+
+    Function-scoped because pytest-asyncio creates a fresh event loop per
+    test; asyncpg connections in the pool are bound to the loop they were
+    created in and cannot be reused across loops.
+    """
+    engine = create_async_engine(
+        database_url,
+        echo=False,
+        pool_size=4,
+        max_overflow=2,
+        pool_pre_ping=True,
+    )
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+def concurrent_session_factory(
+    concurrent_engine: AsyncEngine,
+) -> async_sessionmaker:
+    """
+    Session factory backed by the independent engine.
+
+    Each session opens its own transaction. Sessions/transactions are fully
+    independent and commits are real (not rolled back at end of test).
+    Use with `concurrent_test_user` for automatic data cleanup.
+    """
+    return async_sessionmaker(
+        concurrent_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+
+@pytest.fixture
+async def concurrent_test_user(
+    concurrent_session_factory: async_sessionmaker,
+) -> AsyncGenerator[object]:
+    """
+    Create a fresh User on the concurrent engine; cascade-delete on teardown.
+
+    Yields the User row (with a fresh `id`). Any bookmarks/notes/prompts/
+    content_history created under this user_id are removed by FK cascade
+    when the user is deleted.
+    """
+    # Local import to avoid loading models at collection time / module import.
+    from models.user import User  # noqa: PLC0415
+
+    async with concurrent_session_factory() as session:
+        user = User(
+            auth0_id=f"concurrent-test-{os.urandom(8).hex()}",
+            email=f"concurrent-{os.urandom(4).hex()}@test.local",
+            # "pro" so concurrency tests aren't constrained by FREE-tier quotas.
+            tier="pro",
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+    try:
+        yield user
+    finally:
+        async with concurrent_session_factory() as session:
+            await session.execute(
+                text("DELETE FROM users WHERE id = :uid"),
+                {"uid": user.id},
+            )
+            await session.commit()
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,7 @@
 import asyncio
 import os
 from collections.abc import AsyncGenerator, Generator
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -351,6 +352,109 @@ async def concurrent_test_user(
                 {"uid": user.id},
             )
             await session.commit()
+
+
+@pytest.fixture
+async def concurrent_client(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: object,
+    redis_client: RedisClient,  # noqa: ARG001
+) -> AsyncGenerator[AsyncClient]:
+    """
+    HTTP client where each request opens its own DB session from the concurrent engine.
+
+    Unlike the standard `client` fixture (single shared session, rollback
+    isolation), this fixture wires `get_async_session` to
+    `concurrent_session_factory` so that concurrent HTTP requests actually
+    contend at the database level — necessary for testing row-locking.
+
+    Authenticates via PAT against `concurrent_test_user` (not dev-mode). The
+    user cascades on teardown, removing the PAT, consent, and all created
+    content.
+    """
+    # Imports stay inline: `api.main` runs `get_settings()` at import time,
+    # which validates `DATABASE_URL`. That env var is only set at runtime by
+    # the `database_url` fixture, so a module-level import would fail at
+    # collection time. Same constraint applies to anything that transitively
+    # touches Settings or db.session.
+    from api.main import app  # noqa: PLC0415
+    from core.policy_versions import (  # noqa: PLC0415
+        PRIVACY_POLICY_VERSION,
+        TERMS_OF_SERVICE_VERSION,
+    )
+    from core.tier_limits import Tier, get_tier_limits  # noqa: PLC0415
+    from db.session import get_async_session, get_session_factory  # noqa: PLC0415
+    from models.user_consent import UserConsent  # noqa: PLC0415
+    from schemas.token import TokenCreate  # noqa: PLC0415
+    from services.token_service import create_token  # noqa: PLC0415
+
+    # Seed consent and PAT in their own committed transaction so subsequent
+    # per-request sessions can see them. DEV-tier limits here cover only the
+    # PAT-count quota check at creation time; the user's runtime tier (which
+    # governs rate limiting) stays "pro" as set in `concurrent_test_user`.
+    # N=5 concurrent writes is well under PRO's 200/min write rate limit.
+    async with concurrent_session_factory() as session:
+        session.add(UserConsent(
+            user_id=concurrent_test_user.id,
+            consented_at=datetime.now(UTC),
+            privacy_policy_version=PRIVACY_POLICY_VERSION,
+            terms_of_service_version=TERMS_OF_SERVICE_VERSION,
+        ))
+        _, plaintext_token = await create_token(
+            session,
+            concurrent_test_user.id,
+            TokenCreate(name="concurrency-test"),
+            get_tier_limits(Tier.DEV),
+        )
+        await session.commit()
+
+    # `get_settings` is `@lru_cache`'d. Without `cache_clear()`, the override
+    # below won't take effect because the cached Settings (populated by an
+    # earlier fixture) is still served. After this fixture's teardown, the
+    # next `get_settings()` call repopulates from env vars (pinned by
+    # `pytest_configure` to dev-mode=True) — so other tests are unaffected.
+    get_settings.cache_clear()
+
+    async def override_get_async_session() -> AsyncGenerator[AsyncSession]:
+        """Mirror production `get_async_session`: open, commit, close per request."""
+        async with concurrent_session_factory() as request_session:
+            try:
+                yield request_session
+                await request_session.commit()
+            except Exception:
+                await request_session.rollback()
+                raise
+
+    # `dev_mode=False` is the load-bearing setting: it forces the PAT auth
+    # path (the production shape for MCP callers) instead of the dev-user
+    # bypass. The other fields are just minimum-required Settings fields.
+    def override_get_settings() -> Settings:
+        return Settings(
+            database_url="postgresql://test",
+            dev_mode=False,
+            auth0_custom_claim_namespace="https://test.example.com",
+        )
+
+    app.dependency_overrides[get_async_session] = override_get_async_session
+    app.dependency_overrides[get_session_factory] = lambda: concurrent_session_factory
+    app.dependency_overrides[get_settings] = override_get_settings
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            headers={"Authorization": f"Bearer {plaintext_token}"},
+        ) as test_client:
+            yield test_client
+    finally:
+        app.dependency_overrides.clear()
+        # Defensive teardown-clear: this fixture churns Settings more aggressively
+        # than the standard `client` fixture (it overrides dev_mode and direct
+        # `get_settings()` calls during the test could repopulate the cache with
+        # post-override env state). Clear so the next test starts fresh. The
+        # standard `client` fixture does NOT do this — it only churns dev-mode
+        # parity, so its setup-side clear is sufficient.
+        get_settings.cache_clear()
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,7 +3,11 @@ import asyncio
 import os
 from collections.abc import AsyncGenerator, Generator
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from models.user import User
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -321,7 +325,7 @@ def concurrent_session_factory(
 @pytest.fixture
 async def concurrent_test_user(
     concurrent_session_factory: async_sessionmaker,
-) -> AsyncGenerator[object]:
+) -> "AsyncGenerator[User]":
     """
     Create a fresh User on the concurrent engine; cascade-delete on teardown.
 
@@ -336,8 +340,8 @@ async def concurrent_test_user(
         user = User(
             auth0_id=f"concurrent-test-{os.urandom(8).hex()}",
             email=f"concurrent-{os.urandom(4).hex()}@test.local",
-            # "pro" so concurrency tests aren't constrained by FREE-tier quotas.
-            tier="pro",
+            # PRO tier so concurrency tests aren't constrained by FREE-tier quotas.
+            tier=Tier.PRO.value,
         )
         session.add(user)
         await session.commit()
@@ -357,7 +361,7 @@ async def concurrent_test_user(
 @pytest.fixture
 async def concurrent_client(
     concurrent_session_factory: async_sessionmaker,
-    concurrent_test_user: object,
+    concurrent_test_user: "User",
     redis_client: RedisClient,  # noqa: ARG001
 ) -> AsyncGenerator[AsyncClient]:
     """
@@ -382,7 +386,6 @@ async def concurrent_client(
         PRIVACY_POLICY_VERSION,
         TERMS_OF_SERVICE_VERSION,
     )
-    from core.tier_limits import Tier, get_tier_limits  # noqa: PLC0415
     from db.session import get_async_session, get_session_factory  # noqa: PLC0415
     from models.user_consent import UserConsent  # noqa: PLC0415
     from schemas.token import TokenCreate  # noqa: PLC0415
@@ -391,7 +394,7 @@ async def concurrent_client(
     # Seed consent and PAT in their own committed transaction so subsequent
     # per-request sessions can see them. DEV-tier limits here cover only the
     # PAT-count quota check at creation time; the user's runtime tier (which
-    # governs rate limiting) stays "pro" as set in `concurrent_test_user`.
+    # governs rate limiting) stays PRO as set in `concurrent_test_user`.
     # N=5 concurrent writes is well under PRO's 200/min write rate limit.
     async with concurrent_session_factory() as session:
         session.add(UserConsent(

--- a/backend/tests/mcp_server/conftest.py
+++ b/backend/tests/mcp_server/conftest.py
@@ -12,7 +12,8 @@ from mcp_server import server
 
 @pytest.fixture
 def mock_api() -> respx.MockRouter:
-    """Context manager for mocking API responses.
+    """
+    Context manager for mocking API responses.
 
     Reads VITE_API_URL from env (pinned by top-level conftest's
     pytest_configure) so the mock base_url matches the URL the MCP server

--- a/backend/tests/prompt_mcp_server/conftest.py
+++ b/backend/tests/prompt_mcp_server/conftest.py
@@ -36,7 +36,8 @@ class _LowLevelServerWrapper:
 
 @pytest.fixture
 async def mock_api() -> AsyncGenerator[respx.MockRouter]:
-    """Context manager for mocking API responses.
+    """
+    Context manager for mocking API responses.
 
     Reads VITE_API_URL from env (pinned by top-level conftest's
     pytest_configure) so the mock base_url matches the URL the MCP server

--- a/backend/tests/services/test_get_for_update.py
+++ b/backend/tests/services/test_get_for_update.py
@@ -1,0 +1,358 @@
+"""
+Tests for `get_for_update(...)` and `get_by_name_for_update(...)`.
+
+Two concerns are tested:
+
+  1. Contract: filter semantics (missing entity, archived, soft-deleted) match
+     the documented behavior of the read-path methods.
+
+  2. Lock semantics: real Postgres `SELECT ... FOR UPDATE` behavior across
+     independent transactions. We use the `concurrent_session_factory` fixture
+     (see backend/tests/conftest.py) instead of the standard
+     `db_session_factory`, because the standard factory binds every session to
+     a single connection wrapped in one outer transaction — cross-session lock
+     contention is impossible in that shape.
+
+Blocking is proven by the strongest assertion available: spawn B as a task, A
+modifies + commits a sentinel value, await B, assert B observes the sentinel.
+That single chain proves (a) B was blocked while A held the lock (otherwise B
+would have read the pre-A state), (b) the lock was released on A's commit,
+and (c) B reads correct post-commit state. We deliberately avoid
+`asyncio.wait_for(..., timeout=...)` + `TimeoutError` to assert blocking —
+that pattern proves "the driver cancelled the query," not "the row was locked."
+
+We do not re-test Postgres's responsibilities (deadlock detection, lock
+fairness) — only the wrapper's contract.
+"""
+import asyncio
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from models.bookmark import Bookmark
+from models.prompt import Prompt
+from models.user import User
+from services.bookmark_service import BookmarkService
+from services.prompt_service import PromptService
+
+
+bookmark_service = BookmarkService()
+prompt_service = PromptService()
+
+
+# Yield to the scheduler long enough for the spawned task to start its query
+# and reach the FOR UPDATE wait. We don't assert "still pending" off this
+# sleep — that's timing-fragile and redundant given the post-state assertion.
+TASK_START_DELAY = 0.1
+
+# Generous ceiling for awaiting a task that should unblock once we release the
+# lock. Postgres releases on commit/rollback; the task should resume within
+# tens of milliseconds in practice.
+UNBLOCK_TIMEOUT = 5.0
+
+# Short timeout for "must return quickly" assertions (plain reads on a locked
+# row). Just needs to comfortably exceed normal query latency.
+QUICK_RETURN_TIMEOUT = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Helpers / per-test seeding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def seeded_bookmark(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> Bookmark:
+    """Insert one active bookmark under the per-test user."""
+    async with concurrent_session_factory() as session:
+        bookmark = Bookmark(
+            user_id=concurrent_test_user.id,
+            url=f"https://example.com/{uuid4().hex}",
+            title="lock-test",
+            description="seed",
+            content="original",
+        )
+        session.add(bookmark)
+        await session.commit()
+        await session.refresh(bookmark)
+        return bookmark
+
+
+@pytest.fixture
+async def seeded_prompt(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> Prompt:
+    """Insert one active prompt under the per-test user."""
+    async with concurrent_session_factory() as session:
+        prompt = Prompt(
+            user_id=concurrent_test_user.id,
+            name=f"lock-test-{uuid4().hex[:8]}",
+            title="Lock test",
+            description="seed",
+            content="original",
+            arguments=[],
+        )
+        session.add(prompt)
+        await session.commit()
+        await session.refresh(prompt)
+        return prompt
+
+
+# ---------------------------------------------------------------------------
+# `BaseEntityService.get_for_update(...)` — contract
+# ---------------------------------------------------------------------------
+
+
+async def test_get_for_update_returns_none_for_missing_entity(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """A nonexistent id returns None, not an error."""
+    async with concurrent_session_factory() as session:
+        result = await bookmark_service.get_for_update(
+            session, concurrent_test_user.id, uuid4(),
+        )
+        assert result is None
+
+
+async def test_get_for_update_excludes_archived_by_default(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """Archived entities are excluded when `include_archived=False` (the default)."""
+    async with concurrent_session_factory() as session:
+        bookmark = Bookmark(
+            user_id=concurrent_test_user.id,
+            url=f"https://example.com/{uuid4().hex}",
+            title="archived",
+            archived_at=datetime.now(UTC),
+        )
+        session.add(bookmark)
+        await session.commit()
+        await session.refresh(bookmark)
+
+        result = await bookmark_service.get_for_update(
+            session, concurrent_test_user.id, bookmark.id,
+        )
+        assert result is None
+
+
+async def test_get_for_update_includes_archived_when_requested(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """`include_archived=True` returns archived entities."""
+    async with concurrent_session_factory() as session:
+        bookmark = Bookmark(
+            user_id=concurrent_test_user.id,
+            url=f"https://example.com/{uuid4().hex}",
+            title="archived",
+            archived_at=datetime.now(UTC),
+        )
+        session.add(bookmark)
+        await session.commit()
+        await session.refresh(bookmark)
+
+        result = await bookmark_service.get_for_update(
+            session, concurrent_test_user.id, bookmark.id, include_archived=True,
+        )
+        assert result is not None
+        assert result.id == bookmark.id
+
+
+async def test_get_for_update_always_excludes_soft_deleted(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """Soft-deleted entities are always excluded, even with `include_archived=True`."""
+    async with concurrent_session_factory() as session:
+        bookmark = Bookmark(
+            user_id=concurrent_test_user.id,
+            url=f"https://example.com/{uuid4().hex}",
+            title="deleted",
+            deleted_at=datetime.now(UTC),
+        )
+        session.add(bookmark)
+        await session.commit()
+        await session.refresh(bookmark)
+
+        result = await bookmark_service.get_for_update(
+            session, concurrent_test_user.id, bookmark.id, include_archived=True,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# `BaseEntityService.get_for_update(...)` — lock semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_get_for_update_blocks_until_commit(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+    seeded_bookmark: Bookmark,
+) -> None:
+    """
+    While A holds the row lock, B's FOR UPDATE blocks until A commits.
+
+    The assertion `B saw "committed-by-a"` proves three things at once:
+      (a) B was blocked while A held the lock — otherwise it would have read
+          the pre-A value "original";
+      (b) the lock was released on A's commit;
+      (c) B read the correct post-commit state.
+    """
+    async def acquire_in_b() -> Bookmark | None:
+        async with concurrent_session_factory() as session_b:
+            return await bookmark_service.get_for_update(
+                session_b, concurrent_test_user.id, seeded_bookmark.id,
+            )
+
+    async with concurrent_session_factory() as session_a:
+        locked = await bookmark_service.get_for_update(
+            session_a, concurrent_test_user.id, seeded_bookmark.id,
+        )
+        assert locked is not None
+        locked.content = "committed-by-a"
+        await session_a.flush()
+
+        b_task = asyncio.create_task(acquire_in_b())
+        await asyncio.sleep(TASK_START_DELAY)
+        await session_a.commit()
+
+    result = await asyncio.wait_for(b_task, timeout=UNBLOCK_TIMEOUT)
+    assert result is not None
+    assert result.content == "committed-by-a"
+
+
+async def test_get_for_update_blocks_until_rollback(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+    seeded_bookmark: Bookmark,
+) -> None:
+    """
+    While A holds the row lock, B's FOR UPDATE blocks until A rolls back.
+
+    The assertion `B saw "original"` proves both that the lock was released
+    on rollback AND that A's uncommitted change is invisible to B.
+    """
+    async def acquire_in_b() -> Bookmark | None:
+        async with concurrent_session_factory() as session_b:
+            return await bookmark_service.get_for_update(
+                session_b, concurrent_test_user.id, seeded_bookmark.id,
+            )
+
+    async with concurrent_session_factory() as session_a:
+        locked = await bookmark_service.get_for_update(
+            session_a, concurrent_test_user.id, seeded_bookmark.id,
+        )
+        assert locked is not None
+        locked.content = "uncommitted-change"
+        await session_a.flush()
+
+        b_task = asyncio.create_task(acquire_in_b())
+        await asyncio.sleep(TASK_START_DELAY)
+        await session_a.rollback()
+
+    result = await asyncio.wait_for(b_task, timeout=UNBLOCK_TIMEOUT)
+    assert result is not None
+    assert result.content == "original"
+
+
+async def test_plain_get_does_not_block_on_for_update_lock(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+    seeded_bookmark: Bookmark,
+) -> None:
+    """Plain `get(...)` (a non-locking SELECT) must not block on a FOR UPDATE lock."""
+    async def plain_get_in_b() -> Bookmark | None:
+        async with concurrent_session_factory() as session_b:
+            return await bookmark_service.get(
+                session_b, concurrent_test_user.id, seeded_bookmark.id,
+            )
+
+    async with concurrent_session_factory() as session_a:
+        locked = await bookmark_service.get_for_update(
+            session_a, concurrent_test_user.id, seeded_bookmark.id,
+        )
+        assert locked is not None
+
+        # B must return well before QUICK_RETURN_TIMEOUT. wait_for is the
+        # right primitive here: the assertion *is* "returns quickly."
+        result = await asyncio.wait_for(plain_get_in_b(), timeout=QUICK_RETURN_TIMEOUT)
+        assert result is not None
+        assert result.id == seeded_bookmark.id
+
+
+# ---------------------------------------------------------------------------
+# `PromptService.get_by_name_for_update(...)` — contract + lock semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_get_by_name_for_update_excludes_inactive(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+) -> None:
+    """By-name variant returns active prompts only (archived and soft-deleted excluded)."""
+    async with concurrent_session_factory() as session:
+        archived = Prompt(
+            user_id=concurrent_test_user.id,
+            name=f"archived-{uuid4().hex[:8]}",
+            title="archived",
+            content="x",
+            arguments=[],
+            archived_at=datetime.now(UTC),
+        )
+        deleted = Prompt(
+            user_id=concurrent_test_user.id,
+            name=f"deleted-{uuid4().hex[:8]}",
+            title="deleted",
+            content="x",
+            arguments=[],
+            deleted_at=datetime.now(UTC),
+        )
+        session.add_all([archived, deleted])
+        await session.commit()
+        await session.refresh(archived)
+        await session.refresh(deleted)
+
+        assert await prompt_service.get_by_name_for_update(
+            session, concurrent_test_user.id, archived.name,
+        ) is None
+        assert await prompt_service.get_by_name_for_update(
+            session, concurrent_test_user.id, deleted.name,
+        ) is None
+
+
+async def test_get_by_name_for_update_blocks_until_commit(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+    seeded_prompt: Prompt,
+) -> None:
+    """By-name lock variant blocks a concurrent by-name FOR UPDATE and releases on commit."""
+    async def acquire_in_b() -> Prompt | None:
+        async with concurrent_session_factory() as session_b:
+            return await prompt_service.get_by_name_for_update(
+                session_b, concurrent_test_user.id, seeded_prompt.name,
+            )
+
+    async with concurrent_session_factory() as session_a:
+        locked = await prompt_service.get_by_name_for_update(
+            session_a, concurrent_test_user.id, seeded_prompt.name,
+        )
+        assert locked is not None
+        assert locked.id == seeded_prompt.id
+        locked.content = "committed-by-a"
+        await session_a.flush()
+
+        b_task = asyncio.create_task(acquire_in_b())
+        await asyncio.sleep(TASK_START_DELAY)
+        await session_a.commit()
+
+    result = await asyncio.wait_for(b_task, timeout=UNBLOCK_TIMEOUT)
+    assert result is not None
+    assert result.content == "committed-by-a"

--- a/backend/tests/services/test_get_for_update.py
+++ b/backend/tests/services/test_get_for_update.py
@@ -29,6 +29,8 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from models.bookmark import Bookmark
@@ -261,6 +263,58 @@ async def test_get_for_update_blocks_until_rollback(
     result = await asyncio.wait_for(b_task, timeout=UNBLOCK_TIMEOUT)
     assert result is not None
     assert result.content == "original"
+
+
+async def test_row_lock_survives_savepoint_rollback(
+    concurrent_session_factory: async_sessionmaker,
+    concurrent_test_user: User,
+    seeded_bookmark: Bookmark,
+) -> None:
+    """
+    A row lock held by the outer transaction is NOT released when a nested
+    savepoint inside that transaction rolls back.
+
+    `history_service.record_action` opens `db.begin_nested()` (a savepoint)
+    for unique-constraint retries on the history version. If a savepoint
+    rollback released the FOR UPDATE lock acquired earlier in the request
+    transaction, concurrent str-replace calls could overlap. Postgres docs
+    say row locks survive savepoint rollback; this test proves the property
+    holds in our codebase against our SQLAlchemy version.
+
+    Proven by direct lock-state probe using `SELECT ... FOR UPDATE NOWAIT`:
+    if A still holds the lock, B's NOWAIT raises immediately (asyncpg's
+    `LockNotAvailableError`, wrapped by SQLAlchemy as `DBAPIError`). An
+    "A mutates + B reads sentinel" pattern would not work here — A's UPDATE
+    would acquire its own implicit write lock, blocking B regardless of
+    whether the FOR UPDATE survived. NOWAIT is unambiguous: it answers
+    exactly "is the row locked right now?"
+    """
+    async with concurrent_session_factory() as session_a:
+        locked = await bookmark_service.get_for_update(
+            session_a, concurrent_test_user.id, seeded_bookmark.id,
+        )
+        assert locked is not None
+
+        # Savepoint roundtrip with no work inside: begin_nested issues
+        # SAVEPOINT; raising forces ROLLBACK TO SAVEPOINT on context exit.
+        with pytest.raises(RuntimeError, match="savepoint-abort"):
+            async with session_a.begin_nested():
+                raise RuntimeError("savepoint-abort")
+
+        # Probe from a separate session: NOWAIT fails immediately if A still
+        # holds the row lock.
+        async with concurrent_session_factory() as session_b:
+            # Match asyncpg's LockNotAvailableError message specifically, so
+            # the test would fail informatively if any other lock-related
+            # error class (e.g., deadlock) ever surfaced through this path.
+            with pytest.raises(DBAPIError, match="could not obtain lock"):
+                await session_b.execute(
+                    select(Bookmark)
+                    .where(Bookmark.id == seeded_bookmark.id)
+                    .with_for_update(nowait=True),
+                )
+
+        await session_a.rollback()
 
 
 async def test_plain_get_does_not_block_on_for_update_lock(

--- a/backend/tests/services/test_get_for_update.py
+++ b/backend/tests/services/test_get_for_update.py
@@ -13,20 +13,26 @@ Two concerns are tested:
      a single connection wrapped in one outer transaction — cross-session lock
      contention is impossible in that shape.
 
-Blocking is proven by the strongest assertion available: spawn B as a task, A
-modifies + commits a sentinel value, await B, assert B observes the sentinel.
-That single chain proves (a) B was blocked while A held the lock (otherwise B
-would have read the pre-A state), (b) the lock was released on A's commit,
-and (c) B reads correct post-commit state. We deliberately avoid
-`asyncio.wait_for(..., timeout=...)` + `TimeoutError` to assert blocking —
-that pattern proves "the driver cancelled the query," not "the row was locked."
+Two complementary techniques carry the lock proofs:
+
+  - `_assert_row_is_locked` issues a `SELECT ... FOR UPDATE NOWAIT` from a
+    third session. NOWAIT raises immediately if the row is locked, which
+    deterministically confirms that lock state at the probe point — no
+    timing dependence.
+  - After releasing A's lock, await B's task and assert the post-state it
+    observes (A's committed sentinel, or the pre-A "original" after rollback).
+    This rules out scheduler races where B might have read pre-A state.
+
+We deliberately avoid `asyncio.wait_for(..., timeout=...)` + `TimeoutError`
+as a blocking proof — that pattern only shows "the driver cancelled the
+query," not "the row was locked."
 
 We do not re-test Postgres's responsibilities (deadlock detection, lock
 fairness) — only the wrapper's contract.
 """
 import asyncio
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import select
@@ -62,6 +68,28 @@ QUICK_RETURN_TIMEOUT = 0.5
 # ---------------------------------------------------------------------------
 # Helpers / per-test seeding
 # ---------------------------------------------------------------------------
+
+
+async def _assert_row_is_locked(
+    factory: async_sessionmaker,
+    model: type,
+    entity_id: UUID,
+) -> None:
+    """
+    Deterministic probe: assert the given row is currently locked.
+
+    `SELECT ... FOR UPDATE NOWAIT` raises `LockNotAvailableError` immediately
+    if any other transaction holds the lock. Combined with a post-state
+    assertion in the calling test, this turns timing-dependent "blocking"
+    proofs into a deterministic lock-state check.
+    """
+    async with factory() as probe_session:
+        with pytest.raises(DBAPIError, match="could not obtain lock"):
+            await probe_session.execute(
+                select(model)
+                .where(model.id == entity_id)
+                .with_for_update(nowait=True),
+            )
 
 
 @pytest.fixture
@@ -202,11 +230,17 @@ async def test_get_for_update_blocks_until_commit(
     """
     While A holds the row lock, B's FOR UPDATE blocks until A commits.
 
-    The assertion `B saw "committed-by-a"` proves three things at once:
-      (a) B was blocked while A held the lock — otherwise it would have read
-          the pre-A value "original";
-      (b) the lock was released on A's commit;
-      (c) B read the correct post-commit state.
+    Two assertions carry the proof:
+      1. Before spawning B, a `FOR UPDATE NOWAIT` probe from a third session
+         deterministically confirms A holds the lock right now.
+      2. After A commits, B unblocks and reads "committed-by-a" — proving B
+         did not race ahead of A (which would have read "original" under
+         READ COMMITTED) and that B reads the correct post-commit state.
+
+    The `await asyncio.sleep(TASK_START_DELAY)` is a heuristic giving B time
+    to start its query before A commits. The NOWAIT probe above is what makes
+    this deterministic; the sleep is belt-and-suspenders for the post-state
+    check.
     """
     async def acquire_in_b() -> Bookmark | None:
         async with concurrent_session_factory() as session_b:
@@ -221,6 +255,8 @@ async def test_get_for_update_blocks_until_commit(
         assert locked is not None
         locked.content = "committed-by-a"
         await session_a.flush()
+
+        await _assert_row_is_locked(concurrent_session_factory, Bookmark, seeded_bookmark.id)
 
         b_task = asyncio.create_task(acquire_in_b())
         await asyncio.sleep(TASK_START_DELAY)
@@ -239,8 +275,13 @@ async def test_get_for_update_blocks_until_rollback(
     """
     While A holds the row lock, B's FOR UPDATE blocks until A rolls back.
 
-    The assertion `B saw "original"` proves both that the lock was released
-    on rollback AND that A's uncommitted change is invisible to B.
+    Under READ COMMITTED, an uncommitted UPDATE in A is invisible to other
+    sessions regardless of the FOR UPDATE lock — so the post-state assertion
+    `B saw "original"` alone does not distinguish locked from unlocked
+    behavior. The NOWAIT probe is what makes this test a real proof: it
+    deterministically confirms A holds the lock before B is spawned. After
+    A rolls back, B unblocks and reads "original", confirming both that the
+    lock was released on rollback and that A's uncommitted change is gone.
     """
     async def acquire_in_b() -> Bookmark | None:
         async with concurrent_session_factory() as session_b:
@@ -255,6 +296,8 @@ async def test_get_for_update_blocks_until_rollback(
         assert locked is not None
         locked.content = "uncommitted-change"
         await session_a.flush()
+
+        await _assert_row_is_locked(concurrent_session_factory, Bookmark, seeded_bookmark.id)
 
         b_task = asyncio.create_task(acquire_in_b())
         await asyncio.sleep(TASK_START_DELAY)
@@ -301,18 +344,11 @@ async def test_row_lock_survives_savepoint_rollback(
             async with session_a.begin_nested():
                 raise RuntimeError("savepoint-abort")
 
-        # Probe from a separate session: NOWAIT fails immediately if A still
-        # holds the row lock.
-        async with concurrent_session_factory() as session_b:
-            # Match asyncpg's LockNotAvailableError message specifically, so
-            # the test would fail informatively if any other lock-related
-            # error class (e.g., deadlock) ever surfaced through this path.
-            with pytest.raises(DBAPIError, match="could not obtain lock"):
-                await session_b.execute(
-                    select(Bookmark)
-                    .where(Bookmark.id == seeded_bookmark.id)
-                    .with_for_update(nowait=True),
-                )
+        # Probe from a separate session: if A still holds the lock,
+        # NOWAIT raises immediately. This is the load-bearing assertion of
+        # this test — it answers "is the FOR UPDATE lock still held after
+        # the savepoint rollback?" deterministically.
+        await _assert_row_is_locked(concurrent_session_factory, Bookmark, seeded_bookmark.id)
 
         await session_a.rollback()
 
@@ -402,6 +438,8 @@ async def test_get_by_name_for_update_blocks_until_commit(
         assert locked.id == seeded_prompt.id
         locked.content = "committed-by-a"
         await session_a.flush()
+
+        await _assert_row_is_locked(concurrent_session_factory, Prompt, seeded_prompt.id)
 
         b_task = asyncio.create_task(acquire_in_b())
         await asyncio.sleep(TASK_START_DELAY)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,17 @@ All inherit `UUIDv7Mixin` (time-sortable PK), `TimestampMixin` (`created_at`, `u
 - **Trigger-maintained FTS vectors.** Bookmarks/Notes/Prompts each have a `search_vector` TSVECTOR column that a Postgres trigger keeps up to date on insert/update (weighted: title/name=A, description/summary=B, content=C). GIN indexed. Migration: `c07d5e217ca3_add_search_vector_columns_triggers_gin_*`.
 - **pgvector** is enabled on the Postgres cluster, reserved for future embedding-based features.
 
+### Concurrency control for content edits
+
+Two concurrency models coexist for content writes, chosen per operation semantics:
+
+- **Optimistic locking (`expected_updated_at` → 409).** Used by the *declarative* PATCH endpoints (`PATCH /bookmarks/{id}`, `/notes/{id}`, `/prompts/{id}`, `/prompts/name/{name}`) where the client submits a full new state. The handler compares the client-supplied `expected_updated_at` against the current row; mismatch returns 409 with the current server state. Clients are expected to refetch and merge.
+- **Server-side row locking (`SELECT ... FOR UPDATE`).** Used by the *content-addressable* `str-replace` endpoints (`PATCH /<entity>/{id}/str-replace` for bookmarks/notes/prompts, plus `PATCH /prompts/name/{name}/str-replace`). The handler acquires a row lock via `BaseEntityService.get_for_update(...)` (or `PromptService.get_by_name_for_update(...)` for the by-name route) before reading-and-rewriting content. Parallel calls against the same entity serialize at the database; each acquires the lock in turn, reads the current content, applies its `old_str → new_str` against fresh state, and commits. All succeed (or, if a competing edit removed the pattern they were targeting, surface the existing `400 no_match` — never a silent overwrite). No client-side timestamp tracking, no 409-retry round-trips.
+
+The lock is released when the FastAPI request transaction commits or rolls back (see `db/session.py`). Postgres row locks survive `SAVEPOINT` rollback, so the savepoint-retry loop in `history_service.record_action` does not release a lock acquired by `get_for_update` in the same transaction.
+
+If FK-insert contention against locked rows ever becomes measurable, Postgres's `FOR NO KEY UPDATE` (less restrictive than `FOR UPDATE`) is a future tuning option; not justified at current scale.
+
 ### Versioning — `content_history`
 
 Single table covering all three entity types. Every content change produces a `ContentHistory` row: a reverse diff (diff-match-patch delta from new → old) plus a JSONB `metadata_snapshot`. Every 10th version stores a full snapshot instead of a diff so reconstruction cost is bounded. Audit-only events (delete, restore, archive, unarchive) are stored with `version=NULL`. Retention is tier-based (see §11).

--- a/docs/implementation_plans/2026-05-11-lost-update-race.md
+++ b/docs/implementation_plans/2026-05-11-lost-update-race.md
@@ -1,0 +1,264 @@
+# Implementation Plan: Lost-Update Race on str-replace Endpoints (KAN-148)
+
+**Branch:** `fix/lost-update-race`
+**Ticket:** [KAN-148](https://tiddly.atlassian.net/browse/KAN-148)
+**Sibling ticket closed without action:** [KAN-149](https://tiddly.atlassian.net/browse/KAN-149) — see "Scope decision" below.
+
+## Background
+
+This PR fixes the **lost-update race** on the three MCP str-replace endpoints (bookmarks, notes, prompts). Under Postgres's default `READ COMMITTED` isolation, the current str-replace handlers do an unprotected read-modify-write: two concurrent calls against the same entity can each read the same content, each compute a new version locally, and each write — second commit silently overwrites the first.
+
+In practice, this rarely manifests today because end-to-end serialization (single uvicorn worker, HTTP client behavior, fast hot path) hides it. But AI agents firing parallel str-replace calls against the same entity are the realistic scenario that would surface it. The fix removes the latent risk before that becomes routine.
+
+## Approach: server-side row locking (`SELECT … FOR UPDATE`)
+
+str-replace is semantically **content-addressable**: the operation says "find `old_str`, replace with `new_str`." If `old_str` is still uniquely findable in the current content, the operation is safe regardless of what else changed. There's no client-side assertion about overall document state that needs validating; the existing `no_match` 400 is already the correct error signal when the operation's premise no longer holds.
+
+That semantic points to row locking, not optimistic locking:
+
+- **Row locking** (`SELECT … FOR UPDATE`) serializes the read-modify-write inside the database. N parallel str-replace calls against the same entity each acquire the row lock in turn, each read the **current** content, each apply their str-replace against fresh state, each commit. All N succeed on the first try (assuming their patterns still match). No round-trip retries. No agent-side timestamp tracking.
+- **Optimistic locking** (`expected_updated_at` + 409) would do the opposite: all N calls start with the same timestamp, one wins, the other N-1 get 409 and have to refetch+retry serially. That breaks the parallel-edit workflow agents rely on for efficiency.
+
+KAN-148's ticket description originally proposed optimistic locking ("Option A"). The pivot to row locking ("Option B") is documented in the [ticket's most recent comment](https://tiddly.atlassian.net/browse/KAN-148?focusedCommentId=10399).
+
+## Scope decision: KAN-149 closed without action
+
+KAN-149 covered the same bug class on three declarative-update endpoints (`PATCH /relationships/{id}`, `PATCH /content-filters/{id}`, `PUT /settings/sidebar`). After working through it, we closed it without action. Rationale:
+
+- **Frequency is effectively zero at current scale.** Each of those collisions requires user-driven concurrency on a single-user product: two of the same user's devices reordering the sidebar within the same second; two browser tabs editing the same filter at the same moment; two clients editing the same relationship description simultaneously. None of these workflows are common, and sidebar/filter/relationship-description edits in particular are setup-and-forget operations.
+- **Blast radius is small and recoverable.** Worst case is one device's reorder or one tab's edit doesn't stick. No data corruption, no downstream breakage; the user re-does a small action.
+- **Fix surface is meaningful.** Three backend schema + handler changes, three frontend store/hook + UI changes (including a response-schema reshape for sidebar's singleton shape), plus conflict UX design for surfaces that don't currently have one. Significant work for events that may happen zero times in a year.
+
+If product evolution introduces real multi-user collaboration on any of these surfaces (shared filters, team sidebars, etc.), the fix is straightforward to land at that point. Closed today as "won't fix at current scale" rather than left to drift in the backlog.
+
+This plan therefore covers only the KAN-148 surface.
+
+## Reference Documentation
+
+The agent **must** read these before implementing:
+
+- [PostgreSQL `SELECT ... FOR UPDATE` (locking clauses)](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE) — row-level locking semantics.
+- [PostgreSQL explicit locking — row-level locks](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS) — interaction with READ COMMITTED, savepoint behavior.
+- [SQLAlchemy 2.0 `Select.with_for_update()`](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.with_for_update) — how to issue `FOR UPDATE` in this codebase.
+- In-repo references to study first:
+  - `backend/src/api/helpers/conflict_check.py` — existing `check_optimistic_lock` / `check_optimistic_lock_by_name` helpers (kept in place; this PR is additive, not a swap).
+  - `backend/src/services/base_entity_service.py:254` (`get`) — the shape the new `get_for_update(...)` method should mirror.
+  - The three str-replace handlers in `backend/src/api/routers/{bookmarks,notes,prompts}.py` — the integration points.
+
+## Agent Behavior Rules
+
+- **Complete one milestone fully (implementation + tests + docs) before moving on.** Stop and wait for human review at each milestone boundary.
+- **Ask clarifying questions** rather than guessing. Especially: prompt by-name vs. by-id str-replace endpoints, the existence of a concurrent-async-session test fixture, and the savepoint-interaction question raised in M3.
+- **No backwards-compatibility shims required.** Clean design wins. Breaking internal call sites is acceptable if a cleaner interface emerges.
+- **Use scoped verify commands:** `make backend-verify` for each milestone. Do not run `make tests` (full suite).
+- **Never skip or weaken tests to make them pass.** If a test fails, investigate the root cause.
+- **No commits without explicit human approval.** Stage and show diffs; wait for sign-off.
+
+---
+
+## Milestone 1 — Pre-flight Audit (Backend, Read-Only) — COMPLETE
+
+### Goal & Outcome
+
+Confirm the scope before changing code. Surface anything the ticket or this plan may have missed, and de-risk M2/M3 by verifying assumptions about transaction scope and test fixtures.
+
+### Findings (recorded inline)
+
+**1. Four str-replace endpoints, not three.** Confirmed inventory:
+
+| Endpoint | File:Line | Lookup | Service call to swap in M3 |
+|---|---|---|---|
+| `PATCH /bookmarks/{id}/str-replace` | `backend/src/api/routers/bookmarks.py:457` | by id | `bookmark_service.get(..., include_archived=True)` → `get_for_update(...)` |
+| `PATCH /notes/{id}/str-replace` | `backend/src/api/routers/notes.py:380` | by id | `note_service.get(..., include_archived=True)` → `get_for_update(...)` |
+| `PATCH /prompts/{id}/str-replace` | `backend/src/api/routers/prompts.py:888` | by id | `prompt_service.get(..., include_archived=True)` → `get_for_update(...)` |
+| `PATCH /prompts/name/{name}/str-replace` | `backend/src/api/routers/prompts.py:502` | by name | `prompt_service.get_by_name(...)` → `get_by_name_for_update(...)` |
+
+The by-name path is the path the Prompt MCP `edit_prompt_content` tool actually hits — must be in scope.
+
+**2. No per-entity `get(...)` overrides.** `bookmark_service.py`, `note_service.py`, `prompt_service.py` all use `BaseEntityService.get(...)` unmodified. Safe to mirror with `get_for_update(...)` on the base.
+
+**3. Single transaction per request — confirmed.** `backend/src/db/session.py:32` wraps each request in `async with async_session_factory()` with one commit at the end. Row locks acquired in the handler are released at request commit/rollback.
+
+**4. `expected_updated_at` callers to str-replace endpoints: zero.** Verified across frontend, CLI, Chrome extension, Content MCP, and Prompt MCP. The `check_optimistic_lock*` calls at the top of all 4 str-replace handlers are dead code today; the `expected_updated_at` field on `StrReplaceRequest` / `PromptStrReplaceRequest` is never set. Per M3.3's rule, this means **remove**. See M3 for the full cleanup.
+
+**5. `check_optimistic_lock*` helper definitions stay.** Verified the two helpers in `backend/src/api/helpers/conflict_check.py` are also called by the regular (non-str-replace) PATCH handlers: `notes.py:364`, `bookmarks.py:431`, `prompts.py:861` use `check_optimistic_lock`; `prompts.py:470` uses `check_optimistic_lock_by_name`. M3 removes only the str-replace call sites, not the helpers.
+
+**6. Concurrent-session test fixture does NOT exist, and the current setup actively blocks adding the obvious version.** `backend/tests/conftest.py:247` defines `db_session_factory` bound to a single `db_connection` with `join_transaction_mode="create_savepoint"`. All "concurrent" sessions share one physical connection and one outer transaction, so they cannot contend for a Postgres row lock. Adding a true concurrent fixture is scoped into M2 (see M2 implementation outline).
+
+**7. Broader audit (declarative-replacement PATCH calls without `expected_updated_at`): no new gaps.** Frontend Prompt/Note/Bookmark editors pass `expected_updated_at` on the standard PATCH path. MCP `update_item` / `update_prompt` tools accept and forward it. No follow-up tickets needed.
+
+### Stopping rule
+
+No new findings to file. Audit complete.
+
+---
+
+## Milestone 2 — `get_for_update(...)` on `BaseEntityService` + Concurrent-Session Test Fixture (Backend)
+
+### Goal & Outcome
+
+Add a dedicated `get_for_update(...)` method on `BaseEntityService` and `get_by_name_for_update(...)` on `PromptService` (M1 confirmed the by-name path is in scope), so str-replace handlers can request a row lock with explicit, self-documenting intent at the call site. Also add the concurrent-session test fixture needed to exercise real Postgres lock contention.
+
+- After this milestone, locking-intent is visible at every call site. A future read-only handler cannot accidentally hold a row lock by typo'ing a kwarg.
+- After this milestone, the test suite has a reusable concurrent-session fixture that can prove cross-transaction row-lock behavior.
+
+### Implementation Outline
+
+#### 2a. New concurrent-session test fixture
+
+The existing `db_session_factory` in `backend/tests/conftest.py:247` is bound to a single `db_connection` with `join_transaction_mode="create_savepoint"` — all sessions from it share one physical connection and one outer transaction, so they cannot contend for row locks. We need a separate fixture with independent connections.
+
+Design:
+
+- **Separate engine.** Module-scoped (or session-scoped) `create_async_engine(database_url, ...)` instance, distinct from the test-isolation engine. `pool_size` ≥ 4 (covers the max concurrent sessions any test uses, plus headroom).
+- **Distinct name.** Call it `concurrent_session_factory` (and `concurrent_engine`) so its non-default semantics are obvious at the test definition site.
+- **No outer-transaction wrapper.** Each session opens its own transaction; tests commit/rollback explicitly.
+- **Per-test isolation via unique `user_id`.** Each concurrency test creates its own user (or uses an autouse fixture that yields a fresh UUID), seeds the entities it needs under that user_id, and runs `DELETE WHERE user_id=...` in a `finally` block. Fast, deterministic, no bleed between tests.
+- **Location.** Put the fixture in a new `backend/tests/conftest_concurrent.py` or scoped under `backend/tests/services/conftest.py` — whichever fits existing conventions. Do not pollute the root `conftest.py` with a fixture only a small subset of tests uses.
+
+#### 2b. `get_for_update(...)` on `BaseEntityService`
+
+A separate method beats a `for_update=True` kwarg on `get(...)`: the name forces the caller to think about transaction context, matches how SQLAlchemy/Django patterns typically separate locking from plain reads, and removes the footgun of a one-character typo silently holding row locks for the request lifetime.
+
+```python
+async def get_for_update(
+    self,
+    db: AsyncSession,
+    user_id: UUID,
+    entity_id: UUID,
+    *,
+    include_archived: bool = False,
+) -> T | None:
+    """
+    Fetch an entity and acquire a SELECT ... FOR UPDATE row lock.
+
+    MUST be called inside a transaction. The lock is held until the
+    transaction commits or rolls back. Use only when the same request
+    will issue an UPDATE on the returned entity.
+    """
+    query = (
+        select(self.model)
+        .options(selectinload(self.model.tag_objects))
+        .where(self.model.id == entity_id, self.model.user_id == user_id)
+        .where(self.model.deleted_at.is_(None))
+        .with_for_update()
+    )
+    if not include_archived:
+        query = query.where(~self.model.is_archived)
+    ...
+```
+
+Note the dropped `include_deleted` parameter — str-replace never operates on soft-deleted entities, so the locking path doesn't need it. Keep the API minimal; add the kwarg back only if a real caller emerges.
+
+#### 2c. `PromptService.get_by_name_for_update(...)`
+
+Mirror `PromptService.get_by_name(...)` (`backend/src/services/prompt_service.py:513`), but append `.with_for_update()`. Returns active prompts only (excludes deleted and archived) — same semantics as the existing `get_by_name`.
+
+### Testing Strategy
+
+In the appropriate per-service or `BaseEntityService` test file (match existing convention), using the new `concurrent_session_factory`:
+
+- **Lock-blocks-write test:** Session A calls `get_for_update(...)` on a row. Session B issues an `UPDATE` on the same row. Assert B blocks until A commits/rolls back. (Use `asyncio.wait_for(..., timeout=2)` to verify B does not return immediately.)
+- **Lock-blocks-lock test:** Session A calls `get_for_update(...)`. Session B calls `get_for_update(...)` on the same row. Assert B blocks until A releases.
+- **Plain-get-doesn't-block test:** Session A calls `get_for_update(...)`. Session B calls plain `get(...)`. Assert B returns immediately (Postgres `FOR UPDATE` does not block plain `SELECT`).
+- **Lock-released-on-commit test:** After A commits, B's blocked call unblocks and reads the post-commit state.
+- **Lock-released-on-rollback test:** After A rolls back, B's blocked call unblocks and reads the pre-A state.
+- **By-name lock test:** One test per the above shape (or a single parametrized test) covering `get_by_name_for_update(...)` on `PromptService`.
+
+Avoid testing things that are Postgres's responsibility (deadlock detection, lock fairness). Test only that the wrapper correctly issues `FOR UPDATE`.
+
+### Stop here for review.
+
+---
+
+## Milestone 3 — Apply Row Locking to str-replace Endpoints (Backend)
+
+### Goal & Outcome
+
+Close the lost-update race on the str-replace endpoints by switching their entity fetch from `service.get(...)` to `service.get_for_update(...)`. No changes to MCP tools, request schemas, or any external caller.
+
+- After this milestone, N parallel str-replace calls to the same entity all succeed (assuming their `old_str` patterns still match in the evolving content), with no lost updates and a coherent history trail.
+
+### Implementation Outline
+
+For each of the 4 str-replace endpoints confirmed in M1 (`notes.py:380`, `bookmarks.py:457`, `prompts.py:888` by id, `prompts.py:502` by name):
+
+1. Replace the entity fetch with the locking variant. Example for notes:
+   ```python
+   note = await note_service.get(db, current_user.id, note_id, include_archived=True)
+   ```
+   becomes:
+   ```python
+   note = await note_service.get_for_update(db, current_user.id, note_id, include_archived=True)
+   ```
+   For the by-name path: `prompt_service.get_by_name(...)` → `prompt_service.get_by_name_for_update(...)`.
+2. Confirm the entire read-modify-write-history sequence executes inside a single transaction (the FastAPI `get_async_session` dependency ensures this — M1 confirmed).
+3. **Remove the dead optimistic-lock plumbing.** M1 confirmed zero callers pass `expected_updated_at` to any str-replace endpoint. Cleanup:
+   - Remove the `check_optimistic_lock(...)` call from `bookmarks.py:500`, `notes.py:423`, `prompts.py:954`.
+   - Remove the `check_optimistic_lock_by_name(...)` call from `prompts.py:535`.
+   - Remove the `expected_updated_at` field from `StrReplaceRequest` (used by bookmarks + notes) and `PromptStrReplaceRequest` (used by both prompt str-replace endpoints).
+   - **Keep** the `check_optimistic_lock` / `check_optimistic_lock_by_name` helper definitions in `backend/src/api/helpers/conflict_check.py` — they are still used by the regular PATCH handlers (`notes.py:364`, `bookmarks.py:431`, `prompts.py:861`, `prompts.py:470`).
+   - Update or remove any tests that asserted str-replace honored `expected_updated_at`. Cover the new behavior with the M3 concurrency tests below.
+
+### Testing Strategy
+
+Per str-replace endpoint, add a concurrency integration test:
+
+- **Concurrent non-overlapping str-replace test:** Spawn N (e.g., 5) concurrent str-replace tasks against the same entity with distinct, non-overlapping `old_str` patterns that all exist in the original content. Await all. Assert all N return success **and** the final content reflects all N edits.
+- **Concurrent overlapping str-replace test:** Two concurrent str-replace calls where one removes the substring the other is trying to match. Assert the second returns the existing `no_match` 400 (the correct conflict signal for content-addressable operations), not a silent overwrite.
+- **History coherence test:** After concurrent edits, verify the history rows form a coherent chain — each row's `previous_content` matches the prior row's `new_content`.
+- **Savepoint × row-lock primitive test (one assertion is enough):** Direct primitive test using `concurrent_session_factory`. Session A acquires `FOR UPDATE` on a seeded row, opens `db.begin_nested()`, raises inside the nested block to force a savepoint rollback, catches the error. Then session B issues `FOR UPDATE` on the same row and is asserted to block (`asyncio.wait_for(..., timeout=1)` → `TimeoutError`). No `history_service` involvement — this test proves the Postgres semantic ("row locks survive savepoint rollback") directly, with no coupling to history-recording internals or end-to-end flakiness.
+
+Use real Postgres (not mocks). Follow existing async test fixtures.
+
+### Documentation Updates
+
+- `docs/architecture.md` — add a short subsection (~10 lines) under whatever section covers the API layer or data integrity, explaining the row-locking vs. optimistic-locking choice by operation semantics. Include one note: "If FK-insert contention against locked rows ever becomes measurable, `FOR NO KEY UPDATE` (`.with_for_update(key_share=False)` in SQLAlchemy — verify the exact spelling against current docs) is a less-restrictive alternative. Not needed at current scale." Also note that Postgres savepoints do not release row locks held by the outer transaction (cite the explicit-locking docs).
+- No changes to `AGENTS.md`, `README.md`, or user-facing docs — this is internal correctness.
+
+### Stop here for review.
+
+---
+
+## Milestone 4 — Final Docs Pass and PR Description
+
+### Goal & Outcome
+
+Catch any documentation drift caused by M2/M3 and prepare the PR description.
+
+- After this milestone, the PR is ready for human review and (after approval) commit.
+
+### Implementation Outline
+
+1. Re-read `AGENTS.md`'s "Files to Keep in Sync" section. Update any listed file whose content is now stale (likely only `docs/architecture.md`, already covered in M3).
+2. Verify nothing else in `docs/` references the old behavior.
+3. Draft the PR description with:
+   - One-paragraph framing: what the bug class is, why row locking is the right defense for content-addressable operations.
+   - Per-milestone summary of what shipped.
+   - Verification matrix: every endpoint touched, its concurrency test.
+   - **Schema change callout:** `expected_updated_at` removed from `StrReplaceRequest` and `PromptStrReplaceRequest`. M1 confirmed zero current callers, but flag it explicitly in the PR description so reviewers and downstream integrators don't miss it.
+   - Note on KAN-149's closure decision (link to the ticket comment) — for the reviewer's context.
+   - Any follow-up tickets filed from M1's broader audit (none expected per M1's findings).
+
+### Testing Strategy
+
+Final pass: `make backend-verify` green on the full set of changes.
+
+### Stop here for final review. **Do not commit or push without explicit human approval.**
+
+---
+
+## Risks and Non-Goals
+
+**Risks:**
+
+- `with_for_update()` on a row with no other contenders is essentially free. Under heavy same-entity contention it serializes — but the str-replace path is microseconds, so serialization is invisible in practice. Noted in the architecture doc.
+- If any service `get(...)` is overridden per-entity in a way that diverges from the base, the new `get_for_update(...)` could behave inconsistently. M1's audit verifies the call paths.
+
+**Non-goals (explicitly out of scope, file separate tickets if found):**
+
+- Changing the MCP tool signatures for str-replace. The original KAN-148 "Option A" is intentionally rejected — see the ticket comment.
+- Adding `expected_updated_at` back to str-replace requests. M1 confirmed it has no callers and is removed in M3. The optimistic-lock mechanism still applies (and stays) on the regular PATCH endpoints.
+- Fixing the declarative-update endpoints covered by KAN-149 (relationships, content-filters, sidebar). KAN-149 was closed without action — see "Scope decision" above.
+- Any change to the history-recording layer. KAN-148 confirms the existing retry/savepoint logic is correct.
+- Using `FOR NO KEY UPDATE` instead of `FOR UPDATE`. Noted as a possible future optimization in the architecture doc; not justified at current scale.

--- a/docs/implementation_plans/2026-05-11-lost-update-race.md
+++ b/docs/implementation_plans/2026-05-11-lost-update-race.md
@@ -206,8 +206,8 @@ Per str-replace endpoint, add a concurrency integration test:
 
 - **Concurrent non-overlapping str-replace test:** Spawn N (e.g., 5) concurrent str-replace tasks against the same entity with distinct, non-overlapping `old_str` patterns that all exist in the original content. Await all. Assert all N return success **and** the final content reflects all N edits.
 - **Concurrent overlapping str-replace test:** Two concurrent str-replace calls where one removes the substring the other is trying to match. Assert the second returns the existing `no_match` 400 (the correct conflict signal for content-addressable operations), not a silent overwrite.
-- **History coherence test:** After concurrent edits, verify the history rows form a coherent chain — each row's `previous_content` matches the prior row's `new_content`.
-- **Savepoint × row-lock primitive test (one assertion is enough):** Direct primitive test using `concurrent_session_factory`. Session A acquires `FOR UPDATE` on a seeded row, opens `db.begin_nested()`, raises inside the nested block to force a savepoint rollback, catches the error. Then session B issues `FOR UPDATE` on the same row and is asserted to block (`asyncio.wait_for(..., timeout=1)` → `TimeoutError`). No `history_service` involvement — this test proves the Postgres semantic ("row locks survive savepoint rollback") directly, with no coupling to history-recording internals or end-to-end flakiness.
+- **History version-allocation test:** After concurrent edits, verify `history_service.record_action` produces exactly N UPDATE rows with unique, dense version numbers (no duplicates, no gaps). This proves the history-layer savepoint-retry loop survives contention. **Not a content-chain coherence test** — the load-bearing proof that the row lock fixed the lost-update bug on entity content is the non-overlapping test above (final content reflects all N edits). A real chain-coherence test belongs in `test_history_service.py` exercising the history service directly; out of scope for KAN-148.
+- **Savepoint × row-lock primitive test (one assertion is enough):** Direct primitive test using `concurrent_session_factory`. Session A acquires `FOR UPDATE` on a seeded row, opens `db.begin_nested()`, raises inside the nested block to force a savepoint rollback, catches the error. From a *second* session, issue `SELECT ... FOR UPDATE NOWAIT` on the same row — assert it raises `DBAPIError` for `LockNotAvailableError`, proving A still holds the lock after the savepoint rollback. NOWAIT is unambiguous (it answers exactly "is the row locked right now?") and avoids the conflated implicit write lock that an "A mutates + B reads sentinel" pattern would introduce — A's `UPDATE` would itself acquire a write lock and block B regardless of whether the `FOR UPDATE` survived.
 
 Use real Postgres (not mocks). Follow existing async test fixtures.
 
@@ -237,6 +237,15 @@ Catch any documentation drift caused by M2/M3 and prepare the PR description.
    - Per-milestone summary of what shipped.
    - Verification matrix: every endpoint touched, its concurrency test.
    - **Schema change callout:** `expected_updated_at` removed from `StrReplaceRequest` and `PromptStrReplaceRequest`. M1 confirmed zero current callers, but flag it explicitly in the PR description so reviewers and downstream integrators don't miss it.
+   - **Manual verification** — short checklist for the reviewer to run by hand before merging. The automated tests already cover the lock semantics, so this section is just smoke checks for things that are hard to test automatically:
+     - **MCP str-replace tools (the real production callers):**
+       - `edit_content` (Content MCP) against a bookmark and a note — verify the operation succeeds and content updated as expected.
+       - `edit_prompt_content` (Prompt MCP) — verify success.
+       - Attempt a `no_match` (target a substring that does not exist) — verify the structured 400 error still surfaces cleanly to the MCP client.
+     - **Regular PATCH endpoints — no collateral damage from the schema/handler changes:**
+       - Edit a bookmark, note, and prompt via the web UI; save; reload; confirm changes persisted.
+       - Confirm `expected_updated_at` still triggers 409 on the *regular* PATCH (this PR removed it only from str-replace): open the same entity in two browser tabs, edit and save in one, then save in the other — second save should show the conflict UI.
+     - **API self-check:** send a str-replace request that includes `expected_updated_at` in the body. The field is **silently ignored** — the Pydantic v2 request models in `schemas/errors.py` don't set `extra="forbid"`, and the v2 default is `extra="ignore"`. So existing MCP/CLI payloads that still include the field won't error; the PR description's schema-change callout is what tells integrators to drop it.
    - Note on KAN-149's closure decision (link to the ticket comment) — for the reviewer's context.
    - Any follow-up tickets filed from M1's broader audit (none expected per M1's findings).
 


### PR DESCRIPTION
## Summary

The four MCP-shaped `PATCH /<entity>/{id}/str-replace` endpoints (bookmarks, notes, prompts by-id and by-name) did an unprotected read-modify-write on the entity's `content` field. Under Postgres's default `READ COMMITTED`, two concurrent calls against the same entity could each read the same content, each compute a new version locally, and each write — second commit silently overwriting the first.

In production today this rarely manifests because end-to-end serialization (single uvicorn worker, HTTP client behavior, fast hot path) hides it. The realistic scenario that would surface it is AI agents firing parallel `edit_content` / `edit_prompt_content` calls against the same entity — common enough on the near horizon to warrant fixing now.

**Fix:** acquire a `SELECT ... FOR UPDATE` row lock at fetch time. Parallel str-replace calls against the same entity now serialize at the database; each acquires the lock in turn, reads the **current** content, applies its replacement against fresh state, and commits. All N succeed (assuming patterns still match). No round-trip retries, no agent-side timestamp tracking.

Row locking is the right primitive here because str-replace is **content-addressable** (the operation specifies "find `old_str`, replace with `new_str`"). There's no client-side state assertion to validate; the existing `no_match` 400 is already the correct error signal when the operation's premise no longer holds. Optimistic locking (`expected_updated_at` → 409) is intentionally rejected for this endpoint family — it would force N-1 of N concurrent calls into refetch-and-retry loops, defeating parallel-edit workflows. Both mechanisms are now explained side-by-side in `docs/architecture.md` §4.

KAN-148 ticket: https://tiddly.atlassian.net/browse/KAN-148. The sibling ticket KAN-149 (same bug class on the declarative-update endpoints — relationships, content-filters, sidebar) was closed without action; rationale recorded in the implementation plan's "Scope decision" section.

## Changes

**Locking primitives (`backend/src/services/`)**
- New `BaseEntityService.get_for_update(...)` issues `SELECT ... FOR UPDATE` within the caller's transaction. Soft-deleted rows are always excluded; tag eager-loading is intentionally omitted (handlers refresh `tag_objects` post-flush when needed).
- New `PromptService.get_by_name_for_update(...)` mirrors the by-name read path.
- Extracted `_attach_content_length` helper to dedupe identical post-load attachment logic across `get` / `get_for_update` / `get_by_name` / `get_by_name_for_update`.

**Handler edits (`backend/src/api/routers/`)**
- All four str-replace handlers switched from `service.get(...)` to `get_for_update(...)` / `get_by_name_for_update(...)`. Lock is held until the FastAPI request transaction commits.
- Removed the dead `check_optimistic_lock*` calls from each handler (M1 audit confirmed zero callers passed `expected_updated_at` to str-replace). The helper definitions in `conflict_check.py` remain — the regular PATCH endpoints still use them.

**Schema change**
- `expected_updated_at` removed from `StrReplaceRequest` and `PromptStrReplaceRequest`. Existing payloads sending the field continue to work (Pydantic v2's default `extra="ignore"`) — silently dropped rather than 422'd. MCP/CLI integrators can drop the field from their payloads at their convenience; no immediate action required on their part.

**`changed_fields` accuracy on str-replace history rows**
- Pre-existing imprecision surfaced during manual verification: str-replace history rows had `changed_fields=null`, while regular PATCH UPDATE rows correctly recorded the diff. Frontend version-diff UI uses this column for highlights. Now correctly records `["content"]` (bookmarks/notes), `["arguments"]`, `["content"]`, or `["content", "arguments"]` (prompts) based on structural comparison.
- Closed a related ghost-write bug on the prompt path: sending `arguments=[same as existing]` with unchanged content bumped `updated_at` and wrote a meaningless history row. The no-op early-return only checked `data.arguments is None`. Now extended to structural equality, aligning str-replace with the regular update path's `_compute_changed_fields` pattern.

**Test infrastructure**
- New `concurrent_engine` / `concurrent_session_factory` / `concurrent_test_user` fixtures (`backend/tests/conftest.py`). The standard `db_session_factory` binds every session to a single connection wrapped in one outer transaction, so cross-session lock contention is impossible in that shape. The new fixtures provide independent connections; per-test user with FK-cascade cleanup.
- New `concurrent_client` fixture: PAT-authenticated test client whose `get_async_session` override yields a fresh session per request — `asyncio.gather` of multiple HTTP calls actually contends at the DB layer.

**Tests**
- `backend/tests/services/test_get_for_update.py` (450 lines, new) — filter contract + lock semantics for both locking variants. Blocking proofs use `SELECT ... FOR UPDATE NOWAIT` probes for deterministic lock-state assertions (no timing dependence on `TimeoutError`).
- `backend/tests/api/test_str_replace_concurrency.py` (362 lines, new) — parametrized across all 4 endpoints: N=5 parallel non-overlapping edits all compose into final content, overlapping edits surface as 200/400 with `no_match`, history rows show contiguous unique versions and the right `changed_fields`.
- `backend/tests/api/test_prompts.py` — 5 new tests covering the three `changed_fields` state transitions, the true no-op case, and the by-id handler.
- `backend/tests/api/test_optimistic_locking.py` — parametrized regression test pinning the silent-ignore behavior of `expected_updated_at` on str-replace; old str-replace + `expected_updated_at` tests removed (no longer applicable).

**Docs**
- `docs/architecture.md` §4 — new "Concurrency control for content edits" subsection explaining optimistic-vs-row-locking by operation semantics, the savepoint × row-lock invariant, and `FOR NO KEY UPDATE` as a future tuning option.
- `docs/implementation_plans/2026-05-11-lost-update-race.md` — full implementation plan (audit findings + per-milestone scope) committed for posterity.

## Impact

**Breaking changes to internal API contracts:**
- `StrReplaceRequest` and `PromptStrReplaceRequest` no longer declare `expected_updated_at`. Existing payloads sending the field continue to succeed (silently ignored). Regular PATCH endpoints still honor it — only str-replace changed.

**Behavior changes:**
- Concurrent str-replace calls against the same entity now serialize at the database instead of racing. Expected user-facing impact: AI-agent parallel-edit workflows now work as intended.
- Prompt str-replace with `arguments=[identical to existing]` and unchanged content is now a true no-op (no `updated_at` bump, no history row) — was a ghost write under the prior implementation.

**No deployment considerations.** No new dependencies, no migrations, no env vars. Backend-only; frontend untouched.

**Manual verification performed:** All four endpoints exercised end-to-end (direct API + Content MCP + Prompt MCP), including 50× parallel stress tests through both MCP servers. Final content composes every edit; history versions are contiguous; diff chains walk back to the seed content coherently. See KAN-148 ticket comments for details.