### PR TITLE
Add Antigravity MCP support; remove manual setup flow

### DIFF
--- a/cli/cmd/mcp.go
+++ b/cli/cmd/mcp.go
@@ -33,7 +33,7 @@ func newMCPCmd() *cobra.Command {
 	mcpCmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Manage MCP server integrations",
-		Long: `Configure and manage MCP (Model Context Protocol) servers for AI tools like Claude Desktop, Claude Code, and Codex.
+		Long: `Configure and manage MCP (Model Context Protocol) servers for AI tools like Claude Desktop, Claude Code, Codex, and Antigravity.
 
   tiddly mcp configure           Auto-detect tools and configure MCP servers
   tiddly mcp status              Show MCP configuration for all tools
@@ -68,7 +68,7 @@ If a CLI-managed entry already exists but points at a URL that's not the expecte
 Before destructive writes, the existing config file is copied to <path>.bak.<timestamp> alongside the original.
 
 Tools:
-  claude-desktop, claude-code, codex (auto-detect if omitted)
+  claude-desktop, claude-code, codex, antigravity (auto-detect if omitted)
 
 Scope:
   The --scope flag controls where the MCP server config is written. The default is "user",
@@ -76,6 +76,7 @@ Scope:
 
   user       Configuration available everywhere for the user
   directory  Configuration only applies when running tools from a specific directory
+             (not supported by claude-desktop or antigravity, which are user-scope only)
 
 Examples:
   tiddly mcp configure                                  Auto-detect and configure for all found tools
@@ -298,7 +299,7 @@ Claude Desktop users: restart Claude Desktop after removing.
 Use --servers to scope the removal to only content or only prompts, leaving the other CLI-managed entry untouched.
 
 Tools:
-  claude-desktop, claude-code, codex
+  claude-desktop, claude-code, codex, antigravity
 
 Examples:
   tiddly mcp remove claude-code                          Remove CLI-managed entries

--- a/cli/cmd/skills.go
+++ b/cli/cmd/skills.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/shane-kercheval/tiddly/cli/internal/api"
@@ -86,10 +87,13 @@ Examples:
 			if len(args) > 0 {
 				tools = args
 			} else {
-				// Auto-detect tools
+				// Auto-detect tools. Filter to skills-supported tools only:
+				// some MCP tools (e.g. antigravity) are detectable for MCP
+				// configuration but have no Tiddly skills integration, so they
+				// must not leak into skills auto-detection.
 				detected := mcp.DetectAll(appDeps.handlers(), appDeps.ExecLooker)
 				for _, t := range detected {
-					if t.Detected {
+					if t.Detected && slices.Contains(validSkillsTools, t.Name) {
 						tools = append(tools, t.Name)
 					}
 				}

--- a/cli/internal/mcp/antigravity.go
+++ b/cli/internal/mcp/antigravity.go
@@ -1,0 +1,257 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// antigravityHTTPEntry is the JSON structure for an HTTP MCP server in
+// Antigravity's mcp_config.json. Antigravity uses "serverUrl" (not "url" like
+// Claude Code/Desktop) and does not require a "type" field for HTTP transport
+// — empirically confirmed against agy 1.0.0, where a bare serverUrl + headers
+// entry loads and connects. Defined for clarity at the write site only; reads
+// go through the shared map[string]any round-trip so non-canonical user
+// entries (including stdio servers) survive untouched.
+type antigravityHTTPEntry struct {
+	ServerURL string            `json:"serverUrl"`
+	Headers   map[string]string `json:"headers,omitempty"`
+}
+
+// readAntigravityConfig reads mcp_config.json. A missing OR empty/whitespace
+// file yields an empty config: agy creates empty mcp_config.json files (M1
+// observed this), so an empty file is a valid "no servers configured yet"
+// state, not an error. This is a deliberate asymmetry from the Claude handlers,
+// which hard-fail on unreadable files — they don't create empty ones, so the
+// tolerance isn't warranted there. Non-empty malformed JSON still returns a
+// parse error so status/configure/dry-run fail closed rather than silently
+// treating a corrupt file as empty.
+func readAntigravityConfig(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]any{}, nil
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return config, nil
+}
+
+// extractAntigravityServerURL returns the HTTP URL agy actually loads from an
+// entry. agy 1.0.0 reads only the "serverUrl" field for HTTP MCP servers (M1
+// confirmed it silently ignores "url"/"httpUrl"). Reading serverUrl-only keeps
+// status and PAT extraction honest about what Antigravity will use, instead of
+// over-reporting a mis-keyed entry agy won't load.
+func extractAntigravityServerURL(serverMap map[string]any) string {
+	u, _ := serverMap["serverUrl"].(string)
+	return u
+}
+
+// extractAntigravityPATFromServer reads the Bearer token from an Antigravity
+// MCP server entry's headers.Authorization. Returns "" when absent/malformed.
+func extractAntigravityPATFromServer(server map[string]any) string {
+	headers, _ := server["headers"].(map[string]any)
+	if headers == nil {
+		return ""
+	}
+	authVal, _ := headers["Authorization"].(string)
+	return extractBearerToken(authVal)
+}
+
+// extractAllAntigravityTiddlyPATs returns every Bearer token from a tiddly-URL
+// entry in the Antigravity config, in canonical-first order. Entries without an
+// extractable PAT (missing/malformed headers) are filtered out. Read errors are
+// swallowed (returns nil), mirroring the other handlers' AllTiddlyPATs. URL
+// classification is serverUrl-only so token deletion targets only entries agy
+// actually loads.
+func extractAllAntigravityTiddlyPATs(configPath string) []TiddlyPAT {
+	config, err := readAntigravityConfig(configPath)
+	if err != nil {
+		return nil
+	}
+	servers, _ := config["mcpServers"].(map[string]any)
+	if servers == nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		names = append(names, name)
+	}
+	sortCanonicalFirst(names)
+
+	var out []TiddlyPAT
+	for _, name := range names {
+		serverMap, _ := servers[name].(map[string]any)
+		if serverMap == nil {
+			continue
+		}
+		urlStr := extractAntigravityServerURL(serverMap)
+		pat := extractAntigravityPATFromServer(serverMap)
+		if pat == "" {
+			continue
+		}
+		switch {
+		case isTiddlyContentURL(urlStr):
+			out = append(out, TiddlyPAT{ServerType: ServerContent, Name: name, PAT: pat})
+		case isTiddlyPromptURL(urlStr):
+			out = append(out, TiddlyPAT{ServerType: ServerPrompts, Name: name, PAT: pat})
+		}
+	}
+	return out
+}
+
+// extractAntigravityPATs returns PATs attached to canonical-named entries only.
+func extractAntigravityPATs(configPath string) PATExtraction {
+	return canonicalEntryPATs(extractAllAntigravityTiddlyPATs(configPath))
+}
+
+// buildAntigravityConfig reads the existing config (or creates empty) and writes
+// the CLI-managed entries under canonical names. Non-canonical entries —
+// including those pointing at Tiddly URLs under custom key names, and stdio
+// entries with command/args/env — are preserved as-is via the map round-trip.
+func buildAntigravityConfig(configPath, contentPAT, promptPAT string) (map[string]any, error) {
+	config, err := readAntigravityConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	servers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		servers = make(map[string]any)
+	}
+
+	if contentPAT != "" {
+		servers[serverNameContent] = antigravityHTTPEntry{
+			ServerURL: ContentMCPURL(),
+			Headers:   map[string]string{"Authorization": "Bearer " + contentPAT},
+		}
+	}
+	if promptPAT != "" {
+		servers[serverNamePrompts] = antigravityHTTPEntry{
+			ServerURL: PromptMCPURL(),
+			Headers:   map[string]string{"Authorization": "Bearer " + promptPAT},
+		}
+	}
+
+	config["mcpServers"] = servers
+	return config, nil
+}
+
+// configureAntigravity writes MCP server entries into the Antigravity config.
+// Returns the timestamped backup path (empty if no prior config existed).
+func configureAntigravity(configPath, contentPAT, promptPAT string) (backupPath string, err error) {
+	config, err := buildAntigravityConfig(configPath, contentPAT, promptPAT)
+	if err != nil {
+		return "", err
+	}
+	return writeJSONConfig(configPath, config)
+}
+
+// removeAntigravity deletes CLI-managed entries (canonical key names only) from
+// the Antigravity config. Non-canonical entries are preserved. A CLI-managed
+// entry is deleted regardless of what URL it currently points at; a user who
+// repurposed the slot gets the recovery backup instead.
+func removeAntigravity(configPath string, serverFilter []string) (*RemoveResult, error) {
+	result := &RemoveResult{}
+
+	// Malformed (non-empty unparseable) config surfaces an error rather than
+	// risking a clobbering write; missing/empty yields no servers to remove.
+	config, err := readAntigravityConfig(configPath)
+	if err != nil {
+		return result, err
+	}
+
+	servers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		return result, nil
+	}
+
+	targetNames := canonicalNamesForServers(serverFilter)
+	var removed []string
+	for name := range servers {
+		if targetNames[name] {
+			removed = append(removed, name)
+		}
+	}
+	if len(removed) == 0 {
+		return result, nil
+	}
+	sort.Strings(removed)
+	for _, name := range removed {
+		delete(servers, name)
+	}
+
+	config["mcpServers"] = servers
+	backupPath, werr := writeJSONConfig(configPath, config)
+	result.BackupPath = backupPath
+	if werr != nil {
+		return result, werr
+	}
+	result.RemovedEntries = removed
+	return result, nil
+}
+
+// statusAntigravity returns MCP servers configured in Antigravity.
+// Tiddly servers are identified by URL and listed in Servers; all others go to
+// OtherServers. Entries under canonical names are tagged MatchByName; others
+// MatchByURL.
+func statusAntigravity(configPath string) (StatusResult, error) {
+	result := StatusResult{ConfigPath: configPath}
+
+	// Surface malformed-file errors (matches statusClaudeDesktop); missing or
+	// empty files read as an empty config and report "not configured".
+	config, err := readAntigravityConfig(configPath)
+	if err != nil {
+		return result, err
+	}
+	servers, _ := config["mcpServers"].(map[string]any)
+	if servers == nil {
+		return result, nil
+	}
+
+	for name, entry := range servers {
+		serverMap, _ := entry.(map[string]any)
+		if serverMap == nil {
+			continue
+		}
+		urlStr := extractAntigravityServerURL(serverMap)
+		if match, other := classifyServer(name, urlStr, detectTransport(serverMap)); match != nil {
+			result.Servers = append(result.Servers, *match)
+		} else {
+			result.OtherServers = append(result.OtherServers, *other)
+		}
+	}
+
+	result.SortServers()
+	sortOtherServers(result.OtherServers)
+	return result, nil
+}
+
+// dryRunAntigravity returns the config that would be written without writing it.
+func dryRunAntigravity(configPath, contentPAT, promptPAT string) (before, after string, err error) {
+	existing, readErr := readAntigravityConfig(configPath)
+	if readErr != nil {
+		return "", "", readErr
+	}
+	beforeJSON, _ := json.MarshalIndent(existing, "", "  ")
+	before = string(beforeJSON)
+
+	config, err := buildAntigravityConfig(configPath, contentPAT, promptPAT)
+	if err != nil {
+		return "", "", err
+	}
+	afterJSON, _ := json.MarshalIndent(config, "", "  ")
+	after = string(afterJSON)
+
+	return before, after, nil
+}

--- a/cli/internal/mcp/antigravity_test.go
+++ b/cli/internal/mcp/antigravity_test.go
@@ -1,0 +1,459 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Configure tests
+
+func TestConfigureAntigravity__new_config(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	_, err := configureAntigravity(configPath, "bm_content", "bm_prompts")
+	require.NoError(t, err)
+
+	config := readTestJSON(t, configPath)
+	servers := config["mcpServers"].(map[string]any)
+
+	content := servers["tiddly_notes_bookmarks"].(map[string]any)
+	assert.Equal(t, ContentMCPURL(), content["serverUrl"])
+	headers := content["headers"].(map[string]any)
+	assert.Equal(t, "Bearer bm_content", headers["Authorization"])
+
+	// Antigravity uses serverUrl, not url/httpUrl, and no type field.
+	assert.NotContains(t, content, "url")
+	assert.NotContains(t, content, "httpUrl")
+	assert.NotContains(t, content, "type")
+
+	prompts := servers["tiddly_prompts"].(map[string]any)
+	assert.Equal(t, PromptMCPURL(), prompts["serverUrl"])
+}
+
+func TestConfigureAntigravity__preserves_existing(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			// A non-canonical HTTP server under a custom name.
+			"other_remote": map[string]any{
+				"serverUrl": "https://other.example.com/mcp",
+				"headers":   map[string]any{"Authorization": "Bearer keep-me"},
+			},
+			// A stdio server with command/args/env — must round-trip untouched.
+			"local_stdio": map[string]any{
+				"command": "npx",
+				"args":    []any{"-y", "some-mcp"},
+				"env":     map[string]any{"FOO": "bar"},
+			},
+		},
+	})
+
+	_, err := configureAntigravity(configPath, "bm_content", "bm_prompts")
+	require.NoError(t, err)
+
+	servers := readTestJSON(t, configPath)["mcpServers"].(map[string]any)
+
+	// Canonical entries added.
+	assert.Contains(t, servers, "tiddly_notes_bookmarks")
+	assert.Contains(t, servers, "tiddly_prompts")
+
+	// Non-canonical HTTP entry preserved verbatim.
+	other := servers["other_remote"].(map[string]any)
+	assert.Equal(t, "https://other.example.com/mcp", other["serverUrl"])
+
+	// Stdio entry preserved with all its fields.
+	stdio := servers["local_stdio"].(map[string]any)
+	assert.Equal(t, "npx", stdio["command"])
+	assert.Equal(t, []any{"-y", "some-mcp"}, stdio["args"])
+	assert.Equal(t, map[string]any{"FOO": "bar"}, stdio["env"])
+}
+
+// agy leaves empty mcp_config.json files on disk; configure must treat an
+// empty/whitespace file as a fresh start rather than hard-failing on a JSON
+// parse error.
+func TestConfigureAntigravity__empty_file_starts_fresh(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte("  \n"), 0644))
+
+	_, err := configureAntigravity(configPath, "bm_content", "bm_prompts")
+	require.NoError(t, err)
+
+	servers := readTestJSON(t, configPath)["mcpServers"].(map[string]any)
+	assert.Contains(t, servers, "tiddly_notes_bookmarks")
+	assert.Contains(t, servers, "tiddly_prompts")
+}
+
+// A non-empty malformed config must still fail rather than be clobbered.
+func TestConfigureAntigravity__malformed_file_errors(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte("{not valid json"), 0644))
+
+	_, err := configureAntigravity(configPath, "bm_content", "bm_prompts")
+	require.Error(t, err)
+}
+
+func TestConfigureAntigravity__content_only_preserves_existing_prompts(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	_, err := configureAntigravity(configPath, "bm_content1", "bm_prompts1")
+	require.NoError(t, err)
+
+	// Re-run with content only; prompts entry must survive.
+	_, err = configureAntigravity(configPath, "bm_content2", "")
+	require.NoError(t, err)
+
+	servers := readTestJSON(t, configPath)["mcpServers"].(map[string]any)
+	content := servers["tiddly_notes_bookmarks"].(map[string]any)
+	assert.Equal(t, "Bearer bm_content2", content["headers"].(map[string]any)["Authorization"])
+	prompts := servers["tiddly_prompts"].(map[string]any)
+	assert.Equal(t, "Bearer bm_prompts1", prompts["headers"].(map[string]any)["Authorization"])
+}
+
+// Remove tests
+
+func TestRemoveAntigravity__removes_canonical_only(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			"tiddly_notes_bookmarks": map[string]any{
+				"serverUrl": ContentMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_content"},
+			},
+			"tiddly_prompts": map[string]any{
+				"serverUrl": PromptMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_prompts"},
+			},
+			"work_prompts": map[string]any{
+				"serverUrl": PromptMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_work"},
+			},
+		},
+	})
+
+	result, err := removeAntigravity(configPath, []string{ServerContent, ServerPrompts})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"tiddly_notes_bookmarks", "tiddly_prompts"}, result.RemovedEntries)
+
+	servers := readTestJSON(t, configPath)["mcpServers"].(map[string]any)
+	assert.NotContains(t, servers, "tiddly_notes_bookmarks")
+	assert.NotContains(t, servers, "tiddly_prompts")
+	// Non-canonical Tiddly-URL entry preserved.
+	assert.Contains(t, servers, "work_prompts")
+}
+
+func TestRemoveAntigravity__servers_filter(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	_, err := configureAntigravity(configPath, "bm_content", "bm_prompts")
+	require.NoError(t, err)
+
+	result, err := removeAntigravity(configPath, []string{ServerContent})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tiddly_notes_bookmarks"}, result.RemovedEntries)
+
+	servers := readTestJSON(t, configPath)["mcpServers"].(map[string]any)
+	assert.NotContains(t, servers, "tiddly_notes_bookmarks")
+	assert.Contains(t, servers, "tiddly_prompts")
+}
+
+func TestRemoveAntigravity__missing_file_is_noop(t *testing.T) {
+	result, err := removeAntigravity("/nonexistent/mcp_config.json", []string{ServerContent, ServerPrompts})
+	require.NoError(t, err)
+	assert.Empty(t, result.RemovedEntries)
+}
+
+func TestRemoveAntigravity__no_canonical_entries_skips_write(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			"other": map[string]any{"serverUrl": "https://other.example.com/mcp"},
+		},
+	})
+
+	result, err := removeAntigravity(configPath, []string{ServerContent, ServerPrompts})
+	require.NoError(t, err)
+	assert.Empty(t, result.RemovedEntries)
+	assert.Empty(t, result.BackupPath)
+}
+
+// Status tests
+
+func TestStatusAntigravity__canonical_and_url_match(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			// Canonical name → MatchByName.
+			"tiddly_notes_bookmarks": map[string]any{
+				"serverUrl": ContentMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_content"},
+			},
+			// Custom name but Tiddly URL → MatchByURL.
+			"work_prompts": map[string]any{
+				"serverUrl": PromptMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_work"},
+			},
+			// Non-Tiddly → OtherServers.
+			"other": map[string]any{"serverUrl": "https://other.example.com/mcp"},
+		},
+	})
+
+	result, err := statusAntigravity(configPath)
+	require.NoError(t, err)
+	require.Len(t, result.Servers, 2)
+	require.Len(t, result.OtherServers, 1)
+
+	byName := map[string]ServerMatch{}
+	for _, s := range result.Servers {
+		byName[s.Name] = s
+	}
+	assert.Equal(t, MatchByName, byName["tiddly_notes_bookmarks"].MatchMethod)
+	assert.Equal(t, ServerContent, byName["tiddly_notes_bookmarks"].ServerType)
+	assert.Equal(t, MatchByURL, byName["work_prompts"].MatchMethod)
+	assert.Equal(t, ServerPrompts, byName["work_prompts"].ServerType)
+
+	assert.Equal(t, "other", result.OtherServers[0].Name)
+	assert.Equal(t, "http", result.OtherServers[0].Transport)
+}
+
+func TestStatusAntigravity__missing_file(t *testing.T) {
+	result, err := statusAntigravity("/nonexistent/mcp_config.json")
+	require.NoError(t, err)
+	assert.Empty(t, result.Servers)
+	assert.Empty(t, result.OtherServers)
+}
+
+// agy 1.0.0 reads only serverUrl; a Tiddly URL under the "url" key is silently
+// ignored by agy, so status must NOT report it as a configured Tiddly server.
+// It lands in OtherServers instead — status reflects what Antigravity loads.
+func TestStatusAntigravity__url_keyed_tiddly_entry_is_other(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			"misks_keyed": map[string]any{
+				"url":     ContentMCPURL(),
+				"headers": map[string]any{"Authorization": "Bearer bm_x"},
+			},
+		},
+	})
+
+	result, err := statusAntigravity(configPath)
+	require.NoError(t, err)
+	assert.Empty(t, result.Servers, "url-keyed entry must not classify as a Tiddly server")
+	require.Len(t, result.OtherServers, 1)
+	assert.Equal(t, "misks_keyed", result.OtherServers[0].Name)
+}
+
+// A malformed (non-empty, unparseable) config surfaces an error rather than
+// silently reporting "not configured" — matches statusClaudeDesktop.
+func TestStatusAntigravity__malformed_file_errors(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte("{not valid json"), 0644))
+
+	_, err := statusAntigravity(configPath)
+	require.Error(t, err)
+}
+
+// An empty/whitespace file reads as "no servers" (agy creates such files), not
+// an error.
+func TestStatusAntigravity__empty_file_is_not_configured(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte("  \n"), 0644))
+
+	result, err := statusAntigravity(configPath)
+	require.NoError(t, err)
+	assert.Empty(t, result.Servers)
+}
+
+func TestStatusAntigravity__not_configured(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	writeTestJSON(t, configPath, map[string]any{})
+
+	result, err := statusAntigravity(configPath)
+	require.NoError(t, err)
+	assert.Empty(t, result.Servers)
+}
+
+// PAT extraction tests
+
+func TestExtractAntigravityPATs__valid_config(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	_, err := configureAntigravity(configPath, "bm_content123", "bm_prompt456")
+	require.NoError(t, err)
+
+	ext := extractAntigravityPATs(configPath)
+	assert.Equal(t, "bm_content123", ext.ContentPAT)
+	assert.Equal(t, "bm_prompt456", ext.PromptPAT)
+}
+
+func TestExtractAntigravityPATs__ignores_non_canonical(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	// Only a non-canonical Tiddly-URL entry; canonical PATs must be empty.
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			"work_prompts": map[string]any{
+				"serverUrl": PromptMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_work"},
+			},
+		},
+	})
+
+	ext := extractAntigravityPATs(configPath)
+	assert.Empty(t, ext.ContentPAT)
+	assert.Empty(t, ext.PromptPAT)
+}
+
+func TestExtractAllAntigravityTiddlyPATs__includes_non_canonical(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			"tiddly_prompts": map[string]any{
+				"serverUrl": PromptMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_canonical"},
+			},
+			"work_prompts": map[string]any{
+				"serverUrl": PromptMCPURL(),
+				"headers":   map[string]any{"Authorization": "Bearer bm_work"},
+			},
+		},
+	})
+
+	all := extractAllAntigravityTiddlyPATs(configPath)
+	require.Len(t, all, 2)
+	// Canonical entry sorts first.
+	assert.Equal(t, "tiddly_prompts", all[0].Name)
+	assert.Equal(t, "bm_canonical", all[0].PAT)
+	assert.Equal(t, "work_prompts", all[1].Name)
+}
+
+func TestExtractAntigravityPATs__missing_file(t *testing.T) {
+	ext := extractAntigravityPATs("/nonexistent/mcp_config.json")
+	assert.Empty(t, ext.ContentPAT)
+	assert.Empty(t, ext.PromptPAT)
+}
+
+func TestExtractAntigravityPATs__malformed_file(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte("{not valid json"), 0644))
+
+	ext := extractAntigravityPATs(configPath)
+	assert.Empty(t, ext.ContentPAT)
+	assert.Empty(t, ext.PromptPAT)
+}
+
+// Dry-run test
+
+func TestDryRunAntigravity__shows_before_after(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			"existing": map[string]any{"serverUrl": "https://other.example.com/mcp"},
+		},
+	})
+
+	before, after, err := dryRunAntigravity(configPath, "bm_content", "bm_prompts")
+	require.NoError(t, err)
+
+	assert.Contains(t, before, "existing")
+	assert.NotContains(t, before, "tiddly_notes_bookmarks")
+
+	assert.Contains(t, after, "existing")
+	assert.Contains(t, after, "tiddly_notes_bookmarks")
+	assert.Contains(t, after, "tiddly_prompts")
+	assert.Contains(t, after, "serverUrl")
+
+	// No write occurred.
+	assert.Equal(t, map[string]any{"existing": map[string]any{"serverUrl": "https://other.example.com/mcp"}},
+		readTestJSON(t, configPath)["mcpServers"])
+}
+
+// Detection tests
+
+func TestAntigravityDetect__binary_in_path(t *testing.T) {
+	looker := newMockLooker()
+	looker.paths["agy"] = "/usr/local/bin/agy"
+
+	h := &AntigravityHandler{}
+	tool := h.Detect(looker)
+	assert.True(t, tool.Detected)
+	assert.Equal(t, "binary in PATH", tool.Reason)
+}
+
+func TestAntigravityDetect__cli_dir_exists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".gemini", "antigravity-cli"), 0755))
+
+	h := &AntigravityHandler{}
+	tool := h.Detect(newMockLooker())
+	assert.True(t, tool.Detected)
+	assert.Equal(t, "config directory exists", tool.Reason)
+}
+
+func TestAntigravityDetect__ide_dir_exists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".gemini", "antigravity"), 0755))
+
+	h := &AntigravityHandler{}
+	tool := h.Detect(newMockLooker())
+	assert.True(t, tool.Detected)
+	assert.Equal(t, "config directory exists", tool.Reason)
+}
+
+// A vanilla ~/.gemini/ holding only legacy Gemini CLI artifacts (config/,
+// settings.json) must NOT be detected as Antigravity — that's the false
+// positive the antigravity-specific dir probe is designed to avoid.
+func TestAntigravityDetect__legacy_gemini_only_not_detected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".gemini", "config"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".gemini", "settings.json"), []byte("{}"), 0644))
+
+	h := &AntigravityHandler{}
+	tool := h.Detect(newMockLooker())
+	assert.False(t, tool.Detected)
+}
+
+func TestAntigravityDetect__nothing_present(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	h := &AntigravityHandler{}
+	tool := h.Detect(newMockLooker())
+	assert.False(t, tool.Detected)
+}
+
+// Scope test
+
+func TestAntigravity__user_scope_only(t *testing.T) {
+	h := &AntigravityHandler{}
+	assert.Equal(t, []string{"user"}, h.SupportedScopes())
+}

--- a/cli/internal/mcp/antigravity_test.go
+++ b/cli/internal/mcp/antigravity_test.go
@@ -457,3 +457,19 @@ func TestAntigravity__user_scope_only(t *testing.T) {
 	h := &AntigravityHandler{}
 	assert.Equal(t, []string{"user"}, h.SupportedScopes())
 }
+
+// Configure must warn that the IDE needs a restart — Antigravity reads its
+// config at startup (M1), so without this warning a configure looks like it
+// did nothing inside a running IDE.
+func TestAntigravityHandler__configure_warns_plaintext_and_restart(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	h := &AntigravityHandler{}
+	rc := ResolvedConfig{Path: configPath, Scope: "user"}
+
+	warnings, _, err := h.Configure(rc, "bm_content", "bm_prompts", DetectedTool{Name: "antigravity"})
+	require.NoError(t, err)
+	require.Len(t, warnings, 2)
+	assert.Contains(t, warnings[0], "plaintext")
+	assert.Contains(t, warnings[1], "Restart the Antigravity IDE")
+}

--- a/cli/internal/mcp/configure.go
+++ b/cli/internal/mcp/configure.go
@@ -208,6 +208,17 @@ func RunConfigure(opts ConfigureOpts, tools []DetectedTool) (*ConfigureResult, e
 		// Tiddly URL entries live in sr.Servers with MatchByName.
 		var mismatches []canonicalMismatch
 		for _, o := range sr.OtherServers {
+			// An entry with no recognizable URL isn't a URL conflict — there's
+			// nothing for the canonical write to clash with, so overwrite it
+			// freely (the backup preserves the prior contents) rather than
+			// refusing with a misleading "unexpected URL" error. This also
+			// lets a canonical entry mis-keyed with "url" instead of the
+			// agy-required "serverUrl" (which reads as an empty URL under
+			// Antigravity's strict serverUrl-only classification) self-heal on
+			// configure instead of demanding --force.
+			if o.URL == "" {
+				continue
+			}
 			expected, known := ServerTypeForCanonicalName(o.Name)
 			if !known {
 				continue

--- a/cli/internal/mcp/configure_test.go
+++ b/cli/internal/mcp/configure_test.go
@@ -1890,6 +1890,36 @@ func TestRunConfigure__force_is_no_op_when_no_mismatch(t *testing.T) {
 	assert.NotContains(t, stderr.String(), "Forcing overwrite")
 }
 
+func TestRunConfigure__antigravity_mis_keyed_canonical_self_heals(t *testing.T) {
+	// A canonical-named Antigravity entry mis-keyed with "url" (which agy
+	// ignores) reads as an empty URL under strict serverUrl-only classification.
+	// That must NOT trigger the "unexpected URL" mismatch refusal — configure
+	// should overwrite it in place with the correct serverUrl form.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mcp_config.json")
+	writeTestJSON(t, configPath, map[string]any{
+		"mcpServers": map[string]any{
+			serverNameContent: map[string]any{
+				"url":     ContentMCPURL(),
+				"headers": map[string]any{"Authorization": "Bearer bm_old"},
+			},
+		},
+	})
+
+	client := api.NewClient("http://unused", "bm_login", "pat")
+	tools := []DetectedTool{{Name: "antigravity", Detected: true, ConfigPath: configPath}}
+
+	_, err := RunConfigure(ConfigureOpts{
+		Handlers: DefaultHandlers(), Client: client, AuthType: "pat",
+	}, tools)
+	require.NoError(t, err, "mis-keyed canonical entry must self-heal, not refuse")
+
+	servers := readTestJSON(t, configPath)["mcpServers"].(map[string]any)
+	content := servers[serverNameContent].(map[string]any)
+	assert.Equal(t, ContentMCPURL(), content["serverUrl"])
+	assert.NotContains(t, content, "url", "mis-keyed url field must be replaced by serverUrl")
+}
+
 func TestRunConfigure__reports_preserved_non_canonical_entries(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".claude.json")

--- a/cli/internal/mcp/detect.go
+++ b/cli/internal/mcp/detect.go
@@ -56,3 +56,36 @@ func CodexConfigPath() (string, error) {
 	}
 	return filepath.Join(home, ".codex", "config.toml"), nil
 }
+
+// AntigravityConfigPath returns the Antigravity MCP config file path.
+//
+// Antigravity inherits the ~/.gemini/ tree from its Gemini lineage; the MCP
+// config is the dedicated file ~/.gemini/config/mcp_config.json, shared by both
+// the `agy` CLI and the Antigravity IDE. (Empirically confirmed against agy
+// 1.0.0; the legacy Gemini CLI's own ~/.gemini/settings.json is NOT read by
+// Antigravity and is deliberately not touched here.)
+func AntigravityConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".gemini", "config", "mcp_config.json"), nil
+}
+
+// antigravityInstallDirs returns the directories whose existence signals an
+// Antigravity install. Used for detection when the `agy` binary isn't on PATH
+// (e.g. a desktop-app-only install). These are Antigravity-specific: the CLI
+// installer creates ~/.gemini/antigravity-cli/ and the IDE creates
+// ~/.gemini/antigravity/. We deliberately do NOT probe ~/.gemini/config/ —
+// that path's provenance is ambiguous with a legacy Gemini CLI install, so
+// keying off it would false-positive Antigravity for Gemini-CLI-only users.
+func antigravityInstallDirs() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		filepath.Join(home, ".gemini", "antigravity-cli"),
+		filepath.Join(home, ".gemini", "antigravity"),
+	}, nil
+}

--- a/cli/internal/mcp/detect_test.go
+++ b/cli/internal/mcp/detect_test.go
@@ -154,10 +154,10 @@ func TestConfigPath__returns_error_when_home_unavailable(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDetectAll__always_returns_three_tools(t *testing.T) {
+func TestDetectAll__always_returns_all_tools(t *testing.T) {
 	looker := newMockLooker()
 	tools := DetectAll(DefaultHandlers(), looker)
-	assert.Len(t, tools, 3)
+	assert.Len(t, tools, 4)
 
 	names := make(map[string]bool)
 	for _, tool := range tools {
@@ -166,4 +166,5 @@ func TestDetectAll__always_returns_three_tools(t *testing.T) {
 	assert.True(t, names["claude-desktop"])
 	assert.True(t, names["claude-code"])
 	assert.True(t, names["codex"])
+	assert.True(t, names["antigravity"])
 }

--- a/cli/internal/mcp/handler.go
+++ b/cli/internal/mcp/handler.go
@@ -5,6 +5,7 @@ var (
 	_ ToolHandler = (*ClaudeDesktopHandler)(nil)
 	_ ToolHandler = (*ClaudeCodeHandler)(nil)
 	_ ToolHandler = (*CodexHandler)(nil)
+	_ ToolHandler = (*AntigravityHandler)(nil)
 )
 
 // TiddlyPAT describes one Bearer token found in a tiddly-URL entry during a
@@ -41,7 +42,7 @@ type PATExtraction struct {
 }
 
 // ToolHandler encapsulates all tool-specific behavior for MCP server management.
-// Each supported AI tool (claude-desktop, claude-code, codex) implements this interface.
+// Each supported AI tool (claude-desktop, claude-code, codex, antigravity) implements this interface.
 type ToolHandler interface {
 	Name() string
 	SupportedScopes() []string
@@ -128,6 +129,7 @@ func DefaultHandlers() []ToolHandler {
 		&ClaudeDesktopHandler{},
 		&ClaudeCodeHandler{},
 		&CodexHandler{},
+		&AntigravityHandler{},
 	}
 }
 

--- a/cli/internal/mcp/handler_antigravity.go
+++ b/cli/internal/mcp/handler_antigravity.go
@@ -69,6 +69,10 @@ func (h *AntigravityHandler) Configure(rc ResolvedConfig, contentPAT, promptPAT 
 	}
 	warnings := []string{
 		fmt.Sprintf("Tokens are stored in plaintext in %s. Manage tokens at https://tiddly.me/settings.", rc.Path),
+		// Antigravity reads mcp_config.json at startup, not live (M1 verified
+		// the IDE only picks up new entries after a restart). The agy CLI
+		// re-reads per invocation, so it needs no restart.
+		"Antigravity reads its config at startup. Restart the Antigravity IDE to apply changes (the agy CLI picks them up on its next run).",
 	}
 	return warnings, backupPath, nil
 }

--- a/cli/internal/mcp/handler_antigravity.go
+++ b/cli/internal/mcp/handler_antigravity.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"fmt"
+	"os"
+)
+
+// AntigravityHandler implements ToolHandler for Google Antigravity (the `agy`
+// CLI and the Antigravity IDE, which share one MCP config file).
+type AntigravityHandler struct {
+	ConfigPathOverride string // set by tests; empty in production
+}
+
+func (h *AntigravityHandler) Name() string { return "antigravity" }
+
+// SupportedScopes is user-only. agy 1.0.0 reads MCP config solely from the
+// user-level ~/.gemini/config/mcp_config.json; M1 verification found no
+// directory/project-scoped config path. Re-evaluate if a future agy release
+// adds one.
+func (h *AntigravityHandler) SupportedScopes() []string { return []string{"user"} }
+
+func (h *AntigravityHandler) Detect(looker ExecLooker) DetectedTool {
+	tool := DetectedTool{Name: h.Name()}
+
+	configPath := h.ConfigPathOverride
+	if configPath == "" {
+		var err error
+		configPath, err = AntigravityConfigPath()
+		if err != nil {
+			return tool
+		}
+	}
+
+	if _, err := looker.LookPath("agy"); err == nil {
+		tool.Detected = true
+		tool.ConfigPath = configPath
+		tool.Reason = "binary in PATH"
+		return tool
+	}
+
+	dirs, err := antigravityInstallDirs()
+	if err != nil {
+		return tool
+	}
+	for _, dir := range dirs {
+		if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
+			tool.Detected = true
+			tool.ConfigPath = configPath
+			tool.Reason = "config directory exists"
+			return tool
+		}
+	}
+
+	return tool
+}
+
+func (h *AntigravityHandler) ResolvePath(configPath, _, _ string) (string, error) {
+	if configPath != "" {
+		return configPath, nil
+	}
+	return AntigravityConfigPath()
+}
+
+func (h *AntigravityHandler) Configure(rc ResolvedConfig, contentPAT, promptPAT string, _ DetectedTool) ([]string, string, error) {
+	backupPath, err := configureAntigravity(rc.Path, contentPAT, promptPAT)
+	if err != nil {
+		// Forward backup path on error; see ClaudeDesktopHandler.Configure.
+		return nil, backupPath, err
+	}
+	warnings := []string{
+		fmt.Sprintf("Tokens are stored in plaintext in %s. Manage tokens at https://tiddly.me/settings.", rc.Path),
+	}
+	return warnings, backupPath, nil
+}
+
+func (h *AntigravityHandler) Remove(rc ResolvedConfig, servers []string) (*RemoveResult, error) {
+	return removeAntigravity(rc.Path, servers)
+}
+
+func (h *AntigravityHandler) Status(rc ResolvedConfig) (StatusResult, error) {
+	return statusAntigravity(rc.Path)
+}
+
+func (h *AntigravityHandler) DryRun(rc ResolvedConfig, contentPAT, promptPAT string) (string, string, error) {
+	return dryRunAntigravity(rc.Path, contentPAT, promptPAT)
+}
+
+func (h *AntigravityHandler) ExtractPATs(rc ResolvedConfig) PATExtraction {
+	return extractAntigravityPATs(rc.Path)
+}
+
+func (h *AntigravityHandler) AllTiddlyPATs(rc ResolvedConfig) []TiddlyPAT {
+	return extractAllAntigravityTiddlyPATs(rc.Path)
+}

--- a/cli/internal/mcp/handler_test.go
+++ b/cli/internal/mcp/handler_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultHandlers__returns_all_three_in_order(t *testing.T) {
+func TestDefaultHandlers__returns_all_in_order(t *testing.T) {
 	handlers := DefaultHandlers()
-	require.Len(t, handlers, 3)
+	require.Len(t, handlers, 4)
 	assert.Equal(t, "claude-desktop", handlers[0].Name())
 	assert.Equal(t, "claude-code", handlers[1].Name())
 	assert.Equal(t, "codex", handlers[2].Name())
+	assert.Equal(t, "antigravity", handlers[3].Name())
 }
 
 func TestGetHandler__found(t *testing.T) {
@@ -224,5 +225,5 @@ func TestDetectAll__returns_results_in_handler_order(t *testing.T) {
 
 func TestValidToolNames(t *testing.T) {
 	names := ValidToolNames(DefaultHandlers())
-	assert.Equal(t, []string{"claude-desktop", "claude-code", "codex"}, names)
+	assert.Equal(t, []string{"claude-desktop", "claude-code", "codex", "antigravity"}, names)
 }

--- a/cli/internal/mcp/status.go
+++ b/cli/internal/mcp/status.go
@@ -111,12 +111,20 @@ func isTiddlyPromptURL(rawURL string) bool {
 	return urlMatchesPrefix(rawURL, urlPrefix(PromptMCPURL()))
 }
 
-// extractServerURL returns the MCP URL from a server entry, checking both
-// the HTTP format ("url" field) and the stdio/npx mcp-remote format ("args" array).
-// For stdio format, it finds "mcp-remote" anywhere in args and returns the next element.
-// This handles variants like ["mcp-remote", "<url>"] and ["-y", "mcp-remote", "<url>"]
-// since users may manually configure servers with different npx flag orderings.
+// extractServerURL returns the MCP URL from a server entry, checking the HTTP
+// formats ("serverUrl" or "url" field) and the stdio/npx mcp-remote format
+// ("args" array). For stdio format, it finds "mcp-remote" anywhere in args and
+// returns the next element. This handles variants like ["mcp-remote", "<url>"]
+// and ["-y", "mcp-remote", "<url>"] since users may manually configure servers
+// with different npx flag orderings.
+//
+// "serverUrl" is Antigravity's HTTP field name; "url" is what Claude Code and
+// Claude Desktop use. Antigravity wins when both are present so an Antigravity
+// entry classifies on its own field.
 func extractServerURL(serverMap map[string]any) string {
+	if urlStr, _ := serverMap["serverUrl"].(string); urlStr != "" {
+		return urlStr
+	}
 	if urlStr, _ := serverMap["url"].(string); urlStr != "" {
 		return urlStr
 	}
@@ -133,10 +141,13 @@ func extractServerURL(serverMap map[string]any) string {
 }
 
 // detectTransport returns the transport type for a JSON MCP server entry.
-// Returns "http" if a url field or type:"http" is present, "stdio" if a command
-// field is present, or "" if the format is unrecognized.
-// When both url/type and command fields exist, http takes precedence.
+// Returns "http" if a serverUrl/url field or type:"http" is present, "stdio" if
+// a command field is present, or "" if the format is unrecognized.
+// When both an HTTP URL and command fields exist, http takes precedence.
 func detectTransport(serverMap map[string]any) string {
+	if _, ok := serverMap["serverUrl"].(string); ok {
+		return "http"
+	}
 	if _, ok := serverMap["url"].(string); ok {
 		return "http"
 	}

--- a/cli/internal/mcp/status_test.go
+++ b/cli/internal/mcp/status_test.go
@@ -73,6 +73,21 @@ func TestExtractServerURL__empty_map(t *testing.T) {
 	assert.Equal(t, "", extractServerURL(map[string]any{}))
 }
 
+func TestExtractServerURL__antigravity_serverUrl_field(t *testing.T) {
+	m := map[string]any{"serverUrl": "https://example.com/mcp"}
+	assert.Equal(t, "https://example.com/mcp", extractServerURL(m))
+}
+
+// serverUrl wins when both are set so an Antigravity entry classifies on its
+// own field. Existing url support must remain intact for the Claude handlers.
+func TestExtractServerURL__serverUrl_takes_precedence_over_url(t *testing.T) {
+	m := map[string]any{
+		"serverUrl": "https://antigravity.example.com/mcp",
+		"url":       "https://other.example.com/mcp",
+	}
+	assert.Equal(t, "https://antigravity.example.com/mcp", extractServerURL(m))
+}
+
 func TestDetectTransport__url_field(t *testing.T) {
 	assert.Equal(t, "http", detectTransport(map[string]any{"url": "https://example.com"}))
 }
@@ -91,6 +106,10 @@ func TestDetectTransport__url_takes_precedence(t *testing.T) {
 
 func TestDetectTransport__empty_map(t *testing.T) {
 	assert.Equal(t, "", detectTransport(map[string]any{}))
+}
+
+func TestDetectTransport__serverUrl_field(t *testing.T) {
+	assert.Equal(t, "http", detectTransport(map[string]any{"serverUrl": "https://example.com/mcp"}))
 }
 
 func TestSortOtherServers(t *testing.T) {

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -93,6 +93,27 @@ From the [Config Reference](https://developers.openai.com/codex/config-reference
 
 Claude Desktop does not have a CLI or scope flags. MCP servers are configured via the GUI (Settings > Developer) which writes to a single config file. Skills are configured via Settings > Capabilities.
 
+### Antigravity (Google)
+
+Antigravity is Google's successor to Gemini CLI for individual-tier users (Gemini CLI stops serving Google One / unpaid / Pro / Ultra tiers on 2026-06-18; enterprise keeps it). It ships as both the `agy` CLI and the Antigravity desktop IDE, which **share one MCP config file**.
+
+#### MCP Configuration
+
+- **Config path**: `~/.gemini/config/mcp_config.json` (Antigravity inherits the `~/.gemini/` tree from its Gemini lineage). Empirically verified against agy 1.0.0: the `agy` CLI logs this path on startup, and the IDE reads the same file. Note this is NOT the legacy Gemini CLI `~/.gemini/settings.json`, which Antigravity does not read.
+- **Schema**: HTTP MCP servers use the `serverUrl` field (NOT `url` like Claude Code/Desktop, NOT `httpUrl`), with bearer auth under `headers.Authorization`:
+  ```json
+  {
+    "mcpServers": {
+      "tiddly_notes_bookmarks": {
+        "serverUrl": "https://content-mcp.tiddly.me/mcp",
+        "headers": { "Authorization": "Bearer <PAT>" }
+      }
+    }
+  }
+  ```
+- **No `mcp add` subcommand**: unlike Claude Code, `agy` has no command to add MCP servers. The Tiddly CLI writes the config file directly (the same approach it uses for Claude Desktop and Codex).
+- **Reload**: Antigravity reads `mcp_config.json` at startup, not live. After `tiddly mcp configure antigravity`, quit and restart the IDE (or re-invoke `agy`) to pick up changes.
+
 ## Tiddly CLI Scope Mapping
 
 Our CLI (`tiddly mcp configure`, `tiddly skills configure`) provides two scopes: `user` and `directory`. These apply to both MCP and skills configuration.
@@ -107,7 +128,9 @@ Our CLI (`tiddly mcp configure`, `tiddly skills configure`) provides two scopes:
 | `user`        | `--scope user` (`~/.claude.json` top-level)    | `~/.claude/skills/`      | "User-level" (`~/.codex/config.toml`)        | `USER` scope (`~/.agents/skills/`)        |
 | `directory`   | `--scope local` (`~/.claude.json` under project) | `.claude/skills/`      | "Project-scoped" (`.codex/config.toml`)      | `REPO` scope (`.agents/skills/`)          |
 
-Claude Code and Codex support both scopes for both MCP and skills. Claude Desktop only supports `user` scope.
+Claude Code and Codex support both scopes for both MCP and skills. Claude Desktop and Antigravity only support `user` scope.
+
+For Antigravity, `tiddly mcp configure antigravity` always writes the user-level `~/.gemini/config/mcp_config.json`; `--scope directory` is rejected. Antigravity has no skills integration (see Known Limitations), so it does not appear in `tiddly skills configure`.
 
 ### Known Limitations
 
@@ -116,4 +139,8 @@ Claude Code and Codex support both scopes for both MCP and skills. Claude Deskto
 2. **No official scope flags for skills**: Neither Claude Code nor Codex have a `--scope` flag for skills — scope is determined by file placement. Our `tiddly skills configure --scope` flag is our own abstraction over directory placement.
 
 3. **Codex MCP has no `--scope` flag**: Codex uses "user-level" and "project-scoped" terminology but does not have a CLI `--scope` flag. Our CLI maps our scope flags to writing the appropriate config file.
+
+4. **Antigravity has no directory/project scope (as of agy 1.0.0, 2026-05-19)**: M1 verification probed three candidate project-level paths (`<cwd>/mcp_config.json`, `<cwd>/.gemini/config/mcp_config.json`, `<cwd>/.antigravitycli/mcp_config.json`); none were read by agy. Antigravity is therefore user-scope only. Re-evaluate if a future agy release surfaces a working project path.
+
+5. **Antigravity does not surface MCP prompts (as of agy 1.0.0, 2026-05-19)**: Antigravity (both the `agy` CLI and the IDE) is a tools-only MCP client — it ignores the `prompts/list` / `prompts/get` RPCs that Tiddly's prompt MCP server exposes. Tiddly prompt templates are still fully usable through the prompt server's *tools* (`search_prompts`, `get_prompt_content`, `create_prompt`, etc.); they just aren't invokable as slash-command-style MCP prompts the way Claude Desktop and Claude Code surface them.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,7 @@ flowchart LR
         ClaudeDesktop[Claude Desktop]
         ClaudeCode[Claude Code]
         Codex[Codex]
+        Antigravity[Antigravity]
     end
 
     subgraph ExternalDeps["External dependencies"]
@@ -54,6 +55,7 @@ flowchart LR
     CLITerm -.->|"tiddly mcp configure\nwrites MCP config + PAT"| ClaudeDesktop
     CLITerm -.->|"tiddly mcp configure\nwrites MCP config + PAT"| ClaudeCode
     CLITerm -.->|"tiddly mcp configure\nwrites MCP config + PAT"| Codex
+    CLITerm -.->|"tiddly mcp configure\nwrites MCP config + PAT"| Antigravity
 
     %% Agentic tool flows
     ClaudeDesktop -->|"MCP protocol"| ContentMCP
@@ -62,6 +64,8 @@ flowchart LR
     ClaudeCode -->|"MCP protocol"| PromptMCP
     Codex -->|"MCP protocol"| ContentMCP
     Codex -->|"MCP protocol"| PromptMCP
+    Antigravity -->|"MCP protocol"| ContentMCP
+    Antigravity -->|"MCP protocol"| PromptMCP
 
     ContentMCP -->|"HTTPS + PAT"| API
     PromptMCP -->|"HTTPS + PAT"| API
@@ -88,7 +92,7 @@ flowchart LR
 - The api service is the only process with direct database access. MCP servers and the CLI are clients of the api, not independent DB consumers.
 - Redis fails open: if it's unavailable, rate limiting and auth caching degrade but the app still serves requests.
 - `orphan-relationships` is implemented and documented in `README_DEPLOY.md`, but **intentionally not deployed** at current beta scale. See [KAN-67](https://tiddly.atlassian.net/browse/KAN-67) for the deferral rationale and §9 below.
-- Dashed edges from CLI to the agentic tools represent `tiddly mcp configure` — a one-time local setup action where the CLI mints a PAT (via the api) and writes it into each detected tool's native config file (`claude_desktop_config.json`, `~/.claude.json`, `~/.codex/config.toml`). These are not runtime network protocols; they're filesystem writes on the user's machine that bootstrap the subsequent MCP-protocol edges.
+- Dashed edges from CLI to the agentic tools represent `tiddly mcp configure` — a one-time local setup action where the CLI mints a PAT (via the api) and writes it into each detected tool's native config file (`claude_desktop_config.json`, `~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/config/mcp_config.json`). These are not runtime network protocols; they're filesystem writes on the user's machine that bootstrap the subsequent MCP-protocol edges.
 
 ---
 
@@ -114,7 +118,7 @@ flowchart LR
 
 ### MCP servers — `backend/src/mcp_server/` and `backend/src/prompt_mcp_server/`
 
-Two independent MCP services that agentic tools (Claude Desktop, Claude Code, Codex) talk to via the MCP protocol. Both proxy through the api service over HTTPS using a user-supplied PAT; they hold no database credentials.
+Two independent MCP services that agentic tools (Claude Desktop, Claude Code, Codex, Antigravity) talk to via the MCP protocol. Both proxy through the api service over HTTPS using a user-supplied PAT; they hold no database credentials.
 
 - **content-mcp** — bookmarks + notes: search, get, create, update, content-level edits (old_str/new_str patches), tag and filter listing, relationship creation. Local dev port: 8001.
 - **prompt-mcp** — prompt templates: search, metadata/content fetch, create, update, content-level edits, tag/filter listing. Local dev port: 8002.
@@ -128,7 +132,7 @@ A thin REST client plus an MCP-setup assistant.
 - Commands: `login`, `logout`, `auth`, `status`, `mcp configure|status|remove`, `skills configure|list`, `export`, `tokens`, `config`, `update`
 - Auth: OAuth device-code flow (default) or `--token bm_...` for non-interactive use; credentials stored via `go-keyring` with a plaintext fallback at `~/.config/tiddly/credentials`
 - Config: `~/.config/tiddly/config.yaml` (Viper-managed), `TIDDLY_*` env overrides
-- **Primary non-obvious value:** `tiddly mcp configure` detects installed agentic tools on the host (by probing PATH and tool-specific config locations), generates scoped PATs, and writes the MCP server URLs into each tool's native config file (e.g. `claude_desktop_config.json`, `~/.claude.json`, `~/.codex/config.toml`). This is the "connect my Claude apps to Tiddly" onramp.
+- **Primary non-obvious value:** `tiddly mcp configure` detects installed agentic tools on the host (by probing PATH and tool-specific config locations), generates scoped PATs, and writes the MCP server URLs into each tool's native config file (e.g. `claude_desktop_config.json`, `~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/config/mcp_config.json`). This is the "connect my Claude apps to Tiddly" onramp.
 - Sends `X-Request-Source: cli` on every request
 
 ### Chrome extension — `chrome-extension/`
@@ -476,7 +480,7 @@ Run: `make evals` (requires api + MCP servers + Docker containers running).
 |---|---|
 | [`AGENTS.md`](../AGENTS.md) | Conventions and coding rules for people/agents editing this repo |
 | [`README_DEPLOY.md`](../README_DEPLOY.md) | Railway service setup, env vars, Auth0, crons, post-deploy analytics role |
-| [`docs/ai-integration.md`](ai-integration.md) | Claude Desktop / Claude Code / Codex MCP + skills scope mapping |
+| [`docs/ai-integration.md`](ai-integration.md) | Claude Desktop / Claude Code / Codex / Antigravity MCP + skills scope mapping |
 | [`docs/content-versioning.md`](content-versioning.md) | `ContentHistory` design: reverse diffs, snapshots, audit vs. content events, tier retention, reconstruction |
 | [`docs/http-caching.md`](http-caching.md) | ETag / Last-Modified behavior for GET JSON endpoints |
 | [`docs/connection-pool-tuning.md`](connection-pool-tuning.md) | SQLAlchemy + Redis pool sizing rationale |

--- a/docs/implementation_plans/2026-05-19-antigravity-mcp-configuration.md
+++ b/docs/implementation_plans/2026-05-19-antigravity-mcp-configuration.md
@@ -1,0 +1,285 @@
+# Antigravity MCP Configuration via Tiddly CLI
+
+**Date:** 2026-05-19
+**Status:** Planned
+**Branch:** `antigravity-mcp-support`
+
+## Background
+
+Google announced ([Developers Blog, May 2026](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli)) that Gemini CLI is being replaced by Antigravity for free-tier, Pro, and Ultra users on **June 18, 2026**. Enterprise customers keep Gemini CLI; everyone else moves to Antigravity. We never shipped Gemini CLI support, so the cleanest path is to skip it entirely and target Antigravity directly — that lines up with where the broad individual-user base will be in a month.
+
+Antigravity ships as both an IDE (desktop app) and a terminal CLI binary (`agy`, installed at `~/.local/bin/agy`). They share **one MCP config file** at `~/.gemini/config/mcp_config.json` — so a single `antigravity` handler covers both surfaces.
+
+We support three tools today (`claude-desktop`, `claude-code`, `codex`) via direct file writes (no shelling out to upstream CLIs). This adds a fourth, `antigravity`, following the same pattern.
+
+## What this is and isn't
+
+**This is:** A new `AntigravityHandler` implementing `ToolHandler`, registered alongside the existing three; updates to user-facing settings, docs, and discovery surfaces.
+
+**This is not:**
+- Antigravity skills/plugins support. Antigravity uses git-installable plugins (`agy plugin install ...`) bundling MCP servers, skills, and SKILL.md content. That model doesn't map onto our current `tiddly skills configure` flow (which extracts a tar.gz into `~/.claude/skills/`). Deferred to a separate plan if/when there's a use case.
+- A Gemini CLI handler. Skipped per the discussion above.
+- Antigravity OAuth-based MCP server flows. The binary references `DisconnectMcpOAuth`, but our PATs are static bearer tokens — same as the other three tools.
+
+## Key design decisions (settled)
+
+- **Tool name is `antigravity`** (lowercase, no hyphen). Single name covers both the IDE and the `agy` CLI because they share the same config file. Matches naming convention of existing handlers (`codex`, `claude-code`).
+- **Closest existing analog is `ClaudeDesktopHandler`, not `CodexHandler`.** The MCP config file is *dedicated* — it holds only `mcpServers`, no other user prefs — so we do NOT need the `rest map[string]any` preservation pattern Codex uses. User theme/auth lives in sibling files (`~/.gemini/config/config.json`, `~/.gemini/antigravity-cli/settings.json`); we don't touch those.
+- **HTTP transport field is `serverUrl`**, not `url`. This is the *only* structural difference from how Claude Desktop / Claude Code write HTTP entries. Empirically verified by writing a test entry to `~/.gemini/config/mcp_config.json` and confirming `agy -p "list mcp servers"` reads it back during the research session that produced this plan (transcript appended below under "Verification results"); also confirmed by grepping the `agy` binary for the literal `"serverUrl"`.
+- **`extractServerURL` and `detectTransport` (in `status.go`) are extended in-place to handle `serverUrl`, NOT shadowed by a new Antigravity-local extractor.** The two helpers internally check both field names with preference order `serverUrl` > `url`. No signature change; existing call sites (`claude_code.go:36`, `claude_code.go:276`, `claude_desktop.go:158`) keep working unchanged. Decision rationale: alternative was either a parameterized signature threaded through every call site, or a typed-struct route per Codex. The internal-check route is the smallest diff that keeps URL extraction in one place — load-bearing for status, mismatch preflight, preserved-entry detection, PAT reuse, and `remove --delete-tokens` classification all going through that one helper. The implementing agent does NOT need to re-decide this; just edit the helpers and add tests.
+- **Bearer header is `headers.Authorization: "Bearer <PAT>"`** — same as Claude Code / Claude Desktop. PAT extraction reuses the existing `extractBearerToken` helper.
+- **Detection: `agy` binary in PATH OR `~/.gemini/antigravity-cli/` or `~/.gemini/antigravity/` directory exists.** Mirrors the Codex detection pattern (binary OR Antigravity-specific dir). These two dirs are created by the Antigravity installer (CLI and IDE respectively); the older Gemini CLI does NOT create them. Do NOT use `~/.gemini/config/` as a detection signal — that dir's provenance is ambiguous enough that an enterprise Gemini-CLI user could falsely appear to have Antigravity installed.
+- **No "restart Antigravity" warning.** Unlike Claude Desktop, `agy` re-reads the config on each invocation; the IDE picks up changes via its file watcher.
+- **Plaintext-token warning is included** (same wording pattern as Codex / Claude Code).
+- **File-direct writes, not shell-out.** Matches the existing handler pattern. `agy` has *no* `mcp add` subcommand anyway (only `plugin`, `install`, `update`, `changelog`), so this isn't even an option — but the principle is documented for the agent: we never call the upstream tool's CLI.
+- **Directory-scope path is pending empirical verification.** Community templates ([mapachekurt/antigravity-template](https://github.com/mapachekurt/antigravity-template)) put `mcp_config.json` at the project root (NOT under `.gemini/`). Documentation is thin. Milestone 1 verifies this before Milestone 2 commits to a path.
+
+### Reference documentation (agent must read before implementing)
+
+- Existing handler implementation: `cli/internal/mcp/handler.go`, `claude_desktop.go`, `handler_claude_desktop.go`, `codex.go`, `handler_codex.go` — the new handler must follow the same interface and conventions.
+- Scope translation: `cli/internal/mcp/resolve.go`.
+- URL classifier, transport detection, PAT-sort: `cli/internal/mcp/status.go` (`classifyServer`, `extractServerURL`, `detectTransport`, `sortCanonicalFirst`).
+- Bearer extraction: `cli/internal/mcp/claude_desktop.go` (`extractBearerToken`).
+- Atomic-write helpers and shared JSON read/write: `cli/internal/mcp/config_io.go` (`atomicWriteFileFunc`, `readJSONConfig`, `writeJSONConfig`).
+- Antigravity MCP docs: https://antigravity.google/docs/mcp (sparse but authoritative for the schema).
+- Antigravity transition announcement: https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli — context only.
+- Community installation references (schema corroboration only — these are not authoritative):
+  - https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-antigravity.md
+  - https://github.com/czlonkowski/n8n-mcp/blob/main/docs/ANTIGRAVITY_SETUP.md
+
+## Milestones
+
+---
+
+### Milestone 1 — Empirical verification
+
+Small experiment, not a code change. Resolve four open questions before M2 commits to paths and surfaces.
+
+**Goal & Outcome.** Settle, by direct observation, the facts M2 and M3 depend on:
+
+1. **Confirm the user-level path.** Re-confirm that `agy` reads `~/.gemini/config/mcp_config.json` (this was done in the research session that produced this plan; record the transcript fragment here so future implementers have the receipt).
+2. **Find the directory-scope path** (or confirm there is none).
+3. **Confirm IDE↔CLI path consistency.** Does the Antigravity desktop app read the same `~/.gemini/config/mcp_config.json` post-migration, or has the IDE diverged from the CLI?
+4. **Confirm MCP-prompts surfacing.** Does Antigravity actually expose MCP `prompts/*` to the user, or is it tools-only?
+
+**Implementation Outline.**
+
+**General method.** Use a unique random suffix on every test entry name (e.g. `tiddly_verify_<8 hex chars>`). LLM prose enumeration can omit names or hallucinate them; a unique suffix makes either failure mode unambiguous. Where possible, adjudicate against log/debug output, not prose.
+
+First, before any test, run `agy --help` and confirm the `--dangerously-skip-permissions` and `-p` flags exist (they did during this plan's research session; reconfirming defends against an upstream rename). Also run `agy --debug --help` to see whether `--debug` produces structured output useful for grepping.
+
+**(1) Re-confirm user path.** Write `{"mcpServers": {"tiddly_verify_<suffix>": {"serverUrl": "https://mcp.tiddly.me/content", "headers": {"Authorization": "Bearer test"}}}}` to `~/.gemini/config/mcp_config.json`. Run `agy --dangerously-skip-permissions -p "Print the exact MCP server name from your config"`. Confirm the unique suffix appears in the response AND that `~/.gemini/antigravity-cli/cli.log` references the config path. Paste both fragments into the "Verification results" section.
+
+**(2) Directory-scope path.** Plant a uniquely-named entry at each candidate path in an empty test directory, with the user-level config cleared between probes:
+
+1. `<cwd>/mcp_config.json` (community-template convention)
+2. `<cwd>/.gemini/config/mcp_config.json` (mirror of user-level structure)
+3. `<cwd>/.antigravitycli/mcp_config.json` (using Antigravity's project marker dir)
+
+For each candidate: (a) plant, (b) run agy from that directory and ask for the unique suffix, (c) check `~/.gemini/antigravity-cli/cli.log` for any line resolving an MCP config path. Also test *merge semantics*: with both user-level and a working directory-level config present, are entries additive (combined) or does one override? Record findings.
+
+If none of the three work, project-scope is unavailable; M2 ships `user`-only with `SupportedScopes()` returning `["user"]` (precedent: `ClaudeDesktopHandler`) and `docs/ai-integration.md` "Known Limitations" gets an entry.
+
+**(3) IDE↔CLI consistency.** With the Antigravity desktop app running, edit `~/.gemini/config/mcp_config.json` to contain a uniquely-suffixed server, then in the IDE chat ask it to list its MCP servers. The IDE log lives at `~/Library/Logs/Antigravity` (Mac); grep that log for the config path or the suffix. The IDE check is best-effort — its log structure may not match the CLI's — so write the result up *with the caveat that the CLI check is the rigorous one*. If the IDE doesn't pick up the file, document the divergence in M3's user-facing docs (e.g., "IDE users must restart" or "IDE reads a different file").
+
+**(4) MCP-prompts surfacing.** With both `tiddly_notes_bookmarks` and `tiddly_prompts` configured against staging (or any reachable Tiddly server with a real PAT), ask agy explicitly to list MCP *prompts* (not tools): `agy --dangerously-skip-permissions -p "List every MCP prompt available to you. Prompts are slash-command-style, distinct from tools."` If at least one Tiddly-managed prompt appears, MCP Prompts is `true` in the M3 comparison table. If only tools show up, set the table cell to "Tools only" and add a "Known Limitations" entry in `docs/ai-integration.md`.
+
+**Definition of Done.** Each of the four questions has a recorded answer in this plan's "Verification results" section (appended at the bottom), with at least one of {response-with-unique-suffix, cli.log line, IDE log line} for each. Hand the verified paths and the MCP-Prompts answer to M2 and M3.
+
+---
+
+### Milestone 2 — `AntigravityHandler` implementation
+
+**Goal & Outcome.** The Tiddly CLI supports Antigravity as a fourth target tool:
+
+- `tiddly mcp configure` writes `tiddly_notes_bookmarks` and `tiddly_prompts` entries to `~/.gemini/config/mcp_config.json`. **User scope only** — M1 confirmed agy 1.0.0 supports no directory/project scope.
+- `tiddly mcp status` lists Tiddly entries from those files, distinguishing canonical (`MatchByName`) from non-canonical Tiddly-URL entries (`MatchByURL`), and listing all other entries under `OtherServers`.
+- `tiddly mcp remove` removes the two canonical entries (URL-agnostic, by name), preserving non-canonical Tiddly-URL entries.
+- Auto-detect (`tiddly mcp configure` with no args) picks up Antigravity when `agy` is in PATH or an Antigravity-specific dir (`~/.gemini/antigravity-cli/` or `~/.gemini/antigravity/`) exists.
+- `tiddly mcp configure --dry-run` shows a before/after diff with Bearer tokens redacted.
+- `--force` overrides the canonical-URL-mismatch refusal, same semantics as the other handlers.
+- `tiddly mcp remove --delete-tokens` revokes PATs attached to canonical entries with the same shared-PAT warning and orphan-subtraction logic the other handlers get.
+
+**Implementation Outline.**
+
+1. **Files.** New `cli/internal/mcp/antigravity.go` (per-tool primitives) and `cli/internal/mcp/handler_antigravity.go` (interface adapter). Patterns to mirror: `claude_desktop.go` + `handler_claude_desktop.go` (the closest analog — dedicated MCP-only JSON file).
+
+2. **Schema and round-trip shape.** Read the whole `mcp_config.json` into `map[string]any`, mutate the canonical entries inside `mcpServers`, write the map back. Matches `claude_code.go`'s round-trip approach for `~/.claude.json`. Non-canonical user entries (including stdio entries with `command`/`args`/`env`) are preserved untouched. This is the chosen approach — do NOT use a typed-struct mcpServers value type (Codex's pattern), which would silently drop fields on stdio entries because Antigravity's file mixes HTTP and stdio MCP servers in one map. The contract is "preserve every key we didn't touch."
+
+   When constructing the canonical entries for write, define a small typed struct (e.g. `antigravityHTTPEntry`) with JSON tag `serverUrl` for clarity at the write site; serialize it back into the `map[string]any` for round-trip. This is a write-side convenience, not a read-side type.
+
+3. **Paths.**
+   - User scope → `~/.gemini/config/mcp_config.json`. Add an `AntigravityConfigPath()` helper in `detect.go` next to `CodexConfigPath()`.
+   - **No directory scope.** `SupportedScopes()` returns `["user"]` (precedent: `ClaudeDesktopHandler`). M1 probed three candidate paths and none were read by agy 1.0.0; see the M1 verification writeup for the full negative evidence.
+
+4. **Detection.** Pattern after `CodexHandler.Detect`: prefer `LookPath("agy")`; fall back to `os.Stat` on `~/.gemini/antigravity-cli/` OR `~/.gemini/antigravity/`. Either dir confirms Antigravity is installed (CLI installer creates the former; IDE installer creates the latter). Do NOT use `~/.gemini/config/` as the fallback signal — the older Gemini CLI may produce ambiguous evidence there.
+
+5. **Scope translation.** **No change to `TranslateScope`** (`resolve.go:19`) for Antigravity — directory scope isn't supported. If a user passes `--scope directory` with `antigravity` as the tool, the existing `IsTiddlyScopeSupported` check returns false and the CLI errors out cleanly. No special-case logic needed.
+
+6. **URL classifier integration (the key shared-helper change).** Before adding any Antigravity-side code, extend `extractServerURL` and `detectTransport` in `status.go` so they recognize `serverUrl` in addition to `url`. Internal check, no signature change, no call-site updates required. Preference order inside both functions: `serverUrl` first, then `url`. With that in place, `statusAntigravity` and the PAT extractor can route through the existing helpers exactly like Claude Code does — using `extractServerURL(serverMap)` and `detectTransport(serverMap)` against each entry in `mcpServers`.
+
+   Antigravity stdio entries (community-template style) classify under `OtherServers` and stay there; we never claim ownership of stdio entries.
+
+7. **PAT extraction.** `extractAllAntigravityTiddlyPATs` walks `mcpServers`, reads `headers.Authorization` via the existing `extractBearerToken` helper, and tags entries by URL classification — identical structure to `extractAllClaudeCodeTiddlyPATs` (NOT Codex, which uses its own typed `HTTPHeaders` field). Canonical-first sort via existing `sortCanonicalFirst`.
+
+8. **Registration.** Append `&AntigravityHandler{}` to `DefaultHandlers()` (`handler.go:127`). Order determines display order in CLI output; place it last for now (alphabetical inside the "post-Anthropic" group: `codex`, then `antigravity`). Adjust if the team prefers alphabetical overall — the implementer can decide based on consistency.
+
+9. **Constants.** No new `ServerType` constants — reuse `ServerContent` / `ServerPrompts`. No new canonical names — reuse `serverNameContent` / `serverNamePrompts`.
+
+10. **Configure warnings.** Same plaintext-token warning as Codex/Claude Code (`"Tokens are stored in plaintext in <path>. Manage tokens at https://tiddly.me/settings."`). No restart prompt.
+
+11. **Compile-time interface check.** Add `_ ToolHandler = (*AntigravityHandler)(nil)` in `handler.go:4`.
+
+**Edge cases to handle (these mirror existing handler obligations — listed so the agent can confirm coverage):**
+
+- Empty/missing `mcp_config.json` on first configure → create the file with mode `0600` and parent dir `0700`. Reuse `atomicWriteFileFunc`.
+- Pre-existing entries with non-canonical names pointing at Tiddly URLs (multi-account case) → preserve untouched on both configure and remove.
+- Canonical entry pointing at a non-Tiddly URL → refuse with the mismatch error unless `--force` is set (existing `--force` machinery applies; no per-handler work needed).
+- A user with the Antigravity IDE running while `tiddly mcp configure` writes the file → IDE picks up the change via file watcher; no race we need to handle (we already write atomically).
+
+**Definition of Done.**
+
+- Unit tests parallel to `codex_test.go` and `claude_desktop_test.go` covering: configure-from-empty, configure-with-existing-non-canonical-entries (preservation including stdio entries with `command`/`args`/`env`), configure-with-mismatched-canonical-entry (refuse + force-override), remove (canonical-only), status (canonical vs OtherServers vs URL-match — must exercise both `MatchByName` and `MatchByURL` against `serverUrl` entries), PAT extraction across canonical and non-canonical `serverUrl` entries, dry-run diff with Bearer redaction, detection (binary present; binary absent + `~/.gemini/antigravity-cli/` present; binary absent + `~/.gemini/antigravity/` present; both absent — no false positive on a vanilla `~/.gemini/` that contains only legacy Gemini-CLI artifacts).
+- **New unit tests for the shared-helper change** in `status_test.go` (or wherever existing helper tests live): `extractServerURL` returns the URL when only `serverUrl` is set; returns the URL when only `url` is set; prefers `serverUrl` when both are present; returns "" when neither is set; `mcp-remote` arg lookup still works. `detectTransport` returns `"http"` for `serverUrl`-only entries.
+- Backup/atomic-write behavior identical to other handlers — verify via the shared test helpers if they exist; otherwise write a dedicated test.
+- `mcp configure antigravity` and `mcp remove antigravity` run end-to-end against a real `~/.gemini/config/mcp_config.json` on the dev machine (manual smoke test — record in PR description). **The smoke-test verification must NOT use `agy -p` prose enumeration** — M1 demonstrated that agy's print-mode LLM hallucinates and is unreliable as a verification signal. Use one of these deterministic checks instead: (a) run a local Tiddly Content/Prompt MCP server (via `make content-mcp-server` / `make prompt-mcp-server`) pointed at by the canonical entries, invoke `agy`, and confirm the local server's stdout records a `POST /mcp HTTP/1.1 200 OK` connection; OR (b) open the Antigravity IDE settings panel and confirm both canonical entries appear with non-zero tool counts. See M1's verification writeup at the bottom of this file for the full rationale on why prose-based checks are unreliable.
+- `make cli-verify` passes.
+- No new docs in this milestone — that's M3.
+
+---
+
+### Milestone 3 — User-facing surfaces
+
+**Goal & Outcome.** A user landing on `/app/settings/ai-integration` or `/docs/ai` can discover and follow Antigravity setup; the docs reflect Antigravity's scope mapping.
+
+- The "Gemini CLI / Coming soon" card on `AIIntegration.tsx` is replaced with a working Antigravity card linking into the setup docs.
+- The Compare-integrations table on the same page gains a fourth column for Antigravity.
+- `docs/ai-integration.md` gains an Antigravity section in both the "Official Tool Documentation" group and the "Unified Scope Mapping" table.
+- The command palette can find Antigravity setup via keywords like `antigravity`, `agy`, `gemini` (so users searching for the old name still land on the right page).
+
+**Implementation Outline.**
+
+1. **`frontend/src/pages/AIIntegration.tsx`** — replace the existing `Gemini CLI` "coming soon" entry in `AI_CLIENTS` with an Antigravity entry. Use the existing `GeminiIcon` (Google branding is shared) or add a dedicated `AntigravityIcon` if one exists; the implementer can decide based on what's in `components/icons/`. Add a fourth column to `comparisonRows` for Antigravity:
+   - Environment: Terminal + Desktop (Antigravity ships both)
+   - Config type: JSON
+   - MCP Prompts: **false** (M1 verified Antigravity is a tools-only MCP client as of agy 1.0.0, verified 2026-05-19 — see verification results below). Add a code comment alongside the row anchoring the value to that agy version so a future maintainer has a reason to revisit when they bump the version.
+   - Agent Skills: false (deferred; Antigravity has its own plugin model, our tar.gz skills don't apply)
+
+   Decide whether to keep the table at 3 columns and add Antigravity as a 4th, or split into two tables — the implementer judges based on layout. The card list grid (`sm:grid-cols-2 lg:grid-cols-3`) already supports an extra entry.
+
+2. **`frontend/src/components/AISetupWidget.tsx` — DO NOT skip this file.** It drives the actual setup flow on `/app/settings/ai-integration` and has the tool list hard-coded at many call sites. Required changes:
+   - L18: replace `gemini-cli` in the `ClientType` union with `antigravity`. (The string `gemini-cli` should not appear anywhere after this milestone.)
+   - L108, L287, L355: extend `CliToolType` from `['claude-desktop', 'claude-code', 'codex']` to include `'antigravity'`.
+   - L431, L436, L441, L447, L452: per-tool branches that build config-file path lists and command strings — add Antigravity branches writing `~/.gemini/config/mcp_config.json` (user scope only — no directory branch, since M1 confirmed Antigravity has no directory scope).
+   - L566–L568 and L1929/L1947/L1990: select-option dropdowns; add Antigravity.
+   - L1464 `SkillsClientType` and the skills sub-flow (L1875–L1916): **leave Antigravity OUT** — skills support is explicitly out of scope. Antigravity must not appear in the skills tool selector.
+   - L1947: the legacy `gemini-cli` branch in the manual setup tab is removed entirely (no replacement — Antigravity uses the same MCP CLI flow as other tools).
+
+3. **`frontend/src/pages/settings/SettingsMCP.test.tsx`** — mirror existing claude-code/codex test cases for antigravity: tool-selection state, command-string generation (`tiddly mcp configure antigravity`), file-path generation. `frontend-verify` must pass.
+
+4. **`docs/ai-integration.md`** — add an Antigravity section under "Official Tool Documentation":
+   - Document the user-level path (`~/.gemini/config/mcp_config.json`, empirically verified — cite M1's transcript).
+   - Document the schema difference (`serverUrl` instead of `url`).
+   - Note that Antigravity has no upstream `mcp add` subcommand — our CLI writes the file directly, same as Claude Desktop and Codex.
+   - Note that one config file is shared between the IDE and the `agy` CLI (cite M1's IDE-consistency finding).
+
+   Add an Antigravity row to the "Unified Scope Mapping" table (user scope only — no directory column entry).
+
+   **Add two "Known Limitations" entries**:
+   - **No directory/project scope as of agy 1.0.0 (2026-05-19).** M1 probed three candidate paths (`<cwd>/mcp_config.json`, `<cwd>/.gemini/config/mcp_config.json`, `<cwd>/.antigravitycli/mcp_config.json`); none were read by agy. A future agy release may add directory scope — re-evaluate if a user surfaces a working path.
+   - **MCP prompts not surfaced (tools-only client) as of agy 1.0.0 (2026-05-19).** Tiddly's prompt MCP server registers MCP-protocol prompts (via `@server.list_prompts()`), but Antigravity (CLI and IDE) ignores `prompts/*` RPCs. Tiddly prompt templates are still accessible via the `search_prompts` / `get_prompt_content` *tools*; they're just not invokable as slash-command-style MCP prompts the way Claude Desktop / Claude Code surface them.
+
+5. **`docs/architecture.md`** — if it enumerates supported MCP tools anywhere, add Antigravity. (The agent should grep for `claude-desktop`, `claude-code`, `codex` and patch wherever the list appears.)
+
+6. **`frontend/public/llms.txt`** — same: grep for the existing tool list and add Antigravity.
+
+7. **`frontend/src/data/settingsRoutes.tsx` / `docsRoutes.tsx`** — extend the `searchText` for the AI integration / docs pages with keywords: `antigravity`, `agy`, `gemini` (so users searching for the now-deprecated "Gemini CLI" still land on Antigravity). Per AGENTS.md, optimize for keyword density, not prose.
+
+8. **`README.md`** — if it lists supported AI tools, add Antigravity.
+
+9. **`frontend/src/pages/docs/DocsCLIMCP.tsx`** and **`DocsAIFeatures.tsx`** — patch any tool-list mentions, scope-mapping examples, and configure-flag tables to include Antigravity.
+
+**Definition of Done.**
+
+- `frontend/src/pages/AIIntegration.tsx` shows Antigravity as a real, clickable card (not "Coming soon"). The comparison table includes it with `MCP Prompts: false` and a code comment anchoring the value to agy 1.0.0 / 2026-05-19.
+- `AISetupWidget.tsx` includes Antigravity in every CLI-tool list, dropdown, and per-tool branch; the string `gemini-cli` no longer appears anywhere. No directory-scope branch for Antigravity. `SettingsMCP.test.tsx` covers Antigravity parallel to the existing tools.
+- `docs/ai-integration.md` documents the Antigravity path, scope mapping, and schema specifics, plus the two Known Limitations entries (no directory scope; tools-only).
+- Searching `antigravity`, `agy`, or `gemini` in the command palette surfaces the AI Integration settings page.
+- `make frontend-verify` passes.
+- A manual walk-through: from a clean browser session, navigate `/app/settings/ai-integration → Antigravity card → docs page → run the documented command → `agy -p "list mcp servers"` lists the Tiddly entries`. Record in PR description.
+
+---
+
+## Out of scope (explicit non-goals)
+
+- Antigravity plugin/skills installation. The `agy plugin` model is git-install-based and structurally different from our skills tar.gz extraction. If users ask, that's a follow-up plan.
+- Gemini CLI support. Deprecating for individual tiers June 18, 2026; we never shipped it; not building it.
+- Migration tooling for users moving from Gemini CLI to Antigravity. We never managed their Gemini CLI config, so there's nothing on our side to migrate.
+- Antigravity MCP OAuth flows. Our PATs are bearer tokens — same as the other three handlers.
+
+## Commit/push policy
+
+Per the user's standing instruction: do not commit, do not push, do not open a PR. Stop after each milestone for review.
+
+## Verification results (Milestone 1, completed 2026-05-19)
+
+Test setup: Antigravity CLI `agy` 1.0.0, IDE on macOS 25.3.0. Local content + prompt MCP servers running on ports 8001/8002 against the dev backend (DEV_MODE=true, so bearer tokens accept any non-empty value). Unique suffix used to disambiguate planted entries from anything the IDE/CLI might cache: `1712a0f1`. **The LLM enumeration approach the plan originally proposed turned out to be unreliable** — agy's print-mode LLM hallucinated server names that weren't actually loaded, and reported `chrome-devtools-plugin` (a hardcoded reference in its system context) regardless of mcp_config.json contents. The reliable signal turned out to be **HTTP connection logs from the target MCP server itself**: if the server records `POST /mcp HTTP/1.1 200 OK` from agy's PID, the config was loaded; if not, it wasn't. Use this method for any future agy MCP verification.
+
+### Q1 — User-level config path & schema
+
+**Answer:** `~/.gemini/config/mcp_config.json`, schema `mcpServers.<name>.serverUrl` + `headers.Authorization`.
+
+Evidence:
+- `cli-20260519_134319.log` line: `discovery.go:335] Failed to load JSON config file /Users/shanekercheval/.gemini/config/mcp_config.json: unexpected end of JSON input` — confirms this is the path agy probes at startup. (Triggered by my deliberately-empty file during Q1c.)
+- Q1f probe: planted four schema variants in one file (`url` alone, `url`+`type:"http"`, `httpUrl`, `serverUrl`) all pointing at `http://localhost:8001/mcp`. Only the `serverUrl` entry produced connection log lines in the content MCP server's stdout: `INFO: 127.0.0.1:51748 - "POST /mcp HTTP/1.1" 200 OK`. The other three variants produced no connection attempts, confirming agy silently rejects them.
+
+Other paths probed and **NOT** read by agy: `~/.gemini/antigravity-cli/mcp_config.json`, `~/.gemini/settings.json` (the legacy Gemini CLI MCP location).
+
+### Q2 — Directory-scope path
+
+**Answer:** No directory-scope path among the three candidates probed for agy 1.0.0. M2 ships `SupportedScopes()` returning `["user"]` (precedent: `ClaudeDesktopHandler`); M3 documents the limitation. Re-evaluate if a future agy release or a user surfaces a working path — the negative is over the three candidates probed, not all possible paths.
+
+Evidence: Three candidates planted with uniquely-named entries pointing at `http://localhost:8002/mcp`. From each candidate directory, ran `agy ... -p "list MCP server names ..."`:
+
+| Candidate path | Connection to 8002? | Verdict |
+|---|---|---|
+| `<cwd>/mcp_config.json` (community-template convention) | No | Not read |
+| `<cwd>/.gemini/config/mcp_config.json` (mirror of user-level structure) | No | Not read |
+| `<cwd>/.antigravitycli/mcp_config.json` (Antigravity's project marker dir) | No | Not read |
+
+The prompts MCP server stdout showed zero new bytes after baseline across all three probes. Other plausible paths NOT probed: `~/.gemini/projects/<project-id>/mcp_config.json`, `<cwd>/.agy/mcp_config.json`, `<cwd>/gemini.json`. If any of these turn out to be readable in a later version, the user-only constraint can be lifted.
+
+### Q3 — IDE↔CLI consistency
+
+**Answer:** The IDE reads the same `~/.gemini/config/mcp_config.json` as the CLI. Confirmed.
+
+Evidence: User restarted the Antigravity IDE with the unique-suffixed pair `tiddly_verify_1712a0f1_content` / `tiddly_verify_1712a0f1_prompts` planted in `~/.gemini/config/mcp_config.json`. The IDE's MCP settings panel showed both entries with their tools enumerated (58 tools and 51 tools respectively — screenshot captured but not committed).
+
+### Q4 — MCP Prompts surfacing
+
+**Answer:** As of agy 1.0.0 (verified 2026-05-19), the Antigravity IDE is a **tools-only** MCP client — it does NOT surface MCP-protocol prompts (the `prompts/list` / `prompts/get` RPCs). The agy CLI is inferred to behave the same way by code symmetry with the IDE. M3 comparison table sets "MCP Prompts: false" for Antigravity. `docs/ai-integration.md` adds a "Known Limitations" entry noting that Tiddly's prompt templates are accessible via Antigravity only through the `search_prompts` / `get_prompt_content` *tools*, not as slash-command-style MCP prompts (the way Claude Desktop and Claude Code surface them).
+
+Evidence (ordered by strength):
+
+1. **(Strong, empirical)** The Antigravity IDE settings panel showed `tiddly_verify_1712a0f1_prompts` with 51 entries under "**Mcp Tools**" — no separate "Mcp Prompts" section anywhere in the UI. The 51 entries are CRUD operations (`get_prompt_content`, `search_prompts`, `create_prompt`, etc.) — i.e., the Tiddly tools that *manage* prompt templates, NOT the prompt templates themselves. Falsifiable: if the IDE had surfaced server-provided prompts, they'd appear in a sibling section.
+2. **(Strong, server-side)** The Tiddly prompt MCP server at `backend/src/prompt_mcp_server/server.py:149` registers `@server.list_prompts()`. Tiddly DOES expose MCP-protocol prompts — so the absence in the IDE is on the *client* side, not because Tiddly failed to publish anything.
+3. **(Inference)** The agy CLI and Antigravity IDE share the same compiled MCP client (per Google's "Antigravity is a unified platform" architecture). What the IDE doesn't surface, agy CLI shouldn't either. Stronger empirical confirmation would require capturing agy's JSON-RPC request bodies and grepping for `prompts/list` calls — not done in this M1 run because the IDE evidence is already strong and the inference path is direct. If a future user reports prompts working in the agy CLI but not the IDE, this assumption is the one to revisit.
+4. **(Weak, do not rely on)** `agy -p "List every MCP prompt … available"` returned "no prompts" despite connecting to both servers (proven by `POST /mcp HTTP/1.1 200 OK` on port 8002). This corroborates but does not itself prove the finding — the prose-LLM check is unreliable per the banner at the top of this section.
+
+**DEV_MODE caveat.** Q4 ran against the local Tiddly backend in `DEV_MODE=true`, which only bypasses auth (the MCP server still serves the same `prompts/list` shape it would in prod). The tools-only finding is therefore not dev-mode-specific.
+
+### Restored state
+
+User's `~/.gemini/config/mcp_config.json` and `~/.gemini/settings.json` restored byte-for-byte from `m1-backup-*` snapshots taken at the start of M1, then the backup files deleted. All test directories under `/tmp/m1-*` and probe output files (`/tmp/agy-q*.out`) removed. Local content + prompt MCP servers (ports 8001/8002) and the API on 8000 left running — the user started those before M1 began and may want to keep them up for M2 smoke testing.
+
+### Implications for M2 / M3 (now folded into the milestone bodies above)
+
+The M2/M3 sections at the top of this plan have been normalized to reflect M1's findings — no more conditional "if M1 found a path" language. This subsection summarizes what changed so a reviewer can spot-check that the milestone bodies stay in sync.
+
+- **M2 step 3 (Paths):** Directory scope is permanently dropped. `SupportedScopes()` returns `["user"]`.
+- **M2 step 4 (Detection):** Unchanged.
+- **M2 step 5 (Scope translation):** No `TranslateScope` case added for Antigravity — directory scope isn't supported; existing `IsTiddlyScopeSupported` returns false for `directory + antigravity` and the CLI errors cleanly.
+- **M2 step 6 (URL classifier integration):** `extractServerURL` / `detectTransport` extended to recognize both `serverUrl` and `url`, preference order `serverUrl` > `url`. **Tests in `status_test.go` must keep existing `url` support intact** (Claude Code and Claude Desktop write `url`; rejecting it there would regress those handlers) — verify both fields work and the preference order. The Antigravity-specific tests must verify the *write side*: when configure creates a canonical entry, the JSON key emitted is `serverUrl` — never `url` or `httpUrl`. Do NOT add tests asserting the shared helper rejects `url`/`httpUrl` — that would break Claude Code.
+- **M2 DoD (smoke test):** Manual smoke test does NOT use `agy -p` prose enumeration (M1 showed this is unreliable). Use either local-MCP-server connection logs or the IDE settings panel — see DoD above.
+- **M3 comparison table:** `MCP Prompts: false` for Antigravity. Code comment alongside the row anchoring the value to agy 1.0.0 / 2026-05-19.
+- **M3 `docs/ai-integration.md`:** Two "Known Limitations" entries (no directory scope as of agy 1.0.0; MCP prompts not surfaced as of agy 1.0.0). Both dated; both phrased so a future maintainer has a reason to revisit when bumping the agy version.

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -143,56 +143,29 @@ curl -X POST https://prompts-mcp.tiddly.me/mcp \
 
 ### Setting Up MCP Servers
 
-All MCP setup requires a Personal Access Token (PAT). Generate one in Settings > Personal Access Tokens on tiddly.me. Replace `YOUR_PAT` below with your token. It is recommended to use separate PATs for each MCP server so access can be revoked independently. Treat PATs like passwords — never share them, commit them to version control, or expose them in client-side code. If compromised, revoke immediately in Settings and create a new one.
+The recommended way to connect any supported tool is the Tiddly CLI. It mints dedicated Personal Access Tokens (PATs) per server, writes each tool's config file, and detects which tools are installed — so you never hand-edit config files.
 
-**Claude Desktop** — Add to config file (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
-
-```json
-{
-  "mcpServers": {
-    "tiddly_notes_bookmarks": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://content-mcp.tiddly.me/mcp", "--header", "Authorization: Bearer YOUR_PAT"]
-    },
-    "tiddly_prompts": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://prompts-mcp.tiddly.me/mcp", "--header", "Authorization: Bearer YOUR_PAT"]
-    }
-  }
-}
-```
-
-Restart Claude Desktop after saving. Uses `mcp-remote` as a bridge since Claude Desktop does not natively support streamable HTTP transport.
-
-**Claude Code** — Run in your project directory:
+Install the CLI, log in, then configure:
 
 ```
-claude mcp add --transport http tiddly_notes_bookmarks https://content-mcp.tiddly.me/mcp \
-  --header "Authorization: Bearer YOUR_PAT"
-
-claude mcp add --transport http tiddly_prompts https://prompts-mcp.tiddly.me/mcp \
-  --header "Authorization: Bearer YOUR_PAT"
+curl -fsSL https://raw.githubusercontent.com/shane-kercheval/tiddly/main/cli/install.sh | sh
+tiddly login
+tiddly mcp configure                       # auto-detect installed tools, both servers
+tiddly mcp configure claude-code           # a specific tool
+tiddly mcp configure --servers content     # only the bookmarks/notes server
 ```
 
-Note: Claude Code MCP servers are configured per project directory. Alternatively, if you've already configured Claude Desktop, run `claude mcp add-from-claude-desktop` to import those servers.
+Supported tools: Claude Desktop, Claude Code, Codex, Antigravity. The CLI creates and stores the PATs; manage or revoke them anytime in Settings > Personal Access Tokens on tiddly.me. Treat PATs like passwords — never share or commit them; revoke immediately if compromised.
 
-**Codex** — Add to `~/.codex/config.toml`:
+For an interactive walkthrough that generates the exact command for your selected tools and servers, see the AI Integration settings page: https://tiddly.me/app/settings/ai-integration (Settings > AI Integration).
 
-```toml
-[mcp_servers.tiddly_notes_bookmarks]
-url = "https://content-mcp.tiddly.me/mcp"
-http_headers = { "Authorization" = "Bearer YOUR_PAT" }
+Per-tool notes (the CLI handles each automatically; these explain behavior differences):
 
-[mcp_servers.tiddly_prompts]
-url = "https://prompts-mcp.tiddly.me/mcp"
-http_headers = { "Authorization" = "Bearer YOUR_PAT" }
-```
-
-Note: Codex does not support MCP Prompts natively (the `/prompt-name` slash invocation available in Claude Code). Bookmarks and notes still work normally — Codex uses the MCP tools to search, read, and edit them just like Claude Code does. But to invoke a saved prompt directly, export it as a Codex Skill: at https://tiddly.me/app/settings/ai-integration, pick Codex and run the displayed `tiddly skills configure` command. It writes every prompt tagged `skill` as a SKILL.md file (default: `~/.agents/skills/`). Codex surfaces those skills as `$skill-name` invocations or auto-selects them based on task context — same template behavior, different invocation surface.
-
-**ChatGPT** — Not yet supported. ChatGPT requires OAuth authentication, which is coming soon.
-
-**Gemini CLI** — Not yet supported. Integration instructions coming soon.
+- **Claude Desktop** — user scope only. Restart Claude Desktop after configuring. Uses an `mcp-remote` bridge since it doesn't natively support streamable HTTP transport.
+- **Claude Code** — supports user and directory scope (`--scope directory` writes per-project config).
+- **Codex** — tools-only MCP client: it doesn't surface MCP Prompts (the `/prompt-name` slash invocation available in Claude Code). Bookmarks, notes, and prompt templates all still work through the MCP tools. To invoke a saved prompt directly, export it as a Codex Skill — run the displayed `tiddly skills configure` command, which writes every prompt tagged `skill` as a SKILL.md file (default `~/.agents/skills/`). Codex surfaces those as `$skill-name` invocations or auto-selects them by context.
+- **Antigravity** (Google) — user scope only; the `agy` CLI and the Antigravity IDE share one config file, so `tiddly mcp configure antigravity` covers both. Antigravity reads the config at startup — quit and restart it afterward. Like Codex it's a tools-only client (no MCP Prompts), and it has no Tiddly skills integration. Antigravity is Google's successor to Gemini CLI for individual-tier users.
+- **ChatGPT** — not yet supported (requires OAuth authentication, coming soon).
 
 ### Chrome Extension
 
@@ -216,7 +189,7 @@ curl -fsSL https://raw.githubusercontent.com/shane-kercheval/tiddly/main/cli/ins
 **Commands:**
 - `tiddly login` / `tiddly logout`: Authenticate via OAuth device flow or Personal Access Token.
 - `tiddly status [--path /dir]`: Overview of authentication, API health, content counts, and MCP server status. Use `--path` to inspect a specific directory for directory-scoped configurations (default: cwd).
-- `tiddly mcp configure`: Auto-detect installed AI tools (Claude Desktop, Claude Code, Codex) and configure MCP servers with dedicated tokens.
+- `tiddly mcp configure`: Auto-detect installed AI tools (Claude Desktop, Claude Code, Codex, Antigravity) and configure MCP servers with dedicated tokens.
 - `tiddly mcp status` / `tiddly mcp remove`: View or remove MCP server configurations.
 - `tiddly skills configure [tool...]`: Install prompt templates as agent skills for Claude Code, Codex, or Claude Desktop. Auto-detects tools if none specified. Defaults to `--tags skill` (use `--tags ""` for all prompts). Supports `--tag-match` ("all" or "any") for tag matching mode, and `--scope` (user or directory) for scope selection.
 - `tiddly skills list`: List available skills (prompts eligible for export). Defaults to `--tags skill` (use `--tags ""` for all prompts). Supports `--tag-match` ("all" or "any") for tag matching mode.

--- a/frontend/src/components/AISetupWidget.tsx
+++ b/frontend/src/components/AISetupWidget.tsx
@@ -1,114 +1,30 @@
 /**
- * Reusable AI Integration setup widget with CLI and manual (Curl/PAT) tabs.
+ * Reusable AI Integration setup widget driving the CLI-based setup flow.
  * Used by both Settings → AI Integration and Docs → AI Integration.
  */
 import { useState, useEffect, useRef } from 'react'
 import type { ReactNode, KeyboardEvent } from 'react'
 import { Link } from 'react-router-dom'
-import { config } from '../config'
 import { api } from '../services/api'
 import { useAuthStatus } from '../hooks/useAuthStatus'
 import type { TagCount, TagListResponse } from '../types'
 
-const CONFIG_PATH_MAC = '~/Library/Application\\ Support/Claude/claude_desktop_config.json'
-const CONFIG_PATH_WINDOWS = '%APPDATA%\\Claude\\claude_desktop_config.json'
 
 // Selector types
 type ServerType = 'content' | 'prompts'
-type ClientType = 'claude-desktop' | 'claude-code' | 'gemini-cli' | 'chatgpt' | 'codex'
-type AuthType = 'bearer' | 'oauth'
-type IntegrationType = 'mcp' | 'skills'
-type SetupTab = 'cli' | 'manual'
-
-interface McpServerConfig {
-  command: string
-  args: string[]
-}
-
-/**
- * Selector row component for PyTorch-style configuration.
- */
-interface SelectorOption<T extends string> {
-  value: T
-  label: string
-  disabled?: boolean
-  comingSoon?: boolean
-}
-
-interface SelectorRowProps<T extends string> {
-  label: string
-  options: SelectorOption<T>[]
-  value: T
-  onChange: (value: T) => void
-  disabled?: boolean
-}
-
-function SelectorRow<T extends string>({
-  label,
-  options,
-  value,
-  onChange,
-  disabled = false,
-}: SelectorRowProps<T>): ReactNode {
-  return (
-    <div className="flex flex-col md:flex-row md:items-center gap-1.5">
-      {/* Label - on mobile shows above options with orange border, on desktop shows inline */}
-      <div className="border-l-4 border-l-[#f09040] pl-3 md:border-l-0 md:pl-4 md:w-32 md:flex-shrink-0">
-        <span className={`text-sm font-medium ${disabled ? 'text-gray-400' : 'text-gray-700'}`}>{label}</span>
-      </div>
-      {/* Options - stack vertically on mobile, horizontal on desktop */}
-      <div className="flex flex-col md:flex-row md:flex-1 gap-1.5 pl-4 md:pl-0">
-        {options.map((option) => {
-          const isSelected = value === option.value
-          const isComingSoon = option.comingSoon
-          const isOptionDisabled = disabled || option.disabled
-
-          // Color scheme:
-          // Supported: light orange (unselected) / dark orange (selected)
-          // Unsupported/coming soon: light gray (unselected) / dark gray (selected)
-          // Disabled: very light gray, not clickable
-
-          return (
-            <button
-              key={option.value}
-              type="button"
-              disabled={isOptionDisabled}
-              onClick={() => !isOptionDisabled && onChange(option.value)}
-              className={`
-                md:flex-1 px-4 py-2.5 text-sm font-medium transition-colors text-left md:text-center
-                ${
-                  isOptionDisabled
-                    ? 'bg-gray-100 text-gray-300 cursor-not-allowed'
-                    : isComingSoon
-                    ? isSelected
-                      ? 'bg-gray-300 text-gray-700'
-                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                    : isSelected
-                    ? 'bg-[#f09040] text-white'
-                    : 'bg-[#fff0e5] text-[#d97b3d] hover:bg-[#ffe4d1]'
-                }
-              `}
-            >
-              {option.label}
-            </button>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
-// =============================================================================
-// CLI-First Setup Section
-//
-// For the tool/scope support matrix and terminology decisions,
-// see docs/ai-integration.md
-// =============================================================================
-
-type CliToolType = 'claude-desktop' | 'claude-code' | 'codex'
+type CliToolType = 'claude-desktop' | 'claude-code' | 'codex' | 'antigravity'
 type CliActionType = 'configure' | 'remove'
 type ScopeType = 'user' | 'directory'
 type TagMatchType = 'all' | 'any'
+
+// All MCP-configurable tools, in display order.
+const ALL_CLI_TOOLS: CliToolType[] = ['claude-desktop', 'claude-code', 'codex', 'antigravity']
+// Tools with a Tiddly skills integration. Antigravity is excluded — it has no
+// skills support (its plugin model differs from our SKILL.md export), so it
+// must never appear in `tiddly skills configure` commands or skills paths.
+const SKILLS_CLI_TOOLS: CliToolType[] = ['claude-desktop', 'claude-code', 'codex']
+// Tools that only support user scope (no --scope directory).
+const USER_SCOPE_ONLY_TOOLS: CliToolType[] = ['claude-desktop', 'antigravity']
 
 interface PillOption<T extends string> {
   value: T
@@ -252,24 +168,6 @@ function PillSelectGroup<T extends string>({
 /**
  * Numbered step card for setup instructions.
  */
-function StepCard({ number, title, subtitle, children }: { number: number; title: string; subtitle?: string; children?: ReactNode }): ReactNode {
-  return (
-    <div className="rounded-lg border border-gray-200 bg-white p-4">
-      <div className="flex gap-4">
-        <span className="text-lg font-semibold text-[#d97b3d] select-none">{number}</span>
-        <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
-          {subtitle && <p className="text-xs text-gray-500 mt-0.5">{subtitle}</p>}
-          {children}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Generate CLI command(s) based on selected options.
- */
 function generateCLICommands(
   action: CliActionType,
   selectedServers: Set<ServerType>,
@@ -284,15 +182,14 @@ function generateCLICommands(
     return generateRemoveCommands(selectedServers, installSkills, selectedTools, deleteTokens, scope)
   }
 
-  const allTools: CliToolType[] = ['claude-desktop', 'claude-code', 'codex']
   const needsCd = scope === 'directory'
   const parts: string[] = []
 
   if (selectedServers.size > 0 && selectedTools.size > 0) {
     let cmd = 'tiddly mcp configure'
 
-    const mcpTools = allTools.filter((t) => selectedTools.has(t))
-    if (mcpTools.length < allTools.length) {
+    const mcpTools = ALL_CLI_TOOLS.filter((t) => selectedTools.has(t))
+    if (mcpTools.length < ALL_CLI_TOOLS.length) {
       cmd += ' ' + mcpTools.join(' ')
     }
 
@@ -307,11 +204,11 @@ function generateCLICommands(
     parts.push(cmd)
   }
 
-  if (installSkills && selectedTools.size > 0) {
+  const skillsTools = SKILLS_CLI_TOOLS.filter((t) => selectedTools.has(t))
+  if (installSkills && skillsTools.length > 0) {
     let cmd = 'tiddly skills configure'
 
-    const skillsTools = allTools.filter((t) => selectedTools.has(t))
-    if (skillsTools.length < allTools.length) {
+    if (skillsTools.length < SKILLS_CLI_TOOLS.length) {
       cmd += ' ' + skillsTools.join(' ')
     }
 
@@ -352,12 +249,11 @@ function generateRemoveCommands(
   deleteTokens: boolean,
   scope: ScopeType,
 ): string {
-  const allTools: CliToolType[] = ['claude-desktop', 'claude-code', 'codex']
   const needsCd = scope === 'directory'
   const parts: string[] = []
 
   if (selectedServers.size > 0 && selectedTools.size > 0) {
-    const mcpTools = allTools.filter((t) => selectedTools.has(t))
+    const mcpTools = ALL_CLI_TOOLS.filter((t) => selectedTools.has(t))
     for (const tool of mcpTools) {
       let cmd = `tiddly mcp remove ${tool}`
       if (selectedServers.size === 1) {
@@ -374,7 +270,7 @@ function generateRemoveCommands(
   }
 
   if (removeSkills && selectedTools.size > 0) {
-    const skillsTools = allTools.filter((t) => selectedTools.has(t))
+    const skillsTools = SKILLS_CLI_TOOLS.filter((t) => selectedTools.has(t))
     for (const tool of skillsTools) {
       if (tool === 'claude-desktop') {
         parts.push('# Claude Desktop: manually remove skills from Settings > Capabilities')
@@ -407,6 +303,7 @@ const CLI_TOOL_LABELS: Record<CliToolType, string> = {
   'claude-desktop': 'Claude Desktop',
   'claude-code': 'Claude Code',
   'codex': 'Codex',
+  'antigravity': 'Antigravity',
 }
 
 interface AffectedFile {
@@ -441,6 +338,9 @@ function getAffectedFiles(
     if (selectedTools.has('claude-desktop')) {
       files.push({ path: '~/Library/Application Support/Claude/claude_desktop_config.json', description: 'Claude Desktop MCP (macOS)' })
     }
+    if (selectedTools.has('antigravity')) {
+      files.push({ path: '~/.gemini/config/mcp_config.json', description: 'Antigravity MCP (shared by the agy CLI and the IDE)' })
+    }
   }
 
   if (installSkills) {
@@ -465,11 +365,24 @@ function getAffectedFiles(
 }
 
 /**
- * Returns true when Claude Desktop is selected with directory scope — an invalid
- * configuration since Claude Desktop only supports user scope.
+ * Returns the user-scope-only tools (Claude Desktop, Antigravity) selected
+ * alongside directory scope — an invalid combination since those tools only
+ * support user scope. Empty when there's no conflict.
  */
-function hasClaudeDesktopDirectoryError(selectedTools: Set<CliToolType>, scope: ScopeType): boolean {
-  return selectedTools.has('claude-desktop') && scope === 'directory'
+function userScopeOnlyDirectoryConflicts(selectedTools: Set<CliToolType>, scope: ScopeType): CliToolType[] {
+  if (scope !== 'directory') return []
+  return USER_SCOPE_ONLY_TOOLS.filter((t) => selectedTools.has(t))
+}
+
+/**
+ * Returns the selected tools that have no Tiddly skills integration (e.g.
+ * Antigravity) when skills are enabled — an invalid combination, since skills
+ * cannot be installed for those tools. Empty when skills are off or every
+ * selected tool supports skills. Preserves ALL_CLI_TOOLS display order.
+ */
+function skillsUnsupportedConflicts(selectedTools: Set<CliToolType>, installSkills: boolean): CliToolType[] {
+  if (!installSkills) return []
+  return ALL_CLI_TOOLS.filter((t) => selectedTools.has(t) && !SKILLS_CLI_TOOLS.includes(t))
 }
 
 /**
@@ -530,8 +443,11 @@ function CLISetupSection(): ReactNode {
   const hasMcpServers = selectedServers.size > 0
   const hasSelections = (hasMcpServers || installSkills) && selectedTools.size > 0
   const activeScope = isRemove ? removeScope : scope
-  const desktopDirectoryError = hasClaudeDesktopDirectoryError(selectedTools, activeScope)
-  const command = desktopDirectoryError ? '' : generateCLICommands(cliAction, selectedServers, installSkills, selectedTools, activeScope, skillsTags, skillsTagMatch, deleteTokens)
+  const scopeConflictTools = userScopeOnlyDirectoryConflicts(selectedTools, activeScope)
+  const scopeConflictError = scopeConflictTools.length > 0
+  const skillsConflictTools = skillsUnsupportedConflicts(selectedTools, installSkills)
+  const skillsConflictError = skillsConflictTools.length > 0
+  const command = (scopeConflictError || skillsConflictError) ? '' : generateCLICommands(cliAction, selectedServers, installSkills, selectedTools, activeScope, skillsTags, skillsTagMatch, deleteTokens)
   const hasAnything = hasSelections && command !== ''
   const affectedFiles = hasAnything ? getAffectedFiles(selectedTools, activeScope, hasMcpServers, installSkills, cliAction) : []
 
@@ -566,6 +482,7 @@ function CLISetupSection(): ReactNode {
     { value: 'claude-desktop', label: 'Claude Desktop' },
     { value: 'claude-code', label: 'Claude Code' },
     { value: 'codex', label: 'Codex' },
+    { value: 'antigravity', label: 'Antigravity' },
   ]
 
   // Server options
@@ -724,8 +641,15 @@ function CLISetupSection(): ReactNode {
       <SectionDivider label="Steps" />
       {!hasSelections ? (
         <p className="text-sm text-gray-400 italic">Select at least one item and one target tool above.</p>
-      ) : desktopDirectoryError ? (
-        <p className="text-sm text-amber-600 italic">Claude Desktop only supports User scope. Deselect Claude Desktop or switch to User scope.</p>
+      ) : (scopeConflictError || skillsConflictError) ? (
+        <div className="space-y-1">
+          {scopeConflictError && (
+            <p className="text-sm text-amber-600 italic">{scopeConflictTools.map((t) => CLI_TOOL_LABELS[t]).join(' and ')} only support{scopeConflictTools.length === 1 ? 's' : ''} User scope. Deselect {scopeConflictTools.length === 1 ? 'it' : 'them'} or switch to User scope.</p>
+          )}
+          {skillsConflictError && (
+            <p className="text-sm text-amber-600 italic">{skillsConflictTools.map((t) => CLI_TOOL_LABELS[t]).join(' and ')} {skillsConflictTools.length === 1 ? 'does' : 'do'} not support skills. Deselect {skillsConflictTools.length === 1 ? 'it' : 'them'} or turn off Skills.</p>
+          )}
+        </div>
       ) : (
         <div className="space-y-3">
           {/* Step 1: Install CLI */}
@@ -848,624 +772,6 @@ function CLISetupSection(): ReactNode {
   )
 }
 
-// =============================================================================
-// Manual Setup Section (existing PyTorch-style selector, collapsed by default)
-// =============================================================================
-
-/**
- * Generate the Claude Desktop config JSON based on server selection.
- */
-function generateClaudeDesktopConfig(
-  server: ServerType,
-  mcpUrl: string,
-  promptMcpUrl: string
-): string {
-  const servers: Record<string, McpServerConfig> = {}
-
-  if (server === 'content') {
-    servers.tiddly_notes_bookmarks = {
-      command: 'npx',
-      args: [
-        'mcp-remote',
-        `${mcpUrl}/mcp`,
-        '--header',
-        'Authorization: Bearer YOUR_TOKEN_HERE',
-      ],
-    }
-  } else {
-    servers.tiddly_prompts = {
-      command: 'npx',
-      args: [
-        'mcp-remote',
-        `${promptMcpUrl}/mcp`,
-        '--header',
-        'Authorization: Bearer YOUR_TOKEN_HERE',
-      ],
-    }
-  }
-
-  const configObj = { mcpServers: servers }
-  return JSON.stringify(configObj, null, 2)
-}
-
-/**
- * Generate the Claude Code commands based on server selection.
- */
-function generateClaudeCodeCommand(
-  server: ServerType,
-  mcpUrl: string,
-  promptMcpUrl: string
-): string {
-  if (server === 'content') {
-    return `claude mcp add --transport http tiddly_notes_bookmarks ${mcpUrl}/mcp \\
-  --header "Authorization: Bearer YOUR_TOKEN_HERE"`
-  } else {
-    return `claude mcp add --transport http tiddly_prompts ${promptMcpUrl}/mcp \\
-  --header "Authorization: Bearer YOUR_TOKEN_HERE"`
-  }
-}
-
-/**
- * Claude Desktop setup instructions component.
- */
-interface ClaudeDesktopInstructionsProps {
-  server: ServerType
-  mcpUrl: string
-  promptMcpUrl: string
-}
-
-function ClaudeDesktopInstructions({
-  server,
-  mcpUrl,
-  promptMcpUrl,
-}: ClaudeDesktopInstructionsProps): ReactNode {
-  const [copiedConfig, setCopiedConfig] = useState(false)
-  const [copiedPathMac, setCopiedPathMac] = useState(false)
-  const [copiedPathWin, setCopiedPathWin] = useState(false)
-
-  const exampleConfig = generateClaudeDesktopConfig(server, mcpUrl, promptMcpUrl)
-
-  const handleCopyConfig = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(exampleConfig)
-      setCopiedConfig(true)
-      setTimeout(() => setCopiedConfig(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  const handleCopyPathMac = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(CONFIG_PATH_MAC)
-      setCopiedPathMac(true)
-      setTimeout(() => setCopiedPathMac(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  const handleCopyPathWin = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(CONFIG_PATH_WINDOWS)
-      setCopiedPathWin(true)
-      setTimeout(() => setCopiedPathWin(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  return (
-    <div className="space-y-3">
-      <StepCard number={1} title="Create a Personal Access Token" subtitle="Authenticate with the MCP server">
-        <Link
-          to="/app/settings/tokens"
-          className="btn-primary inline-flex items-center gap-2 mt-2"
-        >
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
-          Create Token
-        </Link>
-      </StepCard>
-
-      <StepCard number={2} title="Locate Config File" subtitle="Create or edit the Claude Desktop configuration file">
-        <div className="space-y-3 mt-2">
-          <div>
-            <span className="text-xs font-medium text-gray-700">macOS:</span>
-            <div className="relative mt-1">
-              <code className="block bg-gray-50 text-gray-700 px-3 py-2 rounded text-xs font-mono pr-14">
-                {CONFIG_PATH_MAC}
-              </code>
-              <button
-                onClick={handleCopyPathMac}
-                className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-                  copiedPathMac
-                    ? 'bg-green-600 text-white'
-                    : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-                }`}
-              >
-                {copiedPathMac ? 'Copied!' : 'Copy'}
-              </button>
-            </div>
-          </div>
-          <div>
-            <span className="text-xs font-medium text-gray-700">Windows:</span>
-            <div className="relative mt-1">
-              <code className="block bg-gray-50 text-gray-700 px-3 py-2 rounded text-xs font-mono pr-14">
-                {CONFIG_PATH_WINDOWS}
-              </code>
-              <button
-                onClick={handleCopyPathWin}
-                className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-                  copiedPathWin
-                    ? 'bg-green-600 text-white'
-                    : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-                }`}
-              >
-                {copiedPathWin ? 'Copied!' : 'Copy'}
-              </button>
-            </div>
-          </div>
-        </div>
-      </StepCard>
-
-      <StepCard number={3} title="Add Configuration" subtitle="Add the following to your config file">
-        <div className="relative mt-2">
-          <pre className="rounded bg-gray-50 px-3 py-2 text-xs text-gray-700 whitespace-pre-wrap break-all overflow-x-auto font-mono pr-14">
-            <code>{exampleConfig}</code>
-          </pre>
-          <button
-            onClick={handleCopyConfig}
-            className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-              copiedConfig
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-            }`}
-          >
-            {copiedConfig ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-        <p className="mt-2 text-xs text-gray-500">
-          Replace <code className="bg-gray-100 px-1 rounded">YOUR_TOKEN_HERE</code> with
-          your Personal Access Token from Step 1.
-        </p>
-      </StepCard>
-
-      <StepCard number={4} title="Restart Claude Desktop" subtitle="Load the MCP server">
-        <div className="mt-2 rounded-lg bg-blue-50 border border-blue-200 p-3">
-          <p className="text-xs text-blue-800">
-            <strong>Verify:</strong> Start a new conversation and try{' '}
-            {server === 'content' ? (
-              <em>&quot;Search my bookmarks&quot;</em>
-            ) : (
-              <em>&quot;List my prompts&quot;</em>
-            )}{' '}
-            to confirm the integration is working.
-          </p>
-        </div>
-      </StepCard>
-
-      <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-2">Want to add both servers?</h3>
-        <p className="text-sm text-gray-600">
-          Switch between &quot;Content&quot; and &quot;Prompts&quot; in the selector above to see the configuration for each server.
-          You can add both configurations to your <code className="bg-gray-200 px-1 rounded text-xs">mcpServers</code> object
-          by combining them.
-        </p>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Claude Code setup instructions component.
- */
-interface ClaudeCodeInstructionsProps {
-  server: ServerType
-  mcpUrl: string
-  promptMcpUrl: string
-}
-
-function ClaudeCodeInstructions({
-  server,
-  mcpUrl,
-  promptMcpUrl,
-}: ClaudeCodeInstructionsProps): ReactNode {
-  const [copiedCommand, setCopiedCommand] = useState(false)
-  const [copiedImport, setCopiedImport] = useState(false)
-
-  const command = generateClaudeCodeCommand(server, mcpUrl, promptMcpUrl)
-  const importCommand = 'claude mcp add-from-claude-desktop'
-
-  const handleCopyCommand = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(command)
-      setCopiedCommand(true)
-      setTimeout(() => setCopiedCommand(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  const handleCopyImport = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(importCommand)
-      setCopiedImport(true)
-      setTimeout(() => setCopiedImport(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  return (
-    <div className="space-y-3">
-      <StepCard number={1} title="Create a Personal Access Token" subtitle="Authenticate with the MCP server">
-        <Link
-          to="/app/settings/tokens"
-          className="btn-primary inline-flex items-center gap-2 mt-2"
-        >
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
-          Create Token
-        </Link>
-      </StepCard>
-
-      <StepCard number={2} title="Add MCP Server" subtitle="Run this command in your project directory">
-        <div className="relative mt-2">
-          <pre className="rounded bg-gray-50 px-3 py-2 text-xs text-gray-700 whitespace-pre-wrap overflow-x-auto font-mono pr-14">
-            <code>{command}</code>
-          </pre>
-          <button
-            onClick={handleCopyCommand}
-            className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-              copiedCommand
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-            }`}
-          >
-            {copiedCommand ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-        <p className="mt-2 text-xs text-gray-500">
-          Replace <code className="bg-gray-100 px-1 rounded">YOUR_TOKEN_HERE</code> with
-          your Personal Access Token from Step 1.
-        </p>
-      </StepCard>
-
-      <StepCard number={3} title="Verify Installation">
-        <p className="text-xs text-gray-500 mt-1">
-          The server is now configured for this project. Try asking Claude Code to{' '}
-          {server === 'content' ? (
-            <em>&quot;search my bookmarks&quot;</em>
-          ) : (
-            <em>&quot;list my prompts&quot;</em>
-          )}{' '}
-          to verify it&apos;s working.
-        </p>
-        <div className="mt-2 rounded-lg bg-blue-50 border border-blue-200 p-3">
-          <p className="text-xs text-blue-800">
-            <strong>Note:</strong> Claude Code MCP servers are configured per project/directory.
-            Run the command in each project where you want access.
-          </p>
-        </div>
-      </StepCard>
-
-      <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-2">Alternative: Import from Claude Desktop</h3>
-        <p className="text-sm text-gray-600 mb-3">
-          If you&apos;ve already configured Claude Desktop, you can import those servers:
-        </p>
-        <div className="relative">
-          <code className="block bg-gray-50 text-gray-700 px-3 py-2 rounded text-xs font-mono pr-14">
-            {importCommand}
-          </code>
-          <button
-            onClick={handleCopyImport}
-            className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-              copiedImport
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-            }`}
-          >
-            {copiedImport ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-      </div>
-
-      <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-2">Want to add both servers?</h3>
-        <p className="text-sm text-gray-600">
-          Switch between &quot;Content&quot; and &quot;Prompts&quot; in the selector above to see the command for each server.
-          Run both commands to add both MCP servers to your project.
-        </p>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Generate the Codex config TOML based on server selection.
- */
-function generateCodexConfig(
-  server: ServerType,
-  mcpUrl: string,
-  promptMcpUrl: string
-): string {
-  if (server === 'content') {
-    return `[mcp_servers.tiddly_notes_bookmarks]
-url = "${mcpUrl}/mcp"
-http_headers = { "Authorization" = "Bearer YOUR_TOKEN_HERE" }`
-  } else {
-    return `[mcp_servers.tiddly_prompts]
-url = "${promptMcpUrl}/mcp"
-http_headers = { "Authorization" = "Bearer YOUR_TOKEN_HERE" }`
-  }
-}
-
-/**
- * Codex setup instructions component.
- */
-interface CodexInstructionsProps {
-  server: ServerType
-  mcpUrl: string
-  promptMcpUrl: string
-}
-
-function CodexInstructions({
-  server,
-  mcpUrl,
-  promptMcpUrl,
-}: CodexInstructionsProps): ReactNode {
-  const [copiedConfig, setCopiedConfig] = useState(false)
-
-  const configContent = generateCodexConfig(server, mcpUrl, promptMcpUrl)
-
-  const handleCopyConfig = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(configContent)
-      setCopiedConfig(true)
-      setTimeout(() => setCopiedConfig(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  return (
-    <div className="space-y-3">
-      <StepCard number={1} title="Create a Personal Access Token" subtitle="Authenticate with the MCP server">
-        <Link
-          to="/app/settings/tokens"
-          className="btn-primary inline-flex items-center gap-2 mt-2"
-        >
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
-          Create Token
-        </Link>
-      </StepCard>
-
-      <StepCard number={2} title="Add to Config File" subtitle={`Open (or create) ~/.codex/config.toml and add:`}>
-        <div className="relative mt-2">
-          <pre className="rounded bg-gray-50 px-3 py-2 text-xs text-gray-700 whitespace-pre-wrap overflow-x-auto font-mono pr-14">
-            <code>{configContent}</code>
-          </pre>
-          <button
-            onClick={handleCopyConfig}
-            className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-              copiedConfig
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-            }`}
-          >
-            {copiedConfig ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-        <p className="mt-2 text-xs text-gray-500">
-          Replace <code className="bg-gray-100 px-1 rounded">YOUR_TOKEN_HERE</code> with
-          your Personal Access Token from Step 1.
-        </p>
-      </StepCard>
-
-      <StepCard number={3} title="Restart Codex" subtitle="If Codex is running, quit and restart it." />
-
-      <StepCard number={4} title="Verify Installation">
-        <p className="text-xs text-gray-500 mt-1">
-          In Codex, type <code className="bg-gray-100 px-1 rounded">/mcp</code> to confirm the server
-          is connected and shows available tools.
-        </p>
-      </StepCard>
-
-      {server === 'prompts' && (
-        <div className="rounded-lg bg-blue-50 border border-blue-200 p-4">
-          <h3 className="text-sm font-semibold text-blue-900 mb-2">Using Your Prompts</h3>
-          <p className="text-sm text-blue-800 mb-3">
-            <strong>Note:</strong> Codex does not support MCP Prompts directly (the{' '}
-            <code className="bg-blue-100 px-1 rounded">/prompt-name</code> slash invocation style
-            available in Claude Code). Instead, it exposes your server&apos;s tools for managing
-            and retrieving prompts.
-          </p>
-          <p className="text-sm text-blue-800 mb-2">
-            To use a saved prompt, ask Codex to fetch and apply it:
-          </p>
-          <ul className="text-sm text-blue-800 list-disc list-inside space-y-1">
-            <li>
-              <em>&quot;Get my &apos;code-review&apos; prompt and use it to review the changes in this file&quot;</em>
-            </li>
-            <li>
-              <em>&quot;Search my prompts for &apos;commit message&apos; and use the best match to write a commit for my staged changes&quot;</em>
-            </li>
-          </ul>
-        </div>
-      )}
-
-      <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-2">Want to add both servers?</h3>
-        <p className="text-sm text-gray-600">
-          Switch between &quot;Bookmarks &amp; Notes&quot; and &quot;Prompts&quot; in the selector above to see the configuration for each server.
-          You can add both configurations to your <code className="bg-gray-200 px-1 rounded text-xs">config.toml</code> file.
-        </p>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Coming soon placeholder component for various unsupported configurations.
- */
-interface ComingSoonProps {
-  title: string
-  description: string
-}
-
-function ComingSoon({ title, description }: ComingSoonProps): ReactNode {
-  return (
-    <div className="rounded-lg bg-gray-50 border border-gray-200 p-6 text-center">
-      <div className="mb-4">
-        <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      </div>
-      <h3 className="text-lg font-medium text-gray-900 mb-2">
-        {title}
-      </h3>
-      <p className="text-sm text-gray-600">
-        {description}
-      </p>
-    </div>
-  )
-}
-
-/**
- * Available tools section component.
- */
-interface AvailableToolsProps {
-  server: ServerType
-}
-
-function AvailableTools({ server }: AvailableToolsProps): ReactNode {
-  const contentTools = [
-    { tool: 'get_context', category: 'Context', description: 'Get context summary of bookmarks and notes' },
-    { tool: 'search_items', category: 'Search & Read', description: 'Search bookmarks and notes by text/tags' },
-    { tool: 'get_item', category: 'Search & Read', description: 'Get full details by ID' },
-    { tool: 'search_in_content', category: 'Search & Read', description: 'Search within content for editing' },
-    { tool: 'list_filters', category: 'Search & Read', description: 'List content filters with IDs and tag rules' },
-    { tool: 'list_tags', category: 'Search & Read', description: 'Get all tags with usage counts' },
-    { tool: 'create_bookmark', category: 'Create & Edit', description: 'Save a new URL' },
-    { tool: 'create_note', category: 'Create & Edit', description: 'Create a new note' },
-    { tool: 'update_item', category: 'Create & Edit', description: 'Update metadata or fully replace content' },
-    { tool: 'edit_content', category: 'Create & Edit', description: 'Edit content using string replacement' },
-  ]
-
-  const promptTools = [
-    { tool: 'get_context', category: 'Context', description: 'Get context summary of prompts' },
-    { tool: 'search_prompts', category: 'Search & Read', description: 'Search prompts by text/tags' },
-    { tool: 'get_prompt_content', category: 'Search & Read', description: 'Get template and arguments for viewing/editing' },
-    { tool: 'get_prompt_metadata', category: 'Search & Read', description: 'Get metadata without the template' },
-    { tool: 'list_filters', category: 'Search & Read', description: 'List prompt filters with IDs and tag rules' },
-    { tool: 'list_tags', category: 'Search & Read', description: 'Get all tags with usage counts' },
-    { tool: 'create_prompt', category: 'Create & Edit', description: 'Create a new prompt template' },
-    { tool: 'edit_prompt_content', category: 'Create & Edit', description: 'Edit template and arguments using string replacement' },
-    { tool: 'update_prompt', category: 'Create & Edit', description: 'Update metadata, content, or arguments' },
-  ]
-
-  const tools = server === 'content' ? contentTools : promptTools
-
-  // Group tools by category and calculate rowSpan
-  const categoryGroups: { category: string; tools: typeof tools }[] = []
-  let currentCategory = ''
-  for (const tool of tools) {
-    if (tool.category !== currentCategory) {
-      categoryGroups.push({ category: tool.category, tools: [tool] })
-      currentCategory = tool.category
-    } else {
-      categoryGroups[categoryGroups.length - 1].tools.push(tool)
-    }
-  }
-
-  return (
-    <div className="mb-8">
-      <h2 className="text-base font-semibold text-gray-900 mb-2">Available MCP Tools</h2>
-      <p className="text-gray-600 mb-4">
-        Once connected, AI agents can use these tools:
-      </p>
-
-      {/* Mobile: Section/bullet format */}
-      <div className="md:hidden space-y-4">
-        {categoryGroups.map((group) => (
-          <div key={group.category}>
-            <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
-              {group.category}
-            </h4>
-            <ul className="space-y-2 text-sm text-gray-600">
-              {group.tools.map((item) => (
-                <li key={item.tool} className="flex items-start gap-2">
-                  <code className="font-mono bg-gray-100 px-1.5 py-0.5 rounded text-gray-800 text-xs flex-shrink-0">
-                    {item.tool}
-                  </code>
-                  <span className="text-xs">{item.description}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
-
-      {/* Desktop: Table format */}
-      <div className="hidden md:block overflow-hidden rounded-lg border border-gray-200">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <th scope="col" className="px-3 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                Category
-              </th>
-              <th scope="col" className="px-3 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                Tool
-              </th>
-              <th scope="col" className="px-3 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                Description
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
-            {categoryGroups.map((group) =>
-              group.tools.map((item, index) => (
-                <tr key={item.tool}>
-                  {index === 0 && (
-                    <td
-                      rowSpan={group.tools.length}
-                      className="px-3 py-2 text-sm text-gray-500 whitespace-nowrap align-top border-r border-gray-200 bg-gray-50"
-                    >
-                      {group.category}
-                    </td>
-                  )}
-                  <td className="px-3 py-2 text-sm">
-                    <code className="font-mono bg-gray-100 px-1.5 py-0.5 rounded text-gray-800">{item.tool}</code>
-                  </td>
-                  <td className="px-3 py-2 text-sm text-gray-600">
-                    {item.description}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  )
-}
-
-// =============================================================================
-// Skills Export Components
-// =============================================================================
-
-// Client type for skills export (subset that supports skills)
-type SkillsClientType = 'claude-code' | 'claude-desktop' | 'codex'
-
-/**
- * Multi-select tag dropdown for filtering which prompts to export as skills.
- */
 interface SkillsTagSelectorProps {
   availableTags: TagCount[]
   selectedTags: string[]
@@ -1607,215 +913,6 @@ function SkillsTagSelector({
 /**
  * Build the export URL for skills API endpoint.
  */
-function buildSkillsExportUrl(client: SkillsClientType, selectedTags: string[]): string {
-  const params = new URLSearchParams()
-  params.append('client', client)
-  selectedTags.forEach((tag) => params.append('tags', tag))
-  return `${config.apiUrl}/prompts/export/skills?${params.toString()}`
-}
-
-/**
- * Claude Code skills configure instructions.
- */
-interface ClaudeCodeSkillsInstructionsProps {
-  exportUrl: string
-}
-
-function ClaudeCodeSkillsInstructions({ exportUrl }: ClaudeCodeSkillsInstructionsProps): ReactNode {
-  const [copiedCommand, setCopiedCommand] = useState(false)
-
-  const syncCommand = `mkdir -p ~/.claude/skills && curl -sH "Authorization: Bearer $PROMPTS_TOKEN" "${exportUrl}" | tar -xzf - -C ~/.claude/skills/`
-
-  const handleCopyCommand = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(syncCommand)
-      setCopiedCommand(true)
-      setTimeout(() => setCopiedCommand(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  return (
-    <div className="space-y-3">
-      <StepCard number={3} title="Install Skills" subtitle="Run this command to install your skills">
-        <div className="relative mt-2">
-          <pre className="rounded bg-gray-50 px-3 py-2 text-xs text-gray-700 whitespace-pre-wrap overflow-x-auto font-mono pr-14">
-            <code>{syncCommand}</code>
-          </pre>
-          <button
-            onClick={handleCopyCommand}
-            className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-              copiedCommand
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-            }`}
-          >
-            {copiedCommand ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-      </StepCard>
-
-      <StepCard number={4} title="Use Your Skills">
-        <p className="text-xs text-gray-500 mt-1">
-          After syncing, Claude auto-invokes skills when relevant to your task.
-          You can also trigger them manually with <code className="bg-gray-100 px-1 rounded">/skill-name</code>.
-        </p>
-        <p className="text-xs text-gray-400 mt-1">
-          Tip: Add this command to a cron job or shell alias for regular syncing.
-        </p>
-      </StepCard>
-
-      <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-2">Sync Behavior</h3>
-        <p className="text-sm text-gray-600">
-          Syncing is <strong>additive</strong>: new skills are added and existing skills are updated,
-          but skills are not deleted. To remove a skill, manually delete its folder from{' '}
-          <code className="bg-gray-200 px-1 rounded text-xs">~/.claude/skills/</code>.
-        </p>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Codex skills configure instructions.
- */
-interface CodexSkillsInstructionsProps {
-  exportUrl: string
-}
-
-function CodexSkillsInstructions({ exportUrl }: CodexSkillsInstructionsProps): ReactNode {
-  const [copiedCommand, setCopiedCommand] = useState(false)
-
-  const syncCommand = `mkdir -p ~/.codex/skills && curl -sH "Authorization: Bearer $PROMPTS_TOKEN" "${exportUrl}" | tar -xzf - -C ~/.codex/skills/`
-
-  const handleCopyCommand = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(syncCommand)
-      setCopiedCommand(true)
-      setTimeout(() => setCopiedCommand(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  return (
-    <div className="space-y-3">
-      <StepCard number={3} title="Install Skills" subtitle="Run this command to install your skills">
-        <div className="relative mt-2">
-          <pre className="rounded bg-gray-50 px-3 py-2 text-xs text-gray-700 whitespace-pre-wrap overflow-x-auto font-mono pr-14">
-            <code>{syncCommand}</code>
-          </pre>
-          <button
-            onClick={handleCopyCommand}
-            className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-              copiedCommand
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-            }`}
-          >
-            {copiedCommand ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-      </StepCard>
-
-      <StepCard number={4} title="Use Your Skills">
-        <p className="text-xs text-gray-500 mt-1">
-          After syncing, invoke skills by typing <code className="bg-gray-100 px-1 rounded">$skill-name</code> in your prompt.
-          Codex will also auto-select skills based on your task context.
-        </p>
-      </StepCard>
-
-      <div className="rounded-lg bg-gray-50 border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-900 mb-2">Sync Behavior</h3>
-        <p className="text-sm text-gray-600">
-          Syncing is <strong>additive</strong>: new skills are added and existing skills are updated,
-          but skills are not deleted. To remove a skill, manually delete its folder from{' '}
-          <code className="bg-gray-200 px-1 rounded text-xs">~/.codex/skills/</code>.
-        </p>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Claude Desktop skills configure instructions.
- */
-interface ClaudeDesktopSkillsInstructionsProps {
-  exportUrl: string
-}
-
-function ClaudeDesktopSkillsInstructions({ exportUrl }: ClaudeDesktopSkillsInstructionsProps): ReactNode {
-  const [copiedCommand, setCopiedCommand] = useState(false)
-
-  const downloadCommand = `curl -sH "Authorization: Bearer YOUR_PAT" "${exportUrl}" -o skills.zip`
-
-  const handleCopyCommand = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(downloadCommand)
-      setCopiedCommand(true)
-      setTimeout(() => setCopiedCommand(false), 2000)
-    } catch {
-      // Silent fail
-    }
-  }
-
-  return (
-    <div className="space-y-3">
-      <StepCard number={3} title="Download Zip File" subtitle="Run this command to download your skills">
-        <div className="relative mt-2">
-          <pre className="rounded bg-gray-50 px-3 py-2 text-xs text-gray-700 whitespace-pre-wrap overflow-x-auto font-mono pr-14">
-            <code>{downloadCommand}</code>
-          </pre>
-          <button
-            onClick={handleCopyCommand}
-            className={`absolute top-1.5 right-1.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
-              copiedCommand
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
-            }`}
-          >
-            {copiedCommand ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-        <p className="mt-2 text-xs text-gray-500">
-          Replace <code className="bg-gray-100 px-1 rounded">YOUR_PAT</code> with your Personal Access Token from Step 1.
-        </p>
-      </StepCard>
-
-      <StepCard number={4} title="Upload to Claude Desktop">
-        <ol className="list-decimal list-inside text-xs text-gray-500 space-y-2 mt-1">
-          <li>Unzip the downloaded <code className="bg-gray-100 px-1 rounded">skills.zip</code> file</li>
-          <li>Open Claude Desktop and go to <strong>Settings → Capabilities</strong></li>
-          <li>Drag and drop <strong>individual</strong> <code className="bg-gray-100 px-1 rounded">.md</code> files from the unzipped folder onto the Capabilities screen, or click <strong>+ Add</strong> to select them one at a time</li>
-        </ol>
-        <p className="mt-2 text-xs text-gray-400">
-          Claude Desktop only accepts one skill per upload — repeat for each <code className="bg-gray-100 px-1 rounded">.md</code> file.
-        </p>
-      </StepCard>
-
-      <StepCard number={5} title="Use Your Skills">
-        <p className="text-xs text-gray-500 mt-1">
-          Skills are invoked via natural language (e.g., &quot;use my code review skill&quot;).
-          Claude will also auto-invoke them when relevant to your conversation.
-        </p>
-      </StepCard>
-    </div>
-  )
-}
-
-/**
- * Main skills export section component.
- */
-interface SkillsExportSectionProps {
-  client: SkillsClientType
-}
-
-/**
- * Compute default tags based on available tags.
- * Returns ['skill'] if 'skill' tag exists, ['skills'] if 'skills' tag exists, otherwise [].
- */
 function getDefaultSkillTags(availableTags: TagCount[]): string[] {
   const tagNames = availableTags.map((t) => t.name)
   if (tagNames.includes('skill')) return ['skill']
@@ -1823,286 +920,7 @@ function getDefaultSkillTags(availableTags: TagCount[]): string[] {
   return []
 }
 
-function SkillsExportSection({ client }: SkillsExportSectionProps): ReactNode {
-  const { isAuthenticated } = useAuthStatus()
-
-  // Local state for prompt-only tags (don't use global store which has all tags)
-  const [promptTags, setPromptTags] = useState<TagCount[]>([])
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-
-  // Fetch prompt tags on mount and apply default selection (only when authenticated to avoid 401 redirect)
-  useEffect(() => {
-    if (!isAuthenticated) return
-    let cancelled = false
-
-    const fetchPromptTags = async (): Promise<void> => {
-      try {
-        const response = await api.get<TagListResponse>('/tags/?content_types=prompt')
-        if (!cancelled) {
-          const tags = response.data.tags
-          setPromptTags(tags)
-          // Apply default tag selection
-          const defaultTags = getDefaultSkillTags(tags)
-          if (defaultTags.length > 0) {
-            setSelectedTags(defaultTags)
-          }
-        }
-      } catch {
-        // Silent fail - tags are optional
-      }
-    }
-    fetchPromptTags()
-
-    return () => {
-      cancelled = true
-    }
-  }, [isAuthenticated])
-
-  const exportUrl = buildSkillsExportUrl(client, selectedTags)
-
-  return (
-    <>
-      {/* CLI tip */}
-      <div className="mb-6 rounded-lg bg-blue-50 border border-blue-200 p-4">
-        <p className="text-sm text-blue-800">
-          <strong>Tip:</strong> If you have the Tiddly CLI installed, run{' '}
-          <code className="bg-blue-100 px-1 rounded">tiddly skills configure {client}</code> instead.
-          See <Link to="/docs/cli/skills" className="text-[#d97b3d] hover:underline">CLI docs</Link>.
-        </p>
-      </div>
-
-      {/* Client-specific notes */}
-      {(client === 'claude-code' || client === 'claude-desktop') && (
-        <div className="mb-6 rounded-lg bg-amber-50 border border-amber-200 p-4">
-          <p className="text-sm text-amber-800">
-            <strong>Note:</strong> Prompt names longer than 64 characters will be truncated for {client === 'claude-code' ? 'Claude Code' : 'Claude Desktop'}.
-          </p>
-        </div>
-      )}
-      {client === 'codex' && (
-        <div className="mb-6 rounded-lg bg-amber-50 border border-amber-200 p-4">
-          <p className="text-sm text-amber-800">
-            <strong>Note:</strong> Multi-line descriptions will be collapsed to a single line for Codex compatibility.
-          </p>
-        </div>
-      )}
-
-      <div className="space-y-3">
-        <StepCard number={1} title="Create a Personal Access Token" subtitle={`Set it as the PROMPTS_TOKEN environment variable`}>
-          <Link
-            to="/app/settings/tokens"
-            className="btn-primary inline-flex items-center gap-2 mt-2"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-            </svg>
-            Create Token
-          </Link>
-        </StepCard>
-
-        <StepCard number={2} title="Filter by Tags (Optional)" subtitle="Select which prompts to export. Leave empty to export all.">
-          <div className="mt-2">
-            <SkillsTagSelector
-              availableTags={promptTags}
-              selectedTags={selectedTags}
-              onChange={setSelectedTags}
-            />
-          </div>
-        </StepCard>
-
-        {/* Client-specific instructions (steps 3+) */}
-        {client === 'claude-code' && <ClaudeCodeSkillsInstructions exportUrl={exportUrl} />}
-        {client === 'codex' && <CodexSkillsInstructions exportUrl={exportUrl} />}
-        {client === 'claude-desktop' && <ClaudeDesktopSkillsInstructions exportUrl={exportUrl} />}
-      </div>
-    </>
-  )
-}
-
-/**
- * Manual setup section — the existing PyTorch-style selector and step-by-step
- * instructions using Personal Access Tokens and curl commands.
- */
-function ManualSetupSection(): ReactNode {
-  // Selector state
-  const [server, setServer] = useState<ServerType>('content')
-  const [client, setClient] = useState<ClientType>('claude-desktop')
-  const [auth, setAuth] = useState<AuthType>('bearer')
-  const [integration, setIntegration] = useState<IntegrationType>('mcp')
-
-  // Helper flags
-  const isSkills = integration === 'skills'
-  const isSkillsClient = client === 'claude-desktop' || client === 'claude-code' || client === 'codex'
-  const isMcpSupported = auth === 'bearer' && integration === 'mcp' && isSkillsClient
-  const isSkillsSupported = isSkills && isSkillsClient && server === 'prompts'
-
-  const getComingSoonContent = (): { title: string; description: string } | null => {
-    if (integration === 'mcp') {
-      if (client === 'chatgpt') {
-        return {
-          title: 'ChatGPT Integration Coming Soon',
-          description: 'ChatGPT requires OAuth authentication. OAuth implementation is coming soon.',
-        }
-      }
-      if (client === 'gemini-cli') {
-        return {
-          title: 'Gemini CLI Integration Coming Soon',
-          description: 'Gemini CLI MCP integration instructions are coming soon.',
-        }
-      }
-      if (auth === 'oauth') {
-        return {
-          title: 'OAuth Coming Soon',
-          description: 'OAuth authentication will allow secure browser-based login without needing to manage tokens manually. Coming soon.',
-        }
-      }
-    }
-    if (isSkills && server === 'content') {
-      return {
-        title: 'Skills Only Apply to Prompts',
-        description: 'Skills are exported from your prompt templates. Select "Prompts" to export your prompt templates as skills.',
-      }
-    }
-    if (isSkills && !isSkillsClient) {
-      return {
-        title: `${client === 'chatgpt' ? 'ChatGPT' : 'Gemini CLI'} Skills Coming Soon`,
-        description: `Skills export for ${client === 'chatgpt' ? 'ChatGPT' : 'Gemini CLI'} is not yet supported.`,
-      }
-    }
-    return null
-  }
-
-  const comingSoonContent = getComingSoonContent()
-
-  const manualServerOptions: SelectorOption<ServerType>[] = [
-    { value: 'content', label: 'Bookmarks & Notes', comingSoon: isSkills },
-    { value: 'prompts', label: 'Prompts' },
-  ]
-
-  const handleIntegrationChange = (newIntegration: IntegrationType): void => {
-    setIntegration(newIntegration)
-    if (newIntegration === 'skills') {
-      setServer('prompts')
-    }
-  }
-
-  const clientOptions: SelectorOption<ClientType>[] = [
-    { value: 'claude-desktop', label: 'Claude Desktop' },
-    { value: 'claude-code', label: 'Claude Code' },
-    { value: 'chatgpt', label: 'ChatGPT', comingSoon: true },
-    { value: 'codex', label: 'Codex' },
-    { value: 'gemini-cli', label: 'Gemini CLI', comingSoon: true },
-  ]
-
-  const authOptions: SelectorOption<AuthType>[] = [
-    { value: 'bearer', label: 'Bearer Token', comingSoon: client === 'chatgpt' },
-    { value: 'oauth', label: 'OAuth', comingSoon: true },
-  ]
-
-  const integrationOptions: SelectorOption<IntegrationType>[] = [
-    { value: 'mcp', label: 'MCP Server' },
-    { value: 'skills', label: 'Skills' },
-  ]
-
-  return (
-    <div data-testid="manual-setup-section">
-      <p className="text-sm text-gray-500 mb-6">
-        Step-by-step instructions for configuring MCP servers and skills using Personal Access Tokens and curl commands.
-        Note: this approach requires manually creating PATs and setting up each server/tool individually.
-        For a faster setup, use the CLI tab above.
-      </p>
-
-      {/* Config Selector */}
-      <div className="mb-8">
-        <h3 className="text-base font-bold text-gray-900 mb-4">Select Integration</h3>
-        <div className="md:border-l-4 md:border-l-[#f09040] bg-white py-1.5 flex flex-col gap-4 md:gap-1.5">
-          <SelectorRow
-            label="Integration"
-            options={integrationOptions}
-            value={integration}
-            onChange={handleIntegrationChange}
-          />
-          <SelectorRow
-            label="Content"
-            options={manualServerOptions}
-            value={server}
-            onChange={setServer}
-          />
-          <SelectorRow
-            label="Client"
-            options={clientOptions}
-            value={client}
-            onChange={setClient}
-          />
-          {!isSkills && (
-            <SelectorRow
-              label="Auth"
-              options={authOptions}
-              value={auth}
-              onChange={setAuth}
-            />
-          )}
-        </div>
-      </div>
-
-      {/* Integration explanation */}
-      {integration === 'mcp' && (
-        <div className="mb-8 rounded-lg bg-gray-50 border border-gray-200 p-4">
-          <h3 className="text-sm font-semibold text-gray-900 mb-2">What is MCP?</h3>
-          <p className="text-sm text-gray-600">
-            The <a href="https://modelcontextprotocol.io/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">Model Context Protocol (MCP)</a> is
-            an open standard that allows AI assistants to securely access external tools and data.
-            By connecting your bookmarks, notes, and prompts via MCP, AI agents can search your content,
-            create new items, and use your prompt templates directly.
-          </p>
-        </div>
-      )}
-      {integration === 'skills' && (
-        <div className="mb-8 rounded-lg bg-gray-50 border border-gray-200 p-4">
-          <h3 className="text-sm font-semibold text-gray-900 mb-2">What are Skills?</h3>
-          <p className="text-sm text-gray-600">
-            Skills are reusable instruction files that AI agents auto-invoke based on context
-            or that you trigger manually. Export your prompts as skills and sync them to your AI client.
-            Skills follow the <a href="https://agentskills.io/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">Agent Skills Standard</a>.
-          </p>
-        </div>
-      )}
-
-      {/* Setup Instructions */}
-      <div className="mb-6">
-        <h3 className="text-base font-bold text-gray-900 mb-4">Setup Instructions</h3>
-      </div>
-
-      {comingSoonContent && (
-        <ComingSoon title={comingSoonContent.title} description={comingSoonContent.description} />
-      )}
-
-      {isMcpSupported && client === 'claude-desktop' && (
-        <ClaudeDesktopInstructions server={server} mcpUrl={config.mcpUrl} promptMcpUrl={config.promptMcpUrl} />
-      )}
-      {isMcpSupported && client === 'claude-code' && (
-        <ClaudeCodeInstructions server={server} mcpUrl={config.mcpUrl} promptMcpUrl={config.promptMcpUrl} />
-      )}
-      {isMcpSupported && client === 'codex' && (
-        <CodexInstructions server={server} mcpUrl={config.mcpUrl} promptMcpUrl={config.promptMcpUrl} />
-      )}
-
-      {isSkillsSupported && (
-        <SkillsExportSection client={client as SkillsClientType} />
-      )}
-
-      {isMcpSupported && <div className="mt-8"><AvailableTools server={server} /></div>}
-    </div>
-  )
-}
-
-/**
- * Reusable AI setup widget with CLI and manual (Curl/PAT) tabs.
- * Renders the full interactive setup experience without page title or heading.
- */
 export function AISetupWidget(): ReactNode {
-  const [activeTab, setActiveTab] = useState<SetupTab>('cli')
-
   return (
     <div>
       <p className="text-sm text-gray-600 mb-4">
@@ -2126,34 +944,11 @@ export function AISetupWidget(): ReactNode {
         files that AI assistants can auto-invoke based on context.
       </p>
 
-      {/* Tab bar */}
-      <div className="flex border-b border-gray-200 mb-6">
-        <button
-          type="button"
-          onClick={() => setActiveTab('cli')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === 'cli'
-              ? 'border-[#f09040] text-[#d97b3d]'
-              : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-          }`}
-        >
-          Setup via CLI (Recommended)
-        </button>
-        <button
-          type="button"
-          onClick={() => setActiveTab('manual')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === 'manual'
-              ? 'border-[#f09040] text-[#d97b3d]'
-              : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-          }`}
-        >
-          Setup via Curl/PAT
-        </button>
-      </div>
+      <h2 className="text-lg font-semibold text-gray-900 mb-6 pb-2 border-b border-gray-200">
+        Setup via CLI
+      </h2>
 
-      {activeTab === 'cli' && <CLISetupSection />}
-      {activeTab === 'manual' && <ManualSetupSection />}
+      <CLISetupSection />
     </div>
   )
 }

--- a/frontend/src/data/docsRoutes.tsx
+++ b/frontend/src/data/docsRoutes.tsx
@@ -116,7 +116,7 @@ export const DOCS_ROUTES: DocsRoute[] = [
     label: 'Docs: AI Integration',
     searchText:
       'ai integration mcp model context protocol claude code claude desktop codex '
-      + 'cursor windsurf chatgpt connect ai assistants agents setup configure tokens '
+      + 'antigravity agy gemini google cursor windsurf chatgpt connect ai assistants agents setup configure tokens '
       + 'example prompts widget tools server',
   },
   {

--- a/frontend/src/data/settingsRoutes.tsx
+++ b/frontend/src/data/settingsRoutes.tsx
@@ -85,7 +85,7 @@ export const SETTINGS_ROUTES: SettingsRoute[] = [
     icon: <SparklesIcon className="h-4 w-4" />,
     searchText:
       'ai integration mcp model context protocol claude desktop claude code '
-      + 'codex setup configure cli command manual curl pat tokens scope user '
+      + 'codex antigravity agy gemini google setup configure cli command tokens scope user '
       + 'directory tools servers content prompts skills agent connect ai '
       + 'assistant install remove status detect',
   },

--- a/frontend/src/data/tips/tips.ts
+++ b/frontend/src/data/tips/tips.ts
@@ -76,7 +76,7 @@ export const allTips: Tip[] = [
     id: 'connect-ai-tool-to-content',
     title: 'Let your AI assistant read and edit your bookmarks and notes',
     body:
-      'Open Settings → AI Integration, pick your AI tool (Claude Desktop, Claude Code, Codex), and run the displayed `tiddly mcp configure` command. Your AI assistant can then search, read, and edit your bookmarks and notes directly — no copy-paste, no exporting. Ask it *"find the article I saved about transformers"* or *"fix the typo in my last meeting note"* and it goes straight at your library.',
+      'Open Settings → AI Integration, pick your AI tool (Claude Desktop, Claude Code, Codex, Antigravity), and run the displayed `tiddly mcp configure` command. Your AI assistant can then search, read, and edit your bookmarks and notes directly — no copy-paste, no exporting. Ask it *"find the article I saved about transformers"* or *"fix the typo in my last meeting note"* and it goes straight at your library.',
     categories: ['cli', 'mcp', 'bookmarks', 'notes'],
     audience: 'all',
     priority: 8,
@@ -114,7 +114,7 @@ export const allTips: Tip[] = [
     id: 'auto-configure-mcp',
     title: 'Set up MCP for every AI tool with one command',
     body:
-      'Run `tiddly mcp configure` with no arguments to set up every detected AI tool at once. The CLI finds Claude Desktop, Claude Code, and Codex, mints a dedicated token per tool/server, and writes entries for both the Content MCP and Prompt MCP servers. Any custom MCP entries you\'ve added by hand are left untouched.',
+      'Run `tiddly mcp configure` with no arguments to set up every detected AI tool at once. The CLI finds Claude Desktop, Claude Code, Codex, and Antigravity, mints a dedicated token per tool/server, and writes entries for both the Content MCP and Prompt MCP servers. Any custom MCP entries you\'ve added by hand are left untouched.',
     categories: ['cli', 'mcp'],
     audience: 'beginner',
     priority: 15,

--- a/frontend/src/pages/AIIntegration.tsx
+++ b/frontend/src/pages/AIIntegration.tsx
@@ -61,41 +61,49 @@ const AI_CLIENTS: AIClient[] = [
     comingSoon: true,
   },
   {
-    name: 'Gemini CLI',
+    name: 'Antigravity',
     maker: 'Google',
     icon: <GeminiIcon className="h-6 w-6" />,
-    environment: 'Terminal',
-    description: 'MCP integration instructions are coming soon.',
-    connectionMethods: { mcp: false, skills: false },
+    environment: 'Terminal + Desktop',
+    description: 'Access your bookmarks, notes, and prompts from the agy CLI or the Antigravity IDE.',
+    connectionMethods: { mcp: true, skills: false },
     docsPath: '/docs/ai',
-    comingSoon: true,
+    configType: 'JSON',
+    mcpPrompts: false,
   },
 ]
 
+// Antigravity values reflect agy 1.0.0 (verified 2026-05-19): JSON config,
+// tools-only MCP client (no MCP prompts), and no Tiddly skills integration.
+// Revisit if a future agy release adds prompt support.
 const comparisonRows = [
   {
     feature: 'Environment',
     claudeDesktop: 'Desktop',
     claudeCode: 'Terminal',
     codex: 'Terminal',
+    antigravity: 'Terminal + Desktop',
   },
   {
     feature: 'Config type',
     claudeDesktop: 'JSON',
     claudeCode: 'CLI',
     codex: 'TOML',
+    antigravity: 'JSON',
   },
   {
     feature: 'MCP Prompts',
     claudeDesktop: true,
     claudeCode: true,
     codex: false,
+    antigravity: false,
   },
   {
     feature: 'Agent Skills',
     claudeDesktop: true,
     claudeCode: true,
     codex: true,
+    antigravity: false,
   },
 ]
 
@@ -229,6 +237,9 @@ export function AIIntegration(): ReactNode {
                 <th className="px-4 py-4 text-center text-sm font-semibold text-gray-900">
                   Codex
                 </th>
+                <th className="px-4 py-4 text-center text-sm font-semibold text-gray-900">
+                  Antigravity
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -243,6 +254,9 @@ export function AIIntegration(): ReactNode {
                   </td>
                   <td className="px-4 py-3 text-center text-sm text-gray-600">
                     <ComparisonCell value={row.codex} />
+                  </td>
+                  <td className="px-4 py-3 text-center text-sm text-gray-600">
+                    <ComparisonCell value={row.antigravity} />
                   </td>
                 </tr>
               ))}

--- a/frontend/src/pages/docs/DocsAIHub.test.tsx
+++ b/frontend/src/pages/docs/DocsAIHub.test.tsx
@@ -46,11 +46,11 @@ describe('DocsAIHub', () => {
     expect(screen.getByText(/Agent Skills/)).toBeInTheDocument()
   })
 
-  it('should render the AI setup widget with CLI tab', () => {
+  it('should render the AI setup widget (CLI setup, no manual tab)', () => {
     renderPage()
     expect(screen.getByTestId('cli-setup-section')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Setup via CLI (Recommended)' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Setup via Curl/PAT' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Setup via CLI' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Setup via Curl/PAT' })).not.toBeInTheDocument()
   })
 
   it('should render example prompts section', () => {

--- a/frontend/src/pages/docs/DocsCLIHub.tsx
+++ b/frontend/src/pages/docs/DocsCLIHub.tsx
@@ -33,7 +33,7 @@ export function DocsCLIHub(): ReactNode {
       <p className="text-sm text-gray-600 mb-8">
         The Tiddly CLI (<code className="bg-gray-100 px-1 rounded">tiddly</code>) is a command-line
         tool for authenticating with the Tiddly API, configuring MCP servers, syncing agent skills,
-        and exporting content for AI tools like Claude Desktop, Claude Code, and Codex.
+        and exporting content for AI tools like Claude Desktop, Claude Code, Codex, and Antigravity.
       </p>
 
       <div className="mb-10">

--- a/frontend/src/pages/docs/DocsCLIMCP.tsx
+++ b/frontend/src/pages/docs/DocsCLIMCP.tsx
@@ -13,7 +13,7 @@ export function DocsCLIMCP(): ReactNode {
       <p className="text-sm text-gray-600 mb-8">
         The <code className="bg-gray-100 px-1 rounded">tiddly mcp</code> commands auto-detect
         installed AI tools and configure MCP servers with dedicated tokens. Supported tools:
-        Claude Desktop, Claude Code, and Codex.
+        Claude Desktop, Claude Code, Codex, and Antigravity.
       </p>
 
       {/* tiddly mcp configure */}
@@ -67,6 +67,24 @@ tiddly mcp configure claude-code codex              # multiple tools`} />
           <Link to="/docs/cli/skills" className="underline hover:text-gray-900">Skills</Link>.
         </p>
       </InfoCallout>
+
+      <div className="mt-4">
+      <InfoCallout variant="info" title="Antigravity (Google)">
+        <p>
+          Antigravity — Google&apos;s successor to Gemini CLI for individual-tier users — is
+          configured with <code className="bg-blue-100 px-1 rounded">tiddly mcp configure antigravity</code>.
+          The <code className="bg-blue-100 px-1 rounded">agy</code> CLI and the Antigravity IDE share
+          one config file (<code className="bg-blue-100 px-1 rounded">~/.gemini/config/mcp_config.json</code>),
+          so configuring once covers both. It reads the file at startup — quit and restart Antigravity
+          after configuring. Antigravity supports <strong>user scope only</strong>, and like Codex it&apos;s
+          a tools-only MCP client (no MCP Prompts). Unlike Codex, it has no Tiddly skills integration,
+          so your prompt templates are accessed through the prompt server&apos;s tools{' '}
+          (<code className="bg-blue-100 px-1 rounded">search_prompts</code>,{' '}
+          <code className="bg-blue-100 px-1 rounded">get_prompt_content</code>) rather than as slash
+          commands or skills.
+        </p>
+      </InfoCallout>
+      </div>
 
       {/* tiddly mcp status */}
       <h2 className="text-lg font-bold text-gray-900 mt-10 mb-4">tiddly mcp status</h2>
@@ -214,9 +232,13 @@ tiddly mcp remove claude-code --delete-tokens" />
               <td className="py-2 pr-4">Claude Code</td>
               <td className="py-2"><code className="bg-gray-100 px-1 rounded">claude</code> binary in PATH</td>
             </tr>
-            <tr>
+            <tr className="border-b border-gray-100">
               <td className="py-2 pr-4">Codex</td>
               <td className="py-2"><code className="bg-gray-100 px-1 rounded">codex</code> binary in PATH or <code className="bg-gray-100 px-1 rounded">~/.codex/</code> exists</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4">Antigravity</td>
+              <td className="py-2"><code className="bg-gray-100 px-1 rounded">agy</code> binary in PATH, or <code className="bg-gray-100 px-1 rounded">~/.gemini/antigravity-cli/</code> / <code className="bg-gray-100 px-1 rounded">~/.gemini/antigravity/</code> exists</td>
             </tr>
           </tbody>
         </table>
@@ -250,10 +272,15 @@ tiddly mcp remove claude-code --delete-tokens" />
               <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded text-xs">~/.claude.json</code></td>
               <td className="py-2">JSON</td>
             </tr>
-            <tr>
+            <tr className="border-b border-gray-100">
               <td className="py-2 pr-4">Codex</td>
               <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded text-xs">~/.codex/config.toml</code></td>
               <td className="py-2">TOML</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4">Antigravity</td>
+              <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded text-xs">~/.gemini/config/mcp_config.json</code>{' '}<span className="text-gray-400 text-xs">(shared by the agy CLI and IDE)</span></td>
+              <td className="py-2">JSON</td>
             </tr>
           </tbody>
         </table>
@@ -285,7 +312,8 @@ tiddly mcp remove claude-code --delete-tokens" />
               <th className="py-2 pr-4 text-left font-semibold text-gray-900">Scope</th>
               <th className="py-2 pr-4 text-left font-semibold text-gray-900">Claude Desktop</th>
               <th className="py-2 pr-4 text-left font-semibold text-gray-900">Claude Code</th>
-              <th className="py-2 text-left font-semibold text-gray-900">Codex</th>
+              <th className="py-2 pr-4 text-left font-semibold text-gray-900">Codex</th>
+              <th className="py-2 text-left font-semibold text-gray-900">Antigravity</th>
             </tr>
           </thead>
           <tbody className="text-sm text-gray-600">
@@ -293,13 +321,15 @@ tiddly mcp remove claude-code --delete-tokens" />
               <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded">user</code> (default)</td>
               <td className="py-2 pr-4">Global config</td>
               <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded text-xs">~/.claude.json</code> top-level</td>
-              <td className="py-2"><code className="bg-gray-100 px-1 rounded text-xs">~/.codex/config.toml</code></td>
+              <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded text-xs">~/.codex/config.toml</code></td>
+              <td className="py-2"><code className="bg-gray-100 px-1 rounded text-xs">~/.gemini/config/mcp_config.json</code></td>
             </tr>
             <tr>
               <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded">directory</code></td>
               <td className="py-2 pr-4 text-gray-400">Not supported</td>
               <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded text-xs">~/.claude.json</code> under project key</td>
-              <td className="py-2"><code className="bg-gray-100 px-1 rounded text-xs">.codex/config.toml</code> in cwd</td>
+              <td className="py-2 pr-4"><code className="bg-gray-100 px-1 rounded text-xs">.codex/config.toml</code> in cwd</td>
+              <td className="py-2 text-gray-400">Not supported</td>
             </tr>
           </tbody>
         </table>
@@ -341,13 +371,6 @@ tiddly mcp remove claude-code --delete-tokens" />
       </div>
 
       {/* Cross-link to AI Integration */}
-      <InfoCallout variant="tip" title="Manual Setup">
-        <p>
-          Prefer configuring MCP servers manually? See the{' '}
-          <Link to="/docs/ai" className="underline hover:text-gray-900">AI Integration</Link>{' '}
-          docs for step-by-step guides.
-        </p>
-      </InfoCallout>
     </div>
   )
 }

--- a/frontend/src/pages/docs/DocsCLIMCP.tsx
+++ b/frontend/src/pages/docs/DocsCLIMCP.tsx
@@ -75,8 +75,9 @@ tiddly mcp configure claude-code codex              # multiple tools`} />
           configured with <code className="bg-blue-100 px-1 rounded">tiddly mcp configure antigravity</code>.
           The <code className="bg-blue-100 px-1 rounded">agy</code> CLI and the Antigravity IDE share
           one config file (<code className="bg-blue-100 px-1 rounded">~/.gemini/config/mcp_config.json</code>),
-          so configuring once covers both. It reads the file at startup — quit and restart Antigravity
-          after configuring. Antigravity supports <strong>user scope only</strong>, and like Codex it&apos;s
+          so configuring once covers both. Antigravity reads the file at startup, so quit and restart
+          the IDE after configuring (the <code className="bg-blue-100 px-1 rounded">agy</code> CLI picks
+          up changes on its next run). Antigravity supports <strong>user scope only</strong>, and like Codex it&apos;s
           a tools-only MCP client (no MCP Prompts). Unlike Codex, it has no Tiddly skills integration,
           so your prompt templates are accessed through the prompt server&apos;s tools{' '}
           (<code className="bg-blue-100 px-1 rounded">search_prompts</code>,{' '}

--- a/frontend/src/pages/docs/DocsCLISkills.tsx
+++ b/frontend/src/pages/docs/DocsCLISkills.tsx
@@ -188,7 +188,7 @@ tiddly skills list --tags python         # list skills filtered by tags`} />
       {/* Cross-links */}
       <InfoCallout variant="tip" title="See Also">
         <p>
-          For manual setup without the CLI, see the{' '}
+          For an overview of supported AI tools and connection methods, see the{' '}
           <Link to="/docs/ai" className="underline hover:text-gray-900">AI Integration</Link>{' '}
           docs. For creating prompts to export as skills, see{' '}
           <Link to="/docs/features/prompts" className="underline hover:text-gray-900">Prompts &amp; Templates</Link>.

--- a/frontend/src/pages/settings/SettingsMCP.test.tsx
+++ b/frontend/src/pages/settings/SettingsMCP.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tests for SettingsMCP settings page.
  *
- * Tests both the CLI setup section (default tab) and the manual setup section (Curl/PAT tab).
+ * Covers the CLI setup section (the only setup flow — the manual Curl/PAT tab was removed).
  *
  * For the tool/scope support matrix and terminology decisions,
  * see docs/ai-integration.md

--- a/frontend/src/pages/settings/SettingsMCP.test.tsx
+++ b/frontend/src/pages/settings/SettingsMCP.test.tsx
@@ -100,13 +100,6 @@ function renderWithRouter(): void {
   )
 }
 
-/** Switch to manual setup tab and return the manual section container. */
-async function openManualSection(): Promise<HTMLElement> {
-  const user = userEvent.setup()
-  await user.click(screen.getByRole('button', { name: 'Setup via Curl/PAT' }))
-  return screen.getByTestId('manual-setup-section')
-}
-
 describe('SettingsMCP', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -126,23 +119,13 @@ describe('SettingsMCP', () => {
       expect(screen.getByText('AI Integration')).toBeInTheDocument()
     })
 
-    it('should render tab buttons', () => {
+    it('should render the CLI setup section (no tabs, manual setup removed)', () => {
       renderWithRouter()
-      expect(screen.getByRole('button', { name: 'Setup via CLI (Recommended)' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Setup via Curl/PAT' })).toBeInTheDocument()
-    })
-
-    it('should show CLI section by default', () => {
-      renderWithRouter()
+      expect(screen.getByRole('heading', { name: 'Setup via CLI' })).toBeInTheDocument()
       expect(screen.getByTestId('cli-setup-section')).toBeInTheDocument()
+      // The old Curl/PAT manual tab is gone.
+      expect(screen.queryByRole('button', { name: 'Setup via Curl/PAT' })).not.toBeInTheDocument()
       expect(screen.queryByTestId('manual-setup-section')).not.toBeInTheDocument()
-    })
-
-    it('should switch to manual section when tab clicked', async () => {
-      renderWithRouter()
-      await openManualSection()
-      expect(screen.getByTestId('manual-setup-section')).toBeInTheDocument()
-      expect(screen.queryByTestId('cli-setup-section')).not.toBeInTheDocument()
     })
   })
 
@@ -168,6 +151,7 @@ describe('SettingsMCP', () => {
       expect(within(cli).getByRole('button', { name: 'Claude Desktop' })).toBeInTheDocument()
       expect(within(cli).getByRole('button', { name: 'Claude Code' })).toBeInTheDocument()
       expect(within(cli).getByRole('button', { name: 'Codex' })).toBeInTheDocument()
+      expect(within(cli).getByRole('button', { name: 'Antigravity' })).toBeInTheDocument()
     })
 
     it('should have servers and tools selected by default with skills off', () => {
@@ -255,6 +239,29 @@ describe('SettingsMCP', () => {
       const pre = within(cli).getByTestId('cli-install-command')
       expect(pre.textContent).toContain('tiddly mcp configure claude-code')
       expect(pre.textContent).not.toContain('codex')
+    })
+
+    // Intentional asymmetry: when ALL tools are selected the command omits tool
+    // names and emits bare `tiddly mcp configure`, which auto-detects *installed*
+    // tools and gracefully skips ones that aren't present. A PARTIAL selection
+    // (the test above) names tools explicitly, which is strict — `tiddly mcp
+    // configure <uninstalled-tool>` errors. So "select everything" maps to the
+    // forgiving auto-detect path on purpose, not by accident.
+    it('should emit bare auto-detect command when all tools selected', async () => {
+      const user = userEvent.setup()
+      renderWithRouter()
+      const cli = screen.getByTestId('cli-setup-section')
+
+      // Defaults are claude-code + codex; add the remaining two to select all four.
+      await user.click(within(cli).getByRole('button', { name: 'Claude Desktop' }))
+      await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+
+      const pre = within(cli).getByTestId('cli-install-command')
+      const mcpLine = (pre.textContent || '').split('\n').find((l) => l.includes('tiddly mcp configure')) || ''
+      expect(mcpLine).toContain('tiddly mcp configure')
+      for (const name of ['claude-desktop', 'claude-code', 'codex', 'antigravity']) {
+        expect(mcpLine).not.toContain(name)
+      }
     })
 
     it('should show empty state when nothing selected', async () => {
@@ -346,6 +353,135 @@ describe('SettingsMCP', () => {
         renderWithRouter()
         const cli = screen.getByTestId('cli-setup-section')
         expect(within(cli).queryByText(/doesn't support/)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('antigravity', () => {
+      it('should add antigravity to the configure command when selected', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+
+        const pre = within(cli).getByTestId('cli-install-command')
+        expect(pre.textContent).toContain('antigravity')
+      })
+
+      it('should show user-scope-only error when antigravity selected with Directory scope', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
+
+        expect(within(cli).getByText(/only support.*User scope/)).toBeInTheDocument()
+        // No command is offered while the conflict stands.
+        expect(within(cli).queryByTestId('cli-install-command')).not.toBeInTheDocument()
+      })
+
+      it('should not be affected by the Skills toggle on its own (no skills, no error when skills off)', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        // Select only Antigravity (deselect the two defaults).
+        await user.click(within(cli).getByRole('button', { name: 'Claude Code' }))
+        await user.click(within(cli).getByRole('button', { name: 'Codex' }))
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+
+        // Skills off (default): just the configure command, no skills, no error.
+        const pre = within(cli).getByTestId('cli-install-command')
+        expect(pre.textContent).toContain('tiddly mcp configure antigravity')
+        expect(pre.textContent).not.toContain('tiddly skills configure')
+        expect(within(cli).queryByText(/does not support skills/)).not.toBeInTheDocument()
+      })
+    })
+
+    describe('skills support conflict', () => {
+      it('should error when skills enabled with only Antigravity selected', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        await user.click(within(cli).getByRole('button', { name: 'Claude Code' }))
+        await user.click(within(cli).getByRole('button', { name: 'Codex' }))
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+        await user.click(within(cli).getByRole('button', { name: 'Yes' })) // enable skills
+
+        expect(within(cli).getByText('Antigravity does not support skills. Deselect it or turn off Skills.')).toBeInTheDocument()
+        // The conflict blocks the command entirely (mirrors the scope conflict).
+        expect(within(cli).queryByTestId('cli-install-command')).not.toBeInTheDocument()
+      })
+
+      it('should error when skills enabled and Antigravity is selected alongside skills-capable tools', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        // Defaults claude-code + codex (skills-capable) plus Antigravity.
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+        await user.click(within(cli).getByRole('button', { name: 'Yes' })) // enable skills
+
+        expect(within(cli).getByText('Antigravity does not support skills. Deselect it or turn off Skills.')).toBeInTheDocument()
+        expect(within(cli).queryByTestId('cli-install-command')).not.toBeInTheDocument()
+      })
+
+      it('should clear the skills conflict when Skills is turned off', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+        await user.click(within(cli).getByRole('button', { name: 'Yes' })) // enable skills → conflict
+        expect(within(cli).getByText(/does not support skills/)).toBeInTheDocument()
+
+        await user.click(within(cli).getByRole('button', { name: 'No' })) // disable skills → resolved
+        expect(within(cli).queryByText(/does not support skills/)).not.toBeInTheDocument()
+        expect(within(cli).getByTestId('cli-install-command').textContent).toContain('tiddly mcp configure')
+      })
+
+      it('should clear the skills conflict when the unsupported tool is deselected', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+        await user.click(within(cli).getByRole('button', { name: 'Yes' })) // conflict
+        expect(within(cli).getByText(/does not support skills/)).toBeInTheDocument()
+
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' })) // deselect → resolved
+        expect(within(cli).queryByText(/does not support skills/)).not.toBeInTheDocument()
+        const pre = within(cli).getByTestId('cli-install-command')
+        expect(pre.textContent).toContain('tiddly skills configure')
+      })
+
+      it('should show both scope and skills conflicts together', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        await user.click(within(cli).getByRole('button', { name: 'Antigravity' }))
+        await user.click(within(cli).getByRole('button', { name: 'Yes' }))       // skills conflict
+        await user.click(within(cli).getByRole('button', { name: 'Directory' })) // scope conflict
+
+        expect(within(cli).getByText(/only support.*User scope/)).toBeInTheDocument()
+        expect(within(cli).getByText(/does not support skills/)).toBeInTheDocument()
+        expect(within(cli).queryByTestId('cli-install-command')).not.toBeInTheDocument()
+      })
+
+      it('should not error when skills enabled with only skills-capable tools', async () => {
+        const user = userEvent.setup()
+        renderWithRouter()
+        const cli = screen.getByTestId('cli-setup-section')
+
+        // Defaults claude-code + codex are both skills-capable.
+        await user.click(within(cli).getByRole('button', { name: 'Yes' })) // enable skills
+
+        expect(within(cli).queryByText(/does not support skills/)).not.toBeInTheDocument()
+        const pre = within(cli).getByTestId('cli-install-command')
+        expect(pre.textContent).toContain('tiddly skills configure')
       })
     })
 
@@ -447,655 +583,4 @@ describe('SettingsMCP', () => {
     })
   })
 
-  // ===========================================================================
-  // Manual Setup Section (Curl/PAT tab)
-  // ===========================================================================
-  describe('manual setup section', () => {
-    it('should not be visible on default CLI tab', () => {
-      renderWithRouter()
-      expect(screen.queryByTestId('manual-setup-section')).not.toBeInTheDocument()
-    })
-
-    it('should show when Curl/PAT tab clicked', async () => {
-      renderWithRouter()
-      const manual = await openManualSection()
-      expect(manual).toBeInTheDocument()
-      expect(within(manual).getByText('Select Integration')).toBeInTheDocument()
-    })
-
-    describe('selector rows', () => {
-      it('should render all selector row labels', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        expect(within(manual).getByText('Content')).toBeInTheDocument()
-        expect(within(manual).getByText('Client')).toBeInTheDocument()
-        expect(within(manual).getByText('Auth')).toBeInTheDocument()
-        expect(within(manual).getByText('Integration')).toBeInTheDocument()
-      })
-
-      it('should render integration options', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        expect(within(manual).getByRole('button', { name: 'MCP Server' })).toBeInTheDocument()
-        expect(within(manual).getByRole('button', { name: 'Skills' })).toBeInTheDocument()
-      })
-
-      it('should render client options', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        expect(within(manual).getByRole('button', { name: 'Claude Desktop' })).toBeInTheDocument()
-        expect(within(manual).getByRole('button', { name: 'Claude Code' })).toBeInTheDocument()
-        expect(within(manual).getByRole('button', { name: 'Gemini CLI' })).toBeInTheDocument()
-        expect(within(manual).getByRole('button', { name: 'ChatGPT' })).toBeInTheDocument()
-        expect(within(manual).getByRole('button', { name: 'Codex' })).toBeInTheDocument()
-      })
-
-      it('should render auth options', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        expect(within(manual).getByRole('button', { name: 'Bearer Token' })).toBeInTheDocument()
-        expect(within(manual).getByRole('button', { name: 'OAuth' })).toBeInTheDocument()
-      })
-    })
-
-    describe('MCP instructions', () => {
-      it('should show What is MCP section when MCP is selected', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-        expect(within(manual).getByText('What is MCP?')).toBeInTheDocument()
-      })
-
-      it('should show Claude Desktop instructions by default', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        expect(within(manual).getByText('Locate Config File')).toBeInTheDocument()
-        expect(within(manual).getByText(/macOS:/)).toBeInTheDocument()
-        expect(within(manual).getByText(/Windows:/)).toBeInTheDocument()
-      })
-
-      it('should generate config with tiddly_notes_bookmarks for content server', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        const preElement = manual.querySelector('pre code')
-        expect(preElement?.textContent).toContain('tiddly_notes_bookmarks')
-        expect(preElement?.textContent).toContain('http://localhost:8001/mcp')
-      })
-
-      it('should show Claude Code instructions when Claude Code is selected', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Claude Code' }))
-
-        expect(within(manual).getByText('Add MCP Server')).toBeInTheDocument()
-        const preElement = manual.querySelector('pre code')
-        expect(preElement?.textContent).toContain('claude mcp add --transport http tiddly_notes_bookmarks')
-      })
-
-      it('should show Claude Code import from desktop option', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Claude Code' }))
-
-        expect(within(manual).getByText('Alternative: Import from Claude Desktop')).toBeInTheDocument()
-        expect(within(manual).getByText('claude mcp add-from-claude-desktop')).toBeInTheDocument()
-      })
-
-      it('should show Codex instructions when Codex is selected', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Codex' }))
-
-        expect(within(manual).getByText('Add to Config File')).toBeInTheDocument()
-        expect(within(manual).getByText(/~\/\.codex\/config\.toml/)).toBeInTheDocument()
-      })
-
-      it('should show prompt server config when Prompts is selected', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Prompts' }))
-
-        const preElement = manual.querySelector('pre code')
-        expect(preElement?.textContent).toContain('"tiddly_prompts"')
-        expect(preElement?.textContent).toContain('http://localhost:8002/mcp')
-      })
-    })
-
-    describe('coming soon features', () => {
-      it('should show coming soon for ChatGPT', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'ChatGPT' }))
-
-        expect(within(manual).getByText('ChatGPT Integration Coming Soon')).toBeInTheDocument()
-      })
-
-      it('should show coming soon for OAuth', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'OAuth' }))
-
-        expect(within(manual).getByText('OAuth Coming Soon')).toBeInTheDocument()
-      })
-
-      it('should show skills not applicable for Bookmarks & Notes', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Skills' }))
-        await user.click(within(manual).getByRole('button', { name: 'Bookmarks & Notes' }))
-
-        expect(within(manual).getByText('Skills Only Apply to Prompts')).toBeInTheDocument()
-      })
-    })
-
-    describe('skills export', () => {
-      it('should show skills export section when Skills + Prompts selected', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Skills' }))
-
-        expect(within(manual).getByText('Filter by Tags (Optional)')).toBeInTheDocument()
-      })
-
-      it('should show What are Skills section', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Skills' }))
-
-        expect(within(manual).getByText('What are Skills?')).toBeInTheDocument()
-      })
-    })
-
-    describe('available tools', () => {
-      it('should show content tools for content server', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        expect(within(manual).getByText('Available MCP Tools')).toBeInTheDocument()
-        expect(within(manual).getAllByText('search_items').length).toBeGreaterThan(0)
-        expect(within(manual).getAllByText('create_bookmark').length).toBeGreaterThan(0)
-      })
-
-      it('should show prompt tools for prompt server', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Prompts' }))
-
-        expect(within(manual).getAllByText('search_prompts').length).toBeGreaterThan(0)
-        expect(within(manual).getAllByText('create_prompt').length).toBeGreaterThan(0)
-      })
-
-      it('should not show tools for unsupported clients', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Gemini CLI' }))
-
-        expect(within(manual).queryByText('Available MCP Tools')).not.toBeInTheDocument()
-      })
-    })
-
-    describe('links', () => {
-      it('should have link to create token page', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        const createTokenLink = within(manual).getByRole('link', { name: /create token/i })
-        expect(createTokenLink).toHaveAttribute('href', '/app/settings/tokens')
-      })
-
-      it('should have link to MCP documentation', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        const mcpLink = within(manual).getByRole('link', { name: /model context protocol/i })
-        expect(mcpLink).toHaveAttribute('href', 'https://modelcontextprotocol.io/')
-        expect(mcpLink).toHaveAttribute('target', '_blank')
-      })
-    })
-
-    describe('both servers tip', () => {
-      it('should show tip for Claude Desktop', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-        expect(within(manual).getByText('Want to add both servers?')).toBeInTheDocument()
-      })
-
-      it('should show tip for Claude Code', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        await user.click(within(manual).getByRole('button', { name: 'Claude Code' }))
-
-        expect(within(manual).getByText('Want to add both servers?')).toBeInTheDocument()
-      })
-    })
-
-    describe('copy functionality', () => {
-      it('should copy config when copy button clicked', async () => {
-        renderWithRouter()
-        const manual = await openManualSection()
-
-        const copyButtons = within(manual).getAllByText('Copy')
-        const user = userEvent.setup()
-        await user.click(copyButtons[0])
-
-        await waitFor(() => {
-          expect(within(manual).getAllByText('Copied!').length).toBeGreaterThan(0)
-        })
-      })
-    })
-  })
-
-  // ===========================================================================
-  // Remove Flow
-  // ===========================================================================
-  describe('remove flow', () => {
-    /** Switch to Remove action and return the CLI section. */
-    async function switchToRemove(): Promise<{ user: ReturnType<typeof userEvent.setup>; cli: HTMLElement }> {
-      const user = userEvent.setup()
-      renderWithRouter()
-      const cli = screen.getByTestId('cli-setup-section')
-      await user.click(within(cli).getByRole('button', { name: 'Remove' }))
-      return { user, cli }
-    }
-
-    describe('scope selector', () => {
-      it('should show single Scope selector in remove flow', async () => {
-        const { cli } = await switchToRemove()
-        expect(within(cli).getByText('Scope')).toBeInTheDocument()
-        expect(within(cli).getByRole('button', { name: 'User' })).toBeInTheDocument()
-        expect(within(cli).getByRole('button', { name: 'Directory' })).toBeInTheDocument()
-      })
-
-      it('should show Scope when only skills selected in remove flow', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Bookmarks & Notes' }))
-        await user.click(within(cli).getByRole('button', { name: 'Prompts' }))
-        const yesButtons = within(cli).getAllByRole('button', { name: 'Yes' })
-        await user.click(yesButtons[0])
-
-        expect(within(cli).getByText('Scope')).toBeInTheDocument()
-      })
-
-      it('should default remove scope to user', async () => {
-        const { cli } = await switchToRemove()
-        expect(within(cli).getByRole('button', { name: 'User' }).className).toContain('bg-[#f09040]')
-      })
-
-      it('should add --scope directory to remove command', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toContain('--scope directory')
-      })
-
-      it('should not add --scope when user scope selected', async () => {
-        const { cli } = await switchToRemove()
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).not.toContain('--scope')
-      })
-    })
-
-    describe('cd step', () => {
-      it('should prepend cd when directory scope selected for remove', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toMatch(/^cd \/path\/to\/your\/project/)
-      })
-
-      it('should not have cd line when user scope selected for remove', async () => {
-        const { cli } = await switchToRemove()
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).not.toContain('cd /path/to/your/project')
-      })
-
-      it('should prepend cd when directory scope selected for configure', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toMatch(/^cd \/path\/to\/your\/project/)
-      })
-
-      it('should not have cd line when user scope selected for configure', () => {
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).not.toContain('cd /path/to/your/project')
-      })
-    })
-
-    describe('skills removal warning', () => {
-      /** Enable skills in remove mode — clicks the first "Yes" button (Skills toggle, not Delete Tokens). */
-      async function enableSkills(user: ReturnType<typeof userEvent.setup>, cli: HTMLElement): Promise<void> {
-        const yesButtons = within(cli).getAllByRole('button', { name: 'Yes' })
-        // Skills Yes is the first Yes button (Delete Tokens Yes comes after in the Options section)
-        await user.click(yesButtons[0])
-      }
-
-      it('should show warning when action=remove and skills=yes', async () => {
-        const { user, cli } = await switchToRemove()
-        await enableSkills(user, cli)
-
-        expect(within(cli).getByTestId('skills-remove-warning')).toBeInTheDocument()
-        expect(within(cli).getByText(/cannot distinguish Tiddly skills from other skills/)).toBeInTheDocument()
-      })
-
-      it('should hide warning when action=configure', async () => {
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        expect(within(cli).queryByTestId('skills-remove-warning')).not.toBeInTheDocument()
-      })
-
-      it('should generate commented-out rm commands for user scope skills', async () => {
-        const { user, cli } = await switchToRemove()
-        await enableSkills(user, cli)
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toContain('# rm -rf ~/.claude/skills/')
-        expect(pre.textContent).toContain('# rm -rf ~/.agents/skills/')
-        // Also includes deprecated Codex path cleanup
-        expect(pre.textContent).toContain('# rm -rf ~/.codex/skills/')
-        expect(pre.textContent).not.toContain('\nrm -rf')
-      })
-
-      it('should generate commented-out rm commands for directory scope skills', async () => {
-        const { user, cli } = await switchToRemove()
-        await enableSkills(user, cli)
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toContain('# rm -rf .claude/skills/')
-        expect(pre.textContent).toContain('# rm -rf .agents/skills/')
-        // Should NOT include user-scope paths
-        expect(pre.textContent).not.toContain('~/.claude/skills/')
-        expect(pre.textContent).not.toContain('~/.agents/skills/')
-      })
-
-      it('should show manual instruction for Claude Desktop skills', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Claude Desktop' }))
-        await enableSkills(user, cli)
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toContain('Claude Desktop: manually remove skills')
-      })
-    })
-
-    describe('delete tokens', () => {
-      it('should default delete tokens to no', async () => {
-        const { cli } = await switchToRemove()
-        // The second "No" button (Delete Tokens) should be selected
-        const noButtons = within(cli).getAllByRole('button', { name: 'No' })
-        // Delete Tokens No should be selected (orange)
-        expect(noButtons[noButtons.length - 1].className).toContain('bg-[#f09040]')
-      })
-
-      it('should hide login step when delete tokens is no', async () => {
-        const { cli } = await switchToRemove()
-        // Delete tokens defaults to No, so login step should not be shown
-        expect(within(cli).queryByText('Log in')).not.toBeInTheDocument()
-      })
-
-      it('should show login step when delete tokens is yes', async () => {
-        const { user, cli } = await switchToRemove()
-        // Enable delete tokens — click the last "Yes" button (Delete Tokens)
-        const yesButtons = within(cli).getAllByRole('button', { name: 'Yes' })
-        await user.click(yesButtons[yesButtons.length - 1])
-
-        expect(within(cli).getByText('Log in')).toBeInTheDocument()
-      })
-
-      it('should add --delete-tokens to generated command when enabled', async () => {
-        const { user, cli } = await switchToRemove()
-        const yesButtons = within(cli).getAllByRole('button', { name: 'Yes' })
-        await user.click(yesButtons[yesButtons.length - 1])
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toContain('--delete-tokens')
-      })
-
-      it('should not add --delete-tokens when disabled', async () => {
-        const { cli } = await switchToRemove()
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).not.toContain('--delete-tokens')
-      })
-
-      it('should hide delete tokens option when only skills selected', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Bookmarks & Notes' }))
-        await user.click(within(cli).getByRole('button', { name: 'Prompts' }))
-        // Enable skills
-        await user.click(within(cli).getByRole('button', { name: 'Yes' }))
-
-        expect(within(cli).queryByText('Delete Tokens')).not.toBeInTheDocument()
-      })
-
-      it('should show Claude Desktop directory scope error instead of steps', async () => {
-        const { user, cli } = await switchToRemove()
-        // Select only Claude Desktop
-        await user.click(within(cli).getByRole('button', { name: 'Claude Code' }))
-        await user.click(within(cli).getByRole('button', { name: 'Codex' }))
-        await user.click(within(cli).getByRole('button', { name: 'Claude Desktop' }))
-        // Select directory scope
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        expect(within(cli).getByText(/Claude Desktop only supports User scope\. Deselect Claude Desktop or switch to User scope\./)).toBeInTheDocument()
-        expect(within(cli).queryByText('Install the CLI')).not.toBeInTheDocument()
-      })
-    })
-
-    describe('--servers flag in remove', () => {
-      it('should add --servers when only one server selected', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Prompts' }))
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toContain('--servers content')
-      })
-
-      it('should not add --servers when both servers selected', async () => {
-        const { cli } = await switchToRemove()
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).not.toContain('--servers')
-      })
-    })
-
-    describe('configure command join behavior', () => {
-      it('should join configure commands with && when user scope', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        // Enable skills
-        await user.click(within(cli).getByRole('button', { name: 'Yes' }))
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).toContain('&& \\')
-      })
-
-      it('should join configure commands with newlines when directory scope', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        // Enable skills and select directory scope
-        await user.click(within(cli).getByRole('button', { name: 'Yes' }))
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        const pre = within(cli).getByTestId('cli-install-command')
-        expect(pre.textContent).not.toContain('&&')
-        expect(pre.textContent).toContain('cd /path/to/your/project')
-      })
-    })
-
-    describe('empty command handling', () => {
-      it('should show Claude Desktop error when only Claude Desktop + directory scope', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Claude Code' }))
-        await user.click(within(cli).getByRole('button', { name: 'Codex' }))
-        await user.click(within(cli).getByRole('button', { name: 'Claude Desktop' }))
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        expect(within(cli).getByText(/Claude Desktop only supports User scope\. Deselect Claude Desktop or switch to User scope\./)).toBeInTheDocument()
-        expect(within(cli).queryByText('Install the CLI')).not.toBeInTheDocument()
-      })
-
-      it('should show error when Claude Desktop + other tools + directory scope', async () => {
-        const { user, cli } = await switchToRemove()
-        await user.click(within(cli).getByRole('button', { name: 'Claude Desktop' }))
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        expect(within(cli).getByText(/Claude Desktop only supports User scope\. Deselect Claude Desktop or switch to User scope\./)).toBeInTheDocument()
-        expect(within(cli).queryByText('Install the CLI')).not.toBeInTheDocument()
-      })
-
-      it('should show nothing-selected message when nothing selected', async () => {
-        const { user, cli } = await switchToRemove()
-        // Deselect all servers and tools
-        await user.click(within(cli).getByRole('button', { name: 'Bookmarks & Notes' }))
-        await user.click(within(cli).getByRole('button', { name: 'Prompts' }))
-
-        expect(within(cli).getByText(/Select at least one item and one target tool above/)).toBeInTheDocument()
-      })
-    })
-
-    describe('file details disclosure', () => {
-      it('should show file details when command is generated', () => {
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        expect(within(cli).getByTestId('affected-files')).toBeInTheDocument()
-        expect(within(cli).getByText('Files modified')).toBeInTheDocument()
-      })
-
-      it('should hide file details when nothing selected', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        await user.click(within(cli).getByRole('button', { name: 'Bookmarks & Notes' }))
-        await user.click(within(cli).getByRole('button', { name: 'Prompts' }))
-
-        expect(within(cli).queryByTestId('affected-files')).not.toBeInTheDocument()
-      })
-
-      it('should show only Claude Code files when only Claude Code selected', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        await user.click(within(cli).getByRole('button', { name: 'Codex' }))
-
-        const details = within(cli).getByTestId('affected-files')
-        expect(within(details).getByText('~/.claude.json')).toBeInTheDocument()
-        expect(within(details).queryByText('~/.codex/config.toml')).not.toBeInTheDocument()
-      })
-
-      it('should show only Codex files when only Codex selected', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        await user.click(within(cli).getByRole('button', { name: 'Claude Code' }))
-
-        const details = within(cli).getByTestId('affected-files')
-        expect(within(details).getByText('~/.codex/config.toml')).toBeInTheDocument()
-        expect(within(details).queryByText('~/.claude.json')).not.toBeInTheDocument()
-      })
-
-      it('should show user-scope paths for user scope', () => {
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        const details = within(cli).getByTestId('affected-files')
-        expect(within(details).getByText('~/.claude.json')).toBeInTheDocument()
-        expect(within(details).getByText('~/.codex/config.toml')).toBeInTheDocument()
-      })
-
-      it('should show directory-scope paths for directory scope', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        await user.click(within(cli).getByRole('button', { name: 'Directory' }))
-
-        const details = within(cli).getByTestId('affected-files')
-        // Claude Code MCP still writes to ~/.claude.json (under project key)
-        expect(within(details).getByText('~/.claude.json')).toBeInTheDocument()
-        // Codex MCP writes to project directory
-        expect(within(details).getByText('.codex/config.toml')).toBeInTheDocument()
-      })
-
-      it('should include skills paths when skills enabled in configure flow', async () => {
-        const user = userEvent.setup()
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        await user.click(within(cli).getByRole('button', { name: 'Yes' }))
-
-        const details = within(cli).getByTestId('affected-files')
-        expect(within(details).getByText('~/.claude/skills/')).toBeInTheDocument()
-        expect(within(details).getByText('~/.agents/skills/')).toBeInTheDocument()
-        // Deprecated Codex path NOT shown in configure flow
-        expect(within(details).queryByText('~/.codex/skills/')).not.toBeInTheDocument()
-      })
-
-      it('should include deprecated Codex path in remove flow', async () => {
-        const { user, cli } = await switchToRemove()
-        const yesButtons = within(cli).getAllByRole('button', { name: 'Yes' })
-        await user.click(yesButtons[0])
-
-        const details = within(cli).getByTestId('affected-files')
-        expect(within(details).getByText('~/.agents/skills/')).toBeInTheDocument()
-        expect(within(details).getByText('~/.codex/skills/')).toBeInTheDocument()
-      })
-    })
-
-    describe('status tip', () => {
-      it('should show status tip', () => {
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        expect(within(cli).getByTestId('status-tip')).toBeInTheDocument()
-        expect(within(cli).getByText(/tiddly status/)).toBeInTheDocument()
-      })
-
-      it('should contain code element for tiddly status', () => {
-        renderWithRouter()
-        const cli = screen.getByTestId('cli-setup-section')
-        const tip = within(cli).getByTestId('status-tip')
-        const code = tip.querySelector('code')
-        expect(code).not.toBeNull()
-        expect(code?.textContent).toBe('tiddly status')
-      })
-    })
-  })
 })


### PR DESCRIPTION
## Summary

Adds Google Antigravity as a fourth supported MCP tool across the CLI, settings UI, and docs. Antigravity is Google's successor to Gemini CLI for individual-tier users (Gemini CLI stops serving free/Pro/Ultra tiers on 2026-06-18), so this targets where those users are migrating — we never shipped Gemini CLI support. Also removes the discouraged manual "Setup via Curl/PAT" flow in favor of CLI-only setup.

The implementation plan (`docs/implementation_plans/2026-05-19-antigravity-mcp-configuration.md`) documents the empirical verification behind the key decisions — config path, schema, scope, and tools-only behavior were all confirmed against a live `agy` 1.0.0 install and the Antigravity IDE, not assumed.

## Changes

**CLI (`cli/internal/mcp/`)**
- New `AntigravityHandler` (mirrors the dedicated-file pattern of Claude Desktop). Writes `~/.gemini/config/mcp_config.json`, shared by the `agy` CLI and the Antigravity IDE.
- User scope only (`agy` 1.0.0 has no directory/project scope) and detected via the `agy` binary or `~/.gemini/antigravity-cli/` / `~/.gemini/antigravity/` dirs (avoids false positives from a legacy Gemini CLI install).
- Extended shared `extractServerURL`/`detectTransport` to recognize Antigravity's `serverUrl` field (preferred over `url`); existing `url` support for the Claude handlers is unchanged.
- Antigravity reads use `serverUrl` only, so `status` and PAT extraction reflect what `agy` actually loads. Empty/whitespace config files are treated as a fresh start (agy creates them); malformed JSON still fails closed.
- Configure emits a restart warning (Antigravity reads config at startup); excluded from `skills configure` (no skills integration).

**Frontend & docs**
- Replaced the Gemini CLI "coming soon" card with a working Antigravity card; added an Antigravity column to the comparison table (MCP Prompts / Agent Skills marked false, anchored to `agy` 1.0.0).
- Wired Antigravity into the CLI setup section as MCP-only / user-scope-only; added a blocking inline conflict when Skills is enabled with a tool that has no skills support (mirrors the existing scope conflict).
- Removed the manual "Setup via Curl/PAT" tab and its per-tool hand-edit instruction components (~1,900 lines incl. tests); "Setup via CLI" is now the only path. Rewrote `llms.txt` MCP setup to be CLI-first.
- Documented Antigravity in `ai-integration.md`, `architecture.md`, `DocsCLIMCP`, and the command-palette keyword indexes.

## Impact

- **No backend or API changes.** No new dependencies. No migrations.
- **User-facing behavior change:** the manual MCP setup flow (hand-edit config snippets) is removed — CLI is now the only documented setup path. This was a deliberate, requested change.
- **CLI behavior:** `tiddly mcp configure`/`status`/`remove` now accept/auto-detect `antigravity`; `--scope directory` is rejected for it.
- No secrets or sensitive data in the diff. Antigravity supports only MCP tools (not MCP prompts) and has no skills integration — documented as known limitations.
- Verified: `make cli-verify` and `make frontend-verify` pass (full suites), plus live verification against `agy` 1.0.0 and the Antigravity IDE (connection logs + IDE settings panel).