### PR TITLE
Use Cache-Control: no-cache to fix Safari stale reads after MCP edits

### DIFF
--- a/backend/src/core/http_cache.py
+++ b/backend/src/core/http_cache.py
@@ -7,9 +7,33 @@ from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 
-# Headers for cacheable responses
+# Headers for cacheable responses.
+#
+# IMPORTANT: `no-cache` is intentional — do NOT change to `must-revalidate` alone.
+#
+# Per RFC 7234 §4.2.2, a response with `Last-Modified` but no explicit freshness
+# (`max-age` / `Expires` / `no-cache`) is eligible for *heuristic freshness*: caches
+# may infer a freshness lifetime as ~10% of (now - Last-Modified). During that
+# window, the cache serves the entry WITHOUT contacting the origin. `must-revalidate`
+# does NOT prevent this — it only governs behavior AFTER the entry becomes stale.
+#
+# Safari applies heuristic freshness aggressively to API responses; current Chrome
+# does not (it revalidates regardless). With `must-revalidate` alone, the symptom
+# was: an out-of-band edit (e.g., via the MCP server while a prompt is open in
+# Safari) was silently invisible on navigate-back, because Safari served the
+# stale entry from cache without ever asking the server. The "Load Latest" flow
+# papered over the immediate symptom via cache-busting query param (?_t=…), but
+# the canonical-URL cache entry stayed stale and subsequent navigate-backs
+# resurfaced the old content. The only user-visible recovery was logout/login
+# (which rotates the Auth0 JWT and changes the Vary cache key).
+#
+# `no-cache` forbids serving from cache without revalidation, eliminating the
+# heuristic-freshness loophole on every browser. The ETag middleware below still
+# returns 304 on unchanged content, so the bandwidth profile is unchanged — only
+# a ~1 KB headers round trip is added per cacheable GET. See `tests/core/
+# test_http_cache.py` for the regression test that pins this directive.
 CACHE_HEADERS = {
-    "Cache-Control": "private, must-revalidate",
+    "Cache-Control": "private, no-cache",
     "Vary": "Authorization",
 }
 

--- a/backend/tests/api/test_http_cache.py
+++ b/backend/tests/api/test_http_cache.py
@@ -193,7 +193,7 @@ class TestCachingHeaders:
         """200 response should include Cache-Control and Vary headers."""
         response = await client.get("/health")
         assert response.status_code == 200
-        assert response.headers.get("cache-control") == "private, must-revalidate"
+        assert response.headers.get("cache-control") == "private, no-cache"
         assert response.headers.get("vary") == "Authorization"
 
     async def test__caching_headers__present_on_304_response(
@@ -207,7 +207,7 @@ class TestCachingHeaders:
         # Request with matching ETag
         response2 = await client.get("/health", headers={"If-None-Match": etag})
         assert response2.status_code == 304
-        assert response2.headers.get("cache-control") == "private, must-revalidate"
+        assert response2.headers.get("cache-control") == "private, no-cache"
         assert response2.headers.get("vary") == "Authorization"
 
     async def test__caching_headers__etag_present_on_304(
@@ -220,6 +220,39 @@ class TestCachingHeaders:
         response2 = await client.get("/health", headers={"If-None-Match": etag})
         assert response2.status_code == 304
         assert response2.headers.get("etag") == etag
+
+    async def test__caching_headers__no_cache_directive_forbids_heuristic_freshness(
+        self, client: AsyncClient,
+    ) -> None:
+        """
+        Regression: Cache-Control MUST include `no-cache` (not just `must-revalidate`).
+
+        Per RFC 7234 §4.2.2, a response with `Last-Modified` but no explicit freshness
+        is eligible for heuristic freshness — caches (notably Safari) may infer a
+        lifetime of ~10% of (now - Last-Modified) and serve the entry WITHOUT contacting
+        the origin during that window. `must-revalidate` alone does NOT prevent this;
+        it only governs behavior after the entry is deemed stale.
+
+        Symptom of regressing this: out-of-band edits (e.g., via MCP) are silently
+        invisible on navigate-back in Safari. Recovery requires logout/login (which
+        rotates the Auth0 JWT and changes the Vary cache key).
+
+        See `backend/src/core/http_cache.py` `CACHE_HEADERS` comment for full context.
+        """
+        response = await client.get("/health")
+        cache_control = response.headers.get("cache-control", "")
+        directives = {d.strip().lower() for d in cache_control.split(",")}
+        assert "no-cache" in directives, (
+            f"Cache-Control must include 'no-cache' to prevent Safari heuristic "
+            f"freshness; got: {cache_control!r}"
+        )
+        # Also assert we did NOT regress to a permissive freshness directive.
+        forbidden_prefixes = ("max-age=", "s-maxage=", "stale-while-revalidate=")
+        for directive in directives:
+            assert not directive.startswith(forbidden_prefixes), (
+                f"Cache-Control must not include {forbidden_prefixes} on "
+                f"per-user API responses; got: {cache_control!r}"
+            )
 
 
 class TestSecurityHeadersOn304:
@@ -431,7 +464,7 @@ class TestCheckNotModified:
 
         result = check_not_modified(request, updated_at)
         assert result is not None
-        assert result.headers.get("cache-control") == "private, must-revalidate"
+        assert result.headers.get("cache-control") == "private, no-cache"
         assert result.headers.get("vary") == "Authorization"
         assert "last-modified" in result.headers
 


### PR DESCRIPTION
## Summary

Fixes a Safari-specific stale-content bug where prompts (and other cacheable resources) edited out-of-band — most commonly via the MCP server during agent sessions — kept displaying the pre-edit version on navigate-back, until the user logged out and back in.

## Root cause

With `Last-Modified` set but no explicit freshness directive, RFC 7234 §4.2.2 permits *heuristic freshness* — clients may infer a freshness lifetime of ~10% of `(now - Last-Modified)` and serve cached responses **without contacting the origin** during that window. For a prompt last modified 3 months ago, that window is on the order of 10 days.

Safari applies this aggressively to API responses; current Chrome does not. The previous `must-revalidate` directive only governs behavior *after* an entry goes stale, so it didn't prevent Safari's heuristic-freshness reads. The frontend's `?_t=` cache-busting (`usePrompts.ts:66`) fixed the explicit "Load Latest" path but left the canonical-URL cache entry untouched, so navigate-back kept resurfacing old content. Only logout/login recovered (new Auth0 JWT → different `Vary: Authorization` cache key).

## Changes

- `backend/src/core/http_cache.py` — `Cache-Control: private, must-revalidate` → `Cache-Control: private, no-cache`. Expanded the `CACHE_HEADERS` block comment to record the RFC mechanic, Safari-specific manifestation, MCP symptom, and the reason `must-revalidate` alone is insufficient. Intent: make accidental reversion to `must-revalidate` in a future "simplify" pass loud rather than silent.
- `backend/tests/api/test_http_cache.py` — updated existing assertions to the new directive; added `test__caching_headers__no_cache_directive_forbids_heuristic_freshness` which pins both the presence of `no-cache` and the absence of permissive freshness directives (`max-age=N`, `s-maxage=N`, `stale-while-revalidate=N`). Test docstring repeats the rationale so anyone touching it sees the reasoning without having to read the source comment.

## Impact

- **No breaking API contract change.** `no-cache` is strictly more conservative than `must-revalidate`; it cannot cause new stale reads anywhere.
- **Bandwidth profile unchanged.** ETag middleware still returns 304 on unchanged content; the only added cost is ~1 KB of headers per cacheable GET per navigation. In Chrome, this is already what was happening (Chrome wasn't applying heuristic freshness). Safari is now brought in line.
- **Mobile client compatibility:** `no-cache` is HTTP-standard and strictly more conservative; iOS `URLSession`/`URLCache`, Android `OkHttp`, and similar clients treat it the same or stricter than `must-revalidate`. No-op for any compliant client; non-breaking for offline caching (still uses `URLCache` storage, just requires revalidation when online).
- **Affects all cacheable GETs** (prompts, notes, bookmarks, metadata endpoints) since `CACHE_HEADERS` is centralized. Same fix, uniformly applied.

## Verification

- `pytest backend/tests/api/test_http_cache.py` — all 51 tests pass, including the new regression.
- `ruff check` on both changed files — clean.
- Manual reproduction in Safari (production) confirmed the bug; verifying the fix resolves it should be part of the post-deploy smoke test.

## Post-deploy follow-up

- Smoke-test in Safari: open an aged prompt → edit via MCP/agent → "Load Latest" → navigate away → navigate back → confirm edit persists.
- Throwaway prompt `zz-cache-debug-throwaway-delete-me` was created in production during debugging and needs to be deleted via the web UI (no MCP delete tool).
- `?_t=` cache-bust in `usePrompts.ts` is now redundant but harmless; worth removing in a follow-up PR after we confirm the server-side fix lands cleanly.