### PR TITLE
Improve/fix right sidebar: Cmd+F panel + max-width toggle

### DIFF
--- a/docs/implementation_plans/2026-05-20-right-sidebar-improvements.md
+++ b/docs/implementation_plans/2026-05-20-right-sidebar-improvements.md
@@ -2,10 +2,16 @@
 
 **Ticket:** https://tiddly.atlassian.net/browse/KAN-153
 **Date:** 2026-05-20
-**Status:** Planned — reviewed (two AI review passes + synthesis), pending implementation
+**Status:** Implemented — shipped on branch `kan-153-right-sidebar-improvements` (Part 1: commit `de93cb9`; Part 2: commit `986d8ba`)
 **Branch:** `kan-153-right-sidebar-improvements`
 
 > **Review note (2026-05-20):** This plan was reviewed by two independent agents and a synthesis pass. Six findings were folded back in — see the "Review-driven corrections" callouts inline and the revised Open Questions. All correctness/testing findings (#1–#5) accepted; #6 (shared maximize flag) confirmed as intended.
+
+> **As-built note (2026-05-20):** Implemented as planned, with these deliberate deviations (recorded here because the rationale otherwise lives only in code comments and review threads):
+> - **Left-sidebar invalidation uses a `ResizeObserver` on the desktop sidebar element, not an `isCollapsed` store subscription** (finding #2 below offered both). A subscription re-renders once at the *start* of the sidebar's `w-12 ↔ w-72` width animation and reads stale pre-animation geometry via `getBoundingClientRect()`, computing the wrong margin until an unrelated re-render. The observer tracks the live width across the animation. Applies to both the Part 1 Cmd+F offset and the Part 2 maximized width. **Do not "simplify" this back to a subscription** — it reintroduces the stale-geometry bug.
+> - **Max-width toggle uses a single icon (no glyph flip) plus active styling when maximized** (resolved the open icon question): the sidebar's expanded state is itself the cue; tooltip/aria-label flip "Maximize" ↔ "Restore". Tooltip is positioned `left` so it isn't clipped at the viewport's right edge.
+> - **The shortcut handler is also gated on `isDesktop`** (mirroring the desktop-only button) so `⌘⌥\` can't silently flip the persisted `maximized` flag on mobile.
+> - The shared `'desktop-sidebar'` id is centralized as `DESKTOP_SIDEBAR_ID` (`src/constants/sidebar.ts`) to avoid silent-failure coupling across its read sites.
 
 ## Summary
 

--- a/docs/implementation_plans/2026-05-20-right-sidebar-improvements.md
+++ b/docs/implementation_plans/2026-05-20-right-sidebar-improvements.md
@@ -1,0 +1,195 @@
+# Right Sidebar Improvements (KAN-153)
+
+**Ticket:** https://tiddly.atlassian.net/browse/KAN-153
+**Date:** 2026-05-20
+**Status:** Planned — reviewed (two AI review passes + synthesis), pending implementation
+**Branch:** `kan-153-right-sidebar-improvements`
+
+> **Review note (2026-05-20):** This plan was reviewed by two independent agents and a synthesis pass. Six findings were folded back in — see the "Review-driven corrections" callouts inline and the revised Open Questions. All correctness/testing findings (#1–#5) accepted; #6 (shared maximize flag) confirmed as intended.
+
+## Summary
+
+Two changes to the right sidebar (Version History + Table of Contents panels), which appear on content detail pages while editing:
+
+1. **Bug fix:** CodeMirror's Cmd+F find/replace panel renders *behind* the right sidebar instead of shifting with the main content.
+2. **Feature:** Add a "max width" toggle button to the sidebar header (both panels) that expands the sidebar to its current maximum, and restores the previous user-set width on a second click. Includes a keyboard shortcut.
+
+---
+
+## Background: how the right sidebar works today
+
+State lives in `frontend/src/stores/rightSidebarStore.ts`:
+- `activePanel: 'history' | 'toc' | null` — only one panel open at a time.
+- `width: number` — persisted to `localStorage` under `right-sidebar-width`, clamped to `>= MIN_SIDEBAR_WIDTH` (280). Default 400.
+- `MIN_CONTENT_WIDTH = 600` — minimum space reserved for the editor.
+- Only the `history` panel is persisted across reloads; `toc` is session-only.
+
+`frontend/src/hooks/useResizableSidebar.ts`:
+- Owns drag-to-resize and the responsive (`md` breakpoint, 768px) logic.
+- `calculateMaxWidth()` (lines 10–14) computes the maximum sidebar width:
+  ```
+  max = window.innerWidth - leftSidebarWidth - MIN_CONTENT_WIDTH
+  ```
+  where `leftSidebarWidth` is read live from `document.getElementById('desktop-sidebar')`. **The left sidebar's collapsed/expanded state does factor in** (the user's hunch was correct).
+- This same formula is duplicated in `Layout.tsx` `getRightSidebarMargin()` (lines 142–149).
+
+Rendered width is `isDesktop ? Math.min(storeWidth, calculateMaxWidth()) : storeWidth`.
+
+The sidebar panels:
+- `frontend/src/components/HistorySidebar.tsx` — `fixed right-0 top-0 h-full z-50`, width via inline `style={{ width }}`. Header at lines 136–153.
+- `frontend/src/components/TableOfContentsSidebar.tsx` — same positioning. Header at lines 46–55.
+
+The main content shifts via `marginRight` in `Layout.tsx` (line 158), using `getRightSidebarMargin()`.
+
+---
+
+## Part 1 — Cmd+F find/replace bug
+
+### Root cause (confirmed)
+
+CSS only — `frontend/src/index.css:301–312`:
+
+```css
+.cm-editor .cm-panels-top {
+  position: fixed !important;
+  top: auto !important;
+  right: 2rem !important;   /* anchored to the VIEWPORT right edge */
+  left: auto !important;
+  bottom: 0 !important;
+  z-index: 50;
+  ...
+}
+```
+
+The search panel is `position: fixed`, pinned `2rem` from the **viewport** right edge. The right sidebar is also `fixed right-0` at `z-50` with width ~400px. Both are `z-50`, so DOM paint order wins and the sidebar covers the panel. The `position: fixed` is intentional (keeps the panel visible while scrolling long docs — see the comment at `index.css:297`), so we must keep it floating but offset it by the sidebar width.
+
+### Fix
+
+Make the panel's right offset track the sidebar margin, mirroring what the main content already does.
+
+1. In `Layout.tsx`, in addition to (or instead of) the inline `marginRight` style on `#main-content`, write the computed margin to a CSS custom property on a stable root element so CSS can read it. Suggested: set `--right-sidebar-margin` (in px) on the `<main id="main-content">` element (or the outer layout `div`), updated from the same `getRightSidebarMargin()` value already computed.
+
+2. Change the CSS rule to offset by that variable:
+   ```css
+   .cm-editor .cm-panels-top {
+     ...
+     right: calc(var(--right-sidebar-margin, 0px) + 2rem) !important;
+   }
+   ```
+   The variable defaults to `0px` when the sidebar is closed, preserving current behavior.
+
+### Notes / cautions
+
+- The CSS variable must be set on an ancestor of the `.cm-editor` so the variable cascades to it. `#main-content` wraps the editor, so setting it there works. Verify the editor is actually a descendant of the element carrying the variable.
+- Do **not** simply bump `z-index` — that would overlap the sidebar instead of moving the panel out from under it.
+- The margin is animated (`transition-[margin] duration-200` on `#main-content`). The search panel's `right` will jump unless we also add a matching transition; consider `transition: right 200ms` on `.cm-panels-top` for parity (optional polish).
+- Test with the left sidebar both collapsed and expanded (changes `calculateMaxWidth`), and at narrow widths where the sidebar width is clamped.
+
+> **Review-driven correction (finding #2 — left-sidebar collapse staleness):** The CSS variable and the content margin both recompute only on render, and the only forced re-render path today is `window.resize` (`Layout.tsx:99-110` — a `setResizeCount` hack gated on `rightSidebarOpen`). Layout subscribes to `toggleCollapse` (the function) but **not** to the left sidebar's `isCollapsed` *state* (`Layout.tsx:56`). So collapsing/expanding the left sidebar (`w-12` ↔ `w-72`) does **not** recompute the right margin or the search-panel offset — they go stale until an unrelated resize. This is invisible today (right sidebar is normally narrower than max) but the maximize feature exposes it (see finding #2 under Part 2). **Fix here too:** subscribe `Layout` to `useSidebarStore((s) => s.isCollapsed)` so a left-sidebar toggle re-renders and recomputes `getRightSidebarMargin()` (and thus the `--right-sidebar-margin` variable). Reading the value is enough to subscribe. A `ResizeObserver` on `#desktop-sidebar` is the more robust alternative if we want to track the animated width frame-by-frame; the store subscription is simpler and sufficient since only the final width matters.
+
+---
+
+## Part 2 — Max-width toggle
+
+### Behavior
+
+- A toggle button in the header of both `HistorySidebar` and `TableOfContentsSidebar`.
+- Click once → sidebar expands to `calculateMaxWidth()` (its current max, accounting for left sidebar + `MIN_CONTENT_WIDTH`).
+- Click again → restore to the user's previous manual width.
+- Keyboard shortcut toggles the same behavior.
+
+### State design
+
+In `rightSidebarStore.ts`:
+- Add `maximized: boolean` and `toggleMaximized()` (and likely `setMaximized(bool)`).
+- **Do not overwrite the user's `width`** when maximizing — that value is the "restore" target and is already persisted. Instead, when `maximized` is true, the *rendered* width becomes `calculateMaxWidth()`; the stored `width` is untouched.
+- Decisions (confirmed with user):
+  - **Persistence:** `maximized` persists across reloads (decision below — see Open Questions if changed).
+  - **Shared vs per-panel:** single shared `maximized` flag across both panels (decision below).
+
+### Rendering
+
+- `useResizableSidebar.ts` should return the effective width: when `maximized`, return `calculateMaxWidth()`; otherwise the current `Math.min(storeWidth, calculateMaxWidth())`.
+- `Layout.tsx` `getRightSidebarMargin()` must use the same effective width so content margin (and the Part 1 CSS variable) stay in sync. **Extract the duplicated `calculateMaxWidth()` into one shared helper** so the hook, Layout, and any toggle logic agree on a single source of truth.
+
+  > **Review-driven correction (finding #5 — testability):** Split the helper into a **pure** `computeMaxWidth(innerWidth: number, leftSidebarWidth: number): number` (the arithmetic + `Math.max(MIN_SIDEBAR_WIDTH, …)` floor) and a thin DOM-reading wrapper that reads `window.innerWidth` / `#desktop-sidebar` and calls it. Both `Layout.tsx` and `useResizableSidebar.ts` use the wrapper. The pure function is what we unit-test (see Tests), so the maximize logic isn't silently asserting jsdom defaults (`innerWidth` 1024, `getElementById` → null → 0, which would make `computeMaxWidth` a tautology and let the 280 floor mask the logic).
+
+- While `maximized`, dragging the resize handle should exit maximized mode and set a new manual width (natural: a drag implies the user wants a specific width). Implement by having the drag's `setWidth` also call `setMaximized(false)`.
+
+> **Review-driven correction (finding #1 — passive resize must not corrupt the restore width):** This is the most important fix and a prerequisite for "restore to previous width" to work at all. Today the constrain effect (`useResizableSidebar.ts:32-43`) calls `setWidth(maxWidth)` whenever the viewport shrinks below the stored width, and `setWidth` **persists to localStorage** (`rightSidebarStore.ts:71-79`). This silently rewrites the user's manual width — so a user at 700px who maximizes then narrows the viewport would "restore" to the squeezed value, not 700px. Crucially this persist-on-shrink is **already redundant for display**: rendered width is independently clamped at `useResizableSidebar.ts:45` (`Math.min(storeWidth, calculateMaxWidth())`). **Fix:** remove the `setWidth(maxWidth)` call from the constrain effect (keep only `setIsDesktop(...)`), and **drop `storeWidth` from that effect's dependency array** (it's no longer read inside; leaving it causes needless listener re-subscription). Persist `width` only on explicit drag (`handleMouseMove`, lines 55-59, already does). With this, `width` always holds the user's intentional value, rendering clamps, and the maximized path computes from `computeMaxWidth()` — so the "don't overwrite width on maximize" promise holds **without** needing a separate `restoreWidth` field.
+
+### Button
+
+- 28×28 icon button matching the existing close button styling (`h-[28px] w-[28px] flex items-center justify-center text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100`).
+- Placement: in the header's **right-side group, immediately left of the close button**:
+  `[Title (+ help icon)] ........ [⤢ max-width toggle] [✕ close]`
+- Same in both `HistorySidebar` and `TableOfContentsSidebar`.
+- Icon: an expand/collapse-horizontal style icon. Check `components/icons` for an existing one; add if needed.
+- `aria-label` should reflect state ("Maximize sidebar width" / "Restore sidebar width").
+
+### Tooltip
+
+- Reuse the registry-driven shortcut tooltip pattern: `shortcutTooltipContent('app.toggleSidebarMaxWidth')` from `components/editor/shortcutTooltip.tsx`. It renders the registry label + platform-localized combo on a muted second line, staying in sync with the registry.
+- Wrap with `<Tooltip ... compact delay={500}>` — **500ms delay** (confirmed with user; matches the formatting-toolbar buttons).
+- **State-dependent label:** the tooltip text should flip between "Maximize Sidebar Width" and "Restore Sidebar Width". `shortcutTooltipContent(id)` currently pulls a fixed label from the registry. Add a small variant that accepts an optional label override, e.g. `shortcutTooltipContent(id, labelOverride?)`, so the combo stays registry-driven while the label can swap. Keep the existing single-arg call sites working.
+
+### Keyboard shortcut
+
+- **`⌘⌥\` (Cmd+Option+Backslash)** — deliberately pairs with the existing history-sidebar toggle `⌘⇧\` (`shortcuts/registry.ts:142`), preserving the "backslash = right sidebar" mental model.
+- Add a registry entry in the `View` section of `frontend/src/shortcuts/registry.ts`:
+  ```ts
+  {
+    id: 'app.toggleSidebarMaxWidth',
+    label: 'Maximize Sidebar Width',
+    section: 'View',
+    keys: ['⌘', '⌥', '\\'],
+    match: { mod: true, alt: true, code: 'Backslash' },
+    allowInInputs: true,   // must work while editing in the editor
+  }
+  ```
+
+  > **Review-driven correction (finding #3 — use `code: 'Backslash'`, not `key`):** On Mac, Option alters the produced character (Option+\ → `«`), so `key: '\\'` would silently fail for users editing — the primary use case. Use `code: 'Backslash'` from the start (no "fall back if unreliable" hedge). **Verified this works on the global path:** `useGlobalShortcuts` → `findMatchingShortcut` → `matches()` handles `code` generically (`matcher.ts`: `if (match.code !== undefined) return event.code === match.code`) on a `document` keydown listener. The `types.ts:46-48` comment ("`code` belongs to the capture-phase path; the CM keymap adapter throws on these") is scoped **only** to entries fed into CodeMirror's keymap — our id lives only in `APP_GLOBAL_IDS`, never the editor keymap, so there's no throw. Since this is the first global (non-editor) `code` matcher, **update the `types.ts:46-48` comment** so it no longer implies `code` is capture-phase-only. The display tokens stay `['⌘', '⌥', '\\']` (the registry coherence test already maps `Backslash` → `\`). `assertNoDuplicateMatchShapes` passes — distinct from `app.toggleHistorySidebar` (`⌘⇧\`) via the alt/shift flags and key-vs-code shape.
+
+- **Register the id in the `APP_GLOBAL_IDS` tuple** (`Layout.tsx:38-46`) alongside the handler-map entry.
+
+  > **Review-driven correction (finding #4):** `useGlobalShortcuts(APP_GLOBAL_IDS, {...})` only dispatches ids present in the tuple. A registry entry + handler without the tuple entry means the shortcut silently does nothing. This is an easy step to miss — call it out explicitly.
+
+- Wire the handler in `Layout.tsx` (alongside `app.toggleHistorySidebar` at lines 131–133): only act when a panel is open (`isDetailPage` + `activePanel != null`), then call `toggleMaximized()`.
+- Verify `⌘⌥\` does not collide with any browser/OS binding.
+
+---
+
+## Files to touch
+
+- `frontend/src/index.css` — Part 1 CSS rule.
+- `frontend/src/components/Layout.tsx` — expose `--right-sidebar-margin` CSS var; wire shortcut handler; use shared max-width helper.
+- `frontend/src/stores/rightSidebarStore.ts` — `maximized` state + actions.
+- `frontend/src/hooks/useResizableSidebar.ts` — effective width when maximized; exit-on-drag; use shared helper.
+- `frontend/src/components/HistorySidebar.tsx` — toggle button in header.
+- `frontend/src/components/TableOfContentsSidebar.tsx` — toggle button in header.
+- `frontend/src/shortcuts/registry.ts` — new shortcut entry (`code: 'Backslash'`).
+- `frontend/src/shortcuts/types.ts` — update the `code` matcher comment (lines 46-48); this becomes the first global `code` matcher.
+- `frontend/src/components/editor/shortcutTooltip.tsx` — optional label-override variant.
+- `frontend/src/components/icons` (or equivalent) — max-width icon if none exists.
+- New shared max-width helper — pure `computeMaxWidth(innerWidth, leftSidebarWidth)` + thin DOM wrapper, to deduplicate `calculateMaxWidth()` and make the logic unit-testable.
+- `Layout.tsx` — also add `'app.toggleSidebarMaxWidth'` to `APP_GLOBAL_IDS`, and subscribe to `useSidebarStore((s) => s.isCollapsed)` for left-sidebar invalidation.
+
+## Docs to sync (per AGENTS.md)
+
+- `frontend/src/pages/docs/DocsShortcuts.tsx` — document the new `⌘⌥\` shortcut.
+- Consider `changelog/Changelog.tsx` if shipping as a user-visible change.
+
+## Tests
+
+- **Pure `computeMaxWidth(innerWidth, leftSidebarWidth)`** (finding #5): wide viewport; narrow viewport hitting the 280 floor; left sidebar collapsed (~48) vs expanded (~288). This is the meaningful coverage for the width math — do **not** rely on jsdom defaults via the DOM wrapper.
+- **Restore width integrity (finding #1):** set width 700, simulate viewport shrink, assert the *persisted/stored* width is still 700 while the *rendered* width clamps. Update any existing resize test that asserts the old shrink-persists behavior to assert rendered-only clamping instead.
+- **Maximize behavior:** effective width = max when maximized; restore to stored manual width on toggle-off; drag while maximized exits maximized and sets a new manual width.
+- **Left-sidebar invalidation (finding #2):** with the right sidebar open/maximized, toggling left-sidebar collapse recomputes the right width / content margin.
+- **Shortcut (findings #3, #4):** synthetic `{metaKey, altKey, code:'Backslash'}` event fires the handler; same combo without Cmd/Alt does not; handler no-ops when no panel open. `assertNoDuplicateMatchShapes` passes with the new entry.
+- **Manual / visual:** Cmd+F panel position with sidebar open/closed, left sidebar collapsed/expanded (toggle live, not just on load), narrow viewport clamping. (Frontend-only change — run `make frontend-verify`; do not run backend tests.)
+
+## Decisions (all confirmed — no open questions remain)
+
+1. **Persistence of `maximized`** across reloads — **persisted**.
+2. **Shared vs per-panel maximize flag** — **single shared flag**. The right sidebar is treated as one component with identical behavior for Version History and ToC; maximize is a property of the sidebar shell, not the panel — consistent with how `width` already behaves. **Intended consequence (finding #6):** after maximizing on History and reloading, the ToC panel will open already-maximized the next time it appears. This is by design, not a bug — recorded here so it isn't later mistaken for one. Both review agents confirmed this as the more coherent model than special-casing ToC.
+3. **Shortcut `⌘⌥\`** — **agreed**, using `code: 'Backslash'` (see finding #3). Reconsider only if a browser/OS collision surfaces during implementation.

--- a/frontend/src/components/HistorySidebar.test.tsx
+++ b/frontend/src/components/HistorySidebar.test.tsx
@@ -27,10 +27,13 @@ vi.mock('../hooks/useHistory', () => ({
 
 // Mock the sidebar store
 vi.mock('../stores/rightSidebarStore', () => ({
-  useRightSidebarStore: (selector: (state: { width: number }) => unknown) =>
-    selector({ width: 500 }),
+  useRightSidebarStore: (
+    selector: (state: { width: number; maximized: boolean; toggleMaximized: () => void; setMaximized: () => void }) => unknown,
+  ) => selector({ width: 500, maximized: false, toggleMaximized: () => {}, setMaximized: () => {} }),
   MIN_SIDEBAR_WIDTH: 300,
   MIN_CONTENT_WIDTH: 400,
+  computeMaxWidth: (innerWidth: number, leftSidebarWidth: number) =>
+    Math.max(300, innerWidth - leftSidebarWidth - 400),
 }))
 
 function createEntry(overrides: Partial<HistoryEntry> = {}): HistoryEntry {

--- a/frontend/src/components/HistorySidebar.tsx
+++ b/frontend/src/components/HistorySidebar.tsx
@@ -14,6 +14,7 @@ import { Tooltip } from './ui/Tooltip'
 import { ActionDot } from './ActionDot'
 import { ChangeIndicators } from './ChangeIndicators'
 import { VersionDiffPanel } from './VersionDiffPanel'
+import { RightSidebarMaxWidthToggle } from './RightSidebarMaxWidthToggle'
 import { formatAction, formatSource, isAuditAction } from '../constants/historyLabels'
 
 interface HistorySidebarProps {
@@ -143,13 +144,16 @@ export function HistorySidebar({
             <HelpIcon className="h-4 w-4 text-gray-400 hover:text-gray-600 cursor-help" />
           </Tooltip>
         </div>
-        <button
-          onClick={onClose}
-          className="h-[28px] w-[28px] flex items-center justify-center text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100"
-          aria-label="Close history sidebar"
-        >
-          <CloseIcon className="w-5 h-5" />
-        </button>
+        <div className="flex items-center gap-0.5">
+          {isDesktop && <RightSidebarMaxWidthToggle />}
+          <button
+            onClick={onClose}
+            className="h-[28px] w-[28px] flex items-center justify-center text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100"
+            aria-label="Close history sidebar"
+          >
+            <CloseIcon className="w-5 h-5" />
+          </button>
+        </div>
       </div>
 
       {/* Pagination - only shown when there's more than one page */}

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -115,21 +115,40 @@ vi.mock('../stores/sidebarStore', () => ({
 
 // Track right sidebar state for tests
 let mockActivePanel: string | null = null
+let mockMaximized = false
 const mockRightSidebarWidth = 384
+const mockToggleMaximized = vi.fn()
 vi.mock('../stores/rightSidebarStore', () => ({
   useRightSidebarStore: (selector?: (state: Record<string, unknown>) => unknown) => {
     const state = {
       activePanel: mockActivePanel,
       width: mockRightSidebarWidth,
+      maximized: mockMaximized,
       setActivePanel: vi.fn(),
       togglePanel: vi.fn(),
       setWidth: vi.fn(),
+      setMaximized: vi.fn(),
+      toggleMaximized: mockToggleMaximized,
     }
     return selector ? selector(state) : state
   },
   MIN_SIDEBAR_WIDTH: 280,
   MIN_CONTENT_WIDTH: 600,
+  // Used by measureMaxSidebarWidth (via Layout's getRightSidebarMargin).
+  computeMaxWidth: (innerWidth: number, leftSidebarWidth: number) =>
+    Math.max(280, innerWidth - leftSidebarWidth - 600),
 }))
+
+function setWindowWidth(width: number): void {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width })
+}
+
+/** Dispatch the ⌘⌥\ (maximize sidebar) shortcut as a real keydown on document. */
+function pressMaximizeShortcut(): void {
+  document.dispatchEvent(
+    new KeyboardEvent('keydown', { metaKey: true, altKey: true, code: 'Backslash', bubbles: true }),
+  )
+}
 
 function TestPage(): ReactNode {
   return <div data-testid="test-page">Test Page Content</div>
@@ -152,7 +171,9 @@ describe('Layout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockActivePanel = null
+    mockMaximized = false
     mockNeedsConsent = false
+    setWindowWidth(1024) // desktop by default
     vi.mocked(config).isDevMode = true
   })
 
@@ -305,6 +326,57 @@ describe('Layout', () => {
 
       const main = screen.getByRole('main')
       expect(main.style.getPropertyValue('--right-sidebar-margin')).toBe('0px')
+    })
+
+    it('should apply the max width as margin when maximized, ignoring the smaller stored width', () => {
+      // jsdom: innerWidth 1024, no measurable left sidebar → max = 1024 - 0 - 600 = 424,
+      // larger than the stored width (384), so maximize widens the margin.
+      mockActivePanel = 'history'
+      mockMaximized = true
+      renderLayout('/app/notes/abc-123')
+
+      const main = screen.getByRole('main')
+      expect(main.style.marginRight).toBe('424px')
+      expect(main.style.getPropertyValue('--right-sidebar-margin')).toBe('424px')
+    })
+  })
+
+  describe('maximize shortcut (⌘⌥\\)', () => {
+    it('toggles maximize on a detail page with a panel open (desktop)', () => {
+      mockActivePanel = 'history'
+      renderLayout('/app/notes/abc-123')
+
+      pressMaximizeShortcut()
+
+      expect(mockToggleMaximized).toHaveBeenCalledTimes(1)
+    })
+
+    it('is a no-op on mobile, so it cannot silently flip the persisted flag', () => {
+      setWindowWidth(600) // below the md breakpoint
+      mockActivePanel = 'history'
+      renderLayout('/app/notes/abc-123')
+
+      pressMaximizeShortcut()
+
+      expect(mockToggleMaximized).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when no sidebar panel is open', () => {
+      mockActivePanel = null
+      renderLayout('/app/notes/abc-123')
+
+      pressMaximizeShortcut()
+
+      expect(mockToggleMaximized).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op on non-detail pages', () => {
+      mockActivePanel = 'history'
+      renderLayout('/app/bookmarks')
+
+      pressMaximizeShortcut()
+
+      expect(mockToggleMaximized).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -286,5 +286,25 @@ describe('Layout', () => {
       const main = screen.getByRole('main')
       expect(main.style.marginRight).toBe('0px')
     })
+
+    // The CodeMirror Cmd+F search panel (position: fixed) offsets its `right`
+    // by --right-sidebar-margin so it shifts with the content instead of
+    // hiding behind the sidebar. The variable must always equal marginRight.
+    it('should expose the margin as the --right-sidebar-margin variable when open', () => {
+      mockActivePanel = 'history'
+      renderLayout('/app/notes/abc-123')
+
+      const main = screen.getByRole('main')
+      expect(main.style.getPropertyValue('--right-sidebar-margin')).toBe(`${mockRightSidebarWidth}px`)
+      expect(main.style.getPropertyValue('--right-sidebar-margin')).toBe(main.style.marginRight)
+    })
+
+    it('should set --right-sidebar-margin to 0px when sidebar is closed', () => {
+      mockActivePanel = null
+      renderLayout('/app/notes/abc-123')
+
+      const main = screen.getByRole('main')
+      expect(main.style.getPropertyValue('--right-sidebar-margin')).toBe('0px')
+    })
   })
 })

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,10 +13,12 @@ import { useSidebarStore } from '../stores/sidebarStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useFiltersStore } from '../stores/filtersStore'
 import { useTagsStore } from '../stores/tagsStore'
-import { useRightSidebarStore, MIN_SIDEBAR_WIDTH, MIN_CONTENT_WIDTH } from '../stores/rightSidebarStore'
+import { useRightSidebarStore } from '../stores/rightSidebarStore'
 import { useGlobalShortcuts } from '../shortcuts/useGlobalShortcuts'
 import type { ShortcutId } from '../shortcuts/registry'
 import { useLimits } from '../hooks/useLimits'
+import { measureMaxSidebarWidth } from '../hooks/useResizableSidebar'
+import { DESKTOP_SIDEBAR_ID } from '../constants/sidebar'
 
 /**
  * Layout component that wraps authenticated pages.
@@ -40,6 +42,7 @@ const APP_GLOBAL_IDS = [
   'app.commandPalette',
   'app.toggleSidebar',
   'app.toggleHistorySidebar',
+  'app.toggleSidebarMaxWidth',
   'app.toggleWidth',
   'app.focusSearch',
   'app.escape',
@@ -68,6 +71,8 @@ export function Layout(): ReactNode {
   const hasFetchedRef = useRef(false)
   const rightSidebarOpen = useRightSidebarStore((state) => state.activePanel !== null)
   const rightSidebarWidth = useRightSidebarStore((state) => state.width)
+  const rightSidebarMaximized = useRightSidebarStore((state) => state.maximized)
+  const toggleSidebarMaximized = useRightSidebarStore((state) => state.toggleMaximized)
 
   // Command palette state
   const [paletteOpen, setPaletteOpen] = useState(false)
@@ -118,7 +123,7 @@ export function Layout(): ReactNode {
   // reads the --right-sidebar-margin variable set below.
   useEffect(() => {
     if (!rightSidebarOpen) return
-    const leftSidebar = document.getElementById('desktop-sidebar')
+    const leftSidebar = document.getElementById(DESKTOP_SIDEBAR_ID)
     if (!leftSidebar) return
     // Guard for environments without ResizeObserver (matches DropdownPortal);
     // the window-resize handler above remains the fallback for margin recompute.
@@ -151,6 +156,13 @@ export function Layout(): ReactNode {
       if (!isDetailPage) return
       togglePanel('history')
     },
+    'app.toggleSidebarMaxWidth': () => {
+      // Desktop-only, mirroring the button: on mobile the sidebar is full-width
+      // and maximize has no visible effect, so toggling would silently mutate
+      // the persisted flag and surprise the user on their next desktop session.
+      if (!isDetailPage || !rightSidebarOpen || !isDesktop) return
+      toggleSidebarMaximized()
+    },
     'app.escape': () => {
       if (showShortcuts) setShowShortcuts(false)
     },
@@ -160,11 +172,10 @@ export function Layout(): ReactNode {
   // Uses the same logic as sidebar components to ensure they stay in sync
   const getRightSidebarMargin = (): number => {
     if (!rightSidebarOpen || !isDesktop || !isDetailPage) return 0
-    const leftSidebar = document.getElementById('desktop-sidebar')
-    const leftSidebarWidth = leftSidebar?.getBoundingClientRect().width ?? 0
-    // Clamp to MIN_SIDEBAR_WIDTH to prevent negative values on narrow viewports
-    const maxWidth = Math.max(MIN_SIDEBAR_WIDTH, window.innerWidth - leftSidebarWidth - MIN_CONTENT_WIDTH)
-    return Math.min(rightSidebarWidth, maxWidth)
+    const maxWidth = measureMaxSidebarWidth()
+    // When maximized the sidebar fills the max; otherwise clamp the stored width
+    // to it. Mirrors useResizableSidebar so margin and sidebar width agree.
+    return rightSidebarMaximized ? maxWidth : Math.min(rightSidebarWidth, maxWidth)
   }
 
   // Single source of truth for the content offset. Exposed as a CSS variable so

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, Suspense } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { Sidebar } from './sidebar'
 import { ShortcutsDialog } from './ShortcutsDialog'
 import { CommandPalette } from './CommandPalette'
@@ -109,6 +109,25 @@ export function Layout(): ReactNode {
     return () => window.removeEventListener('resize', handleResize)
   }, [rightSidebarOpen])
 
+  // Recompute the right-sidebar margin when the left sidebar's width changes.
+  // Collapsing/expanding it animates (w-12 ↔ w-72), and the margin depends on
+  // that width (see getRightSidebarMargin). A ResizeObserver tracks the live
+  // width across the transition — a state subscription would re-render once at
+  // the animation's start and read the stale pre-transition width. Keeping the
+  // margin in sync also keeps the Cmd+F search panel offset correct, since it
+  // reads the --right-sidebar-margin variable set below.
+  useEffect(() => {
+    if (!rightSidebarOpen) return
+    const leftSidebar = document.getElementById('desktop-sidebar')
+    if (!leftSidebar) return
+    // Guard for environments without ResizeObserver (matches DropdownPortal);
+    // the window-resize handler above remains the fallback for margin recompute.
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => setResizeCount((c) => c + 1))
+    observer.observe(leftSidebar)
+    return () => observer.disconnect()
+  }, [rightSidebarOpen])
+
   const togglePanel = useRightSidebarStore((state) => state.togglePanel)
 
   // Global keyboard shortcuts (work on all pages).
@@ -148,6 +167,11 @@ export function Layout(): ReactNode {
     return Math.min(rightSidebarWidth, maxWidth)
   }
 
+  // Single source of truth for the content offset. Exposed as a CSS variable so
+  // the CodeMirror search panel (position: fixed) can offset by the same amount
+  // and shift with the content instead of hiding behind the right sidebar.
+  const rightSidebarMargin = getRightSidebarMargin()
+
   return (
     <div data-viewport-locked className="flex h-dvh bg-white overflow-hidden">
       <Sidebar onOpenPalette={() => openPalette('commands')} />
@@ -155,7 +179,7 @@ export function Layout(): ReactNode {
       <main
         id="main-content"
         className="flex-1 flex flex-col min-w-0 relative overflow-x-hidden transition-[margin] duration-200"
-        style={{ marginRight: `${getRightSidebarMargin()}px` }}
+        style={{ marginRight: `${rightSidebarMargin}px`, '--right-sidebar-margin': `${rightSidebarMargin}px` } as CSSProperties}
       >
         <div className="flex-1 overflow-y-auto overflow-x-hidden relative">
           <div className={`flex flex-col min-h-0 px-4 pb-4 md:px-5 ${fullWidthLayout ? 'max-w-full' : 'max-w-5xl'}`}>

--- a/frontend/src/components/RightSidebarMaxWidthToggle.tsx
+++ b/frontend/src/components/RightSidebarMaxWidthToggle.tsx
@@ -1,0 +1,35 @@
+/**
+ * Header button that toggles the right sidebar between its current width and
+ * its maximum. Shared by HistorySidebar and TableOfContentsSidebar so the two
+ * stay identical. Desktop-only — callers gate on isDesktop (resize is
+ * meaningless when the sidebar is full-width on mobile).
+ */
+import type { ReactNode } from 'react'
+import { useRightSidebarStore } from '../stores/rightSidebarStore'
+import { Tooltip } from './ui/Tooltip'
+import { shortcutTooltipContent } from './editor/shortcutTooltip'
+import { ExpandWidthIcon } from './icons'
+
+export function RightSidebarMaxWidthToggle(): ReactNode {
+  const maximized = useRightSidebarStore((state) => state.maximized)
+  const toggleMaximized = useRightSidebarStore((state) => state.toggleMaximized)
+  const label = maximized ? 'Restore Sidebar Width' : 'Maximize Sidebar Width'
+
+  return (
+    <Tooltip content={shortcutTooltipContent('app.toggleSidebarMaxWidth', label)} compact delay={500} position="left">
+      <button
+        type="button"
+        onClick={toggleMaximized}
+        aria-label={label}
+        aria-pressed={maximized}
+        className={`h-[28px] w-[28px] flex items-center justify-center rounded-md ${
+          maximized
+            ? 'text-gray-700 bg-gray-200'
+            : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+        }`}
+      >
+        <ExpandWidthIcon className="w-5 h-5" />
+      </button>
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/TableOfContentsSidebar.test.tsx
+++ b/frontend/src/components/TableOfContentsSidebar.test.tsx
@@ -16,7 +16,7 @@ import { TableOfContentsSidebar } from './TableOfContentsSidebar'
 const mockSetActivePanel = vi.fn()
 vi.mock('../stores/rightSidebarStore', () => ({
   useRightSidebarStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({ setActivePanel: mockSetActivePanel, width: 320 }),
+    selector({ setActivePanel: mockSetActivePanel, width: 320, maximized: false, toggleMaximized: vi.fn() }),
   MIN_SIDEBAR_WIDTH: 300,
   MIN_CONTENT_WIDTH: 400,
 }))
@@ -120,10 +120,7 @@ describe('TableOfContentsSidebar', () => {
       <TableOfContentsSidebar content={content} onHeadingClick={vi.fn()} />
     )
 
-    // Find the close button (the one that doesn't contain heading text)
-    const headerButtons = screen.getAllByRole('button')
-    const closeBtn = headerButtons.find(btn => !btn.textContent?.includes('Heading'))!
-    fireEvent.click(closeBtn)
+    fireEvent.click(screen.getByLabelText('Close table of contents'))
 
     expect(mockSetActivePanel).toHaveBeenCalledWith(null)
   })

--- a/frontend/src/components/TableOfContentsSidebar.tsx
+++ b/frontend/src/components/TableOfContentsSidebar.tsx
@@ -10,6 +10,7 @@ import { useRightSidebarStore } from '../stores/rightSidebarStore'
 import { useResizableSidebar } from '../hooks/useResizableSidebar'
 import { parseMarkdownHeadings } from '../utils/markdownHeadings'
 import { CloseIcon } from './icons'
+import { RightSidebarMaxWidthToggle } from './RightSidebarMaxWidthToggle'
 
 interface TableOfContentsSidebarProps {
   content: string
@@ -45,13 +46,17 @@ export function TableOfContentsSidebar({
       {/* Header */}
       <div className="flex items-center justify-between py-1.5 px-4 border-b border-gray-200 shrink-0">
         <h3 className="text-base font-semibold text-gray-900">Table of Contents</h3>
-        <button
-          type="button"
-          onClick={() => setActivePanel(null)}
-          className="h-[28px] w-[28px] flex items-center justify-center text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100"
-        >
-          <CloseIcon className="w-5 h-5" />
-        </button>
+        <div className="flex items-center gap-0.5">
+          {isDesktop && <RightSidebarMaxWidthToggle />}
+          <button
+            type="button"
+            onClick={() => setActivePanel(null)}
+            className="h-[28px] w-[28px] flex items-center justify-center text-gray-500 hover:text-gray-700 rounded-md hover:bg-gray-100"
+            aria-label="Close table of contents"
+          >
+            <CloseIcon className="w-5 h-5" />
+          </button>
+        </div>
       </div>
 
       {/* Heading list */}

--- a/frontend/src/components/editor/shortcutTooltip.tsx
+++ b/frontend/src/components/editor/shortcutTooltip.tsx
@@ -18,11 +18,16 @@ import type { ReactNode } from 'react'
 import { getShortcut, type ShortcutId } from '../../shortcuts/registry'
 import { formatShortcut } from '../../utils/platform'
 
-export function shortcutTooltipContent(id: ShortcutId): ReactNode {
+/**
+ * @param labelOverride - replaces the registry label on the first line (the
+ *   shortcut combo stays registry-driven). For buttons whose label depends on
+ *   state, e.g. "Maximize" vs "Restore" for a single toggle id.
+ */
+export function shortcutTooltipContent(id: ShortcutId, labelOverride?: string): ReactNode {
   const entry = getShortcut(id)
   return (
     <>
-      {entry.label}
+      {labelOverride ?? entry.label}
       <br />
       <span className="opacity-75">{formatShortcut(entry.keys)}</span>
     </>

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -196,6 +196,13 @@ export const NoteIcon = ({ className = 'h-full w-full' }: IconProps): ReactNode 
   </svg>
 )
 
+/** Horizontal double-headed arrow — "expand width" affordance for the sidebar max-width toggle */
+export const ExpandWidthIcon = ({ className = 'h-5 w-5' }: IconProps): ReactNode => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h16.5M7.5 8.25 3.75 12l3.75 3.75M16.5 8.25 20.25 12l-3.75 3.75" />
+  </svg>
+)
+
 /** Restore/undo arrow icon */
 export const RestoreIcon = ({ className = 'h-4 w-4' }: IconProps): ReactNode => (
   <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -65,6 +65,7 @@ import {
   IconWithBadge,
 } from '../icons'
 import { Tooltip } from '../ui'
+import { DESKTOP_SIDEBAR_ID } from '../../constants/sidebar'
 import type {
   SidebarItemComputed,
   SidebarBuiltinItemComputed,
@@ -871,7 +872,7 @@ export function Sidebar({ onOpenPalette }: SidebarProps): ReactNode {
 
       {/* Desktop sidebar */}
       <aside
-        id="desktop-sidebar"
+        id={DESKTOP_SIDEBAR_ID}
         className={`hidden h-dvh flex-shrink-0 border-r border-gray-200 bg-white transition-all md:block ${
           isCollapsed ? 'w-12' : 'w-72'
         }`}

--- a/frontend/src/constants/sidebar.ts
+++ b/frontend/src/constants/sidebar.ts
@@ -1,0 +1,8 @@
+/**
+ * DOM id of the desktop left sidebar. Shared because the right-sidebar width
+ * logic measures this element's width (it collapses w-12 ↔ w-72) to size and
+ * track the right sidebar. Naming it once avoids silent failures: a renamed id
+ * would otherwise make getElementById return null at every read site, falling
+ * back to a 0 width (max computed too large) with no error.
+ */
+export const DESKTOP_SIDEBAR_ID = 'desktop-sidebar'

--- a/frontend/src/hooks/useResizableSidebar.test.ts
+++ b/frontend/src/hooks/useResizableSidebar.test.ts
@@ -32,7 +32,7 @@ beforeEach(() => {
   // Default to desktop width
   setWindowWidth(1400)
   // Reset store
-  useRightSidebarStore.setState({ activePanel: null, width: DEFAULT_SIDEBAR_WIDTH })
+  useRightSidebarStore.setState({ activePanel: null, width: DEFAULT_SIDEBAR_WIDTH, maximized: false })
   // No left sidebar element by default
   document.getElementById('desktop-sidebar')?.remove()
 })
@@ -119,22 +119,62 @@ describe('useResizableSidebar', () => {
       sidebar.remove()
     })
 
-    it('should constrain store width on window resize', () => {
-      // Start with width that fits
+    it('should clamp rendered width on window resize without mutating the stored width', () => {
+      // The stored width is the user's chosen "restore" target — a transient
+      // viewport shrink must clamp what's rendered but never overwrite it.
       useRightSidebarStore.setState({ width: 500 })
-      renderHook(() => useResizableSidebar())
+      const { result } = renderHook(() => useResizableSidebar())
+      expect(result.current.width).toBe(500)
 
-      // Shrink window so max becomes smaller than stored width
-      // New max = max(280, 700 - 0 - 600) = 280 (since MIN_SIDEBAR_WIDTH clamping applies in store)
-      setWindowWidth(700)
+      // Shrink to a still-desktop width (>= 768) so max = max(280, 800 - 0 - 600)
+      // = 280, below stored 500. Below 768 we'd hit the mobile (unclamped) path.
+      setWindowWidth(800)
       act(() => {
         window.dispatchEvent(new Event('resize'))
       })
 
-      // Store should have been constrained
-      // max = max(280, 700 - 0 - 600) = 280
-      // 500 > 280, so store gets set to 280
-      expect(useRightSidebarStore.getState().width).toBe(MIN_SIDEBAR_WIDTH)
+      expect(result.current.width).toBe(MIN_SIDEBAR_WIDTH) // rendered clamps
+      expect(useRightSidebarStore.getState().width).toBe(500) // stored preserved
+    })
+  })
+
+  describe('maximize', () => {
+    it('should render at max width when maximized, ignoring the smaller stored width', () => {
+      // Stored 400, but maximized → max = max(280, 1400 - 0 - 600) = 800
+      useRightSidebarStore.setState({ width: 400, maximized: true })
+      const { result } = renderHook(() => useResizableSidebar())
+
+      expect(result.current.width).toBe(800)
+    })
+
+    it('should return to the stored width when maximize is turned off', () => {
+      useRightSidebarStore.setState({ width: 400, maximized: true })
+      const { result, rerender } = renderHook(() => useResizableSidebar())
+      expect(result.current.width).toBe(800)
+
+      act(() => {
+        useRightSidebarStore.getState().setMaximized(false)
+      })
+      rerender()
+
+      expect(result.current.width).toBe(400)
+    })
+
+    it('should exit maximize mode when the user drags the handle', () => {
+      useRightSidebarStore.setState({ width: 400, maximized: true })
+      const { result } = renderHook(() => useResizableSidebar())
+
+      act(() => {
+        const mockEvent = { preventDefault: vi.fn() } as unknown as React.MouseEvent
+        result.current.handleMouseDown(mockEvent)
+      })
+      // Drag to clientX=1000 → newWidth = 1400 - 1000 = 400
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 1000 }))
+      })
+
+      expect(useRightSidebarStore.getState().maximized).toBe(false)
+      expect(useRightSidebarStore.getState().width).toBe(400)
     })
   })
 

--- a/frontend/src/hooks/useResizableSidebar.test.ts
+++ b/frontend/src/hooks/useResizableSidebar.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useResizableSidebar } from './useResizableSidebar'
 import { useRightSidebarStore, DEFAULT_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH } from '../stores/rightSidebarStore'
+import { DESKTOP_SIDEBAR_ID } from '../constants/sidebar'
 
 // We don't mock the store — we use the real Zustand store and reset it between tests.
 // This gives higher confidence that the hook integrates correctly.
@@ -34,7 +35,7 @@ beforeEach(() => {
   // Reset store
   useRightSidebarStore.setState({ activePanel: null, width: DEFAULT_SIDEBAR_WIDTH, maximized: false })
   // No left sidebar element by default
-  document.getElementById('desktop-sidebar')?.remove()
+  document.getElementById(DESKTOP_SIDEBAR_ID)?.remove()
 })
 
 afterEach(() => {
@@ -106,7 +107,7 @@ describe('useResizableSidebar', () => {
     it('should account for left sidebar width in max calculation', () => {
       // Create a left sidebar element
       const sidebar = document.createElement('div')
-      sidebar.id = 'desktop-sidebar'
+      sidebar.id = DESKTOP_SIDEBAR_ID
       // jsdom doesn't compute layout, getBoundingClientRect returns zeros
       // So left sidebar width will be 0; this just verifies the element lookup works
       document.body.appendChild(sidebar)

--- a/frontend/src/hooks/useResizableSidebar.ts
+++ b/frontend/src/hooks/useResizableSidebar.ts
@@ -1,16 +1,24 @@
 /**
  * Shared drag-to-resize logic for right sidebar panels.
- * Handles width constraints, drag state, responsive breakpoint, and window resize.
+ * Handles width constraints, drag state, responsive breakpoint, maximize mode,
+ * and recompute on viewport / left-sidebar width changes.
  */
-import { useState, useEffect, useCallback } from 'react'
-import { useRightSidebarStore, MIN_SIDEBAR_WIDTH, MIN_CONTENT_WIDTH } from '../stores/rightSidebarStore'
+import { useReducer, useState, useEffect, useCallback } from 'react'
+import { useRightSidebarStore, computeMaxWidth } from '../stores/rightSidebarStore'
+import { DESKTOP_SIDEBAR_ID } from '../constants/sidebar'
 
 const MD_BREAKPOINT = 768
 
-function calculateMaxWidth(): number {
-  const leftSidebar = document.getElementById('desktop-sidebar')
+/**
+ * Measure the current maximum sidebar width from the live DOM/window. The left
+ * sidebar's width is read from the desktop sidebar element (it collapses
+ * w-12 ↔ w-72). Thin wrapper over the pure computeMaxWidth so the arithmetic
+ * stays testable.
+ */
+export function measureMaxSidebarWidth(): number {
+  const leftSidebar = document.getElementById(DESKTOP_SIDEBAR_ID)
   const leftSidebarWidth = leftSidebar?.getBoundingClientRect().width ?? 0
-  return Math.max(MIN_SIDEBAR_WIDTH, window.innerWidth - leftSidebarWidth - MIN_CONTENT_WIDTH)
+  return computeMaxWidth(window.innerWidth, leftSidebarWidth)
 }
 
 interface ResizableSidebarResult {
@@ -23,26 +31,46 @@ interface ResizableSidebarResult {
 export function useResizableSidebar(): ResizableSidebarResult {
   const storeWidth = useRightSidebarStore((state) => state.width)
   const setWidth = useRightSidebarStore((state) => state.setWidth)
+  const maximized = useRightSidebarStore((state) => state.maximized)
+  const setMaximized = useRightSidebarStore((state) => state.setMaximized)
   const [isDragging, setIsDragging] = useState(false)
   const [isDesktop, setIsDesktop] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth >= MD_BREAKPOINT : true
   )
+  // Forces a width recompute when the viewport or left-sidebar width changes.
+  // Kept separate from the persisted `width` so a transient viewport shrink
+  // clamps the rendered width without overwriting the user's chosen width.
+  const [, recompute] = useReducer((n: number) => n + 1, 0)
 
-  // Constrain width to current viewport on mount and window resize
   useEffect(() => {
-    const constrainWidth = (): void => {
-      const maxWidth = calculateMaxWidth()
-      if (storeWidth > maxWidth) {
-        setWidth(maxWidth)
-      }
+    const onResize = (): void => {
       setIsDesktop(window.innerWidth >= MD_BREAKPOINT)
+      recompute()
     }
-    constrainWidth()
-    window.addEventListener('resize', constrainWidth)
-    return () => window.removeEventListener('resize', constrainWidth)
-  }, [storeWidth, setWidth])
+    window.addEventListener('resize', onResize)
 
-  const width = isDesktop ? Math.min(storeWidth, calculateMaxWidth()) : storeWidth
+    // Track the left sidebar's animated collapse/expand so the clamped (and,
+    // when maximized, the effective) width stay in step with it.
+    const leftSidebar = document.getElementById(DESKTOP_SIDEBAR_ID)
+    let observer: ResizeObserver | undefined
+    if (leftSidebar && typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(() => recompute())
+      observer.observe(leftSidebar)
+    }
+
+    return () => {
+      window.removeEventListener('resize', onResize)
+      observer?.disconnect()
+    }
+  }, [])
+
+  // Effective rendered width. When maximized, follow the live max; otherwise
+  // clamp the stored width to it. Clamping here (not by mutating the store)
+  // keeps the restore target intact across viewport changes.
+  const maxWidth = measureMaxSidebarWidth()
+  const width = isDesktop
+    ? (maximized ? maxWidth : Math.min(storeWidth, maxWidth))
+    : storeWidth
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -54,8 +82,10 @@ export function useResizableSidebar(): ResizableSidebarResult {
 
     const handleMouseMove = (e: MouseEvent): void => {
       const newWidth = window.innerWidth - e.clientX
-      const maxWidth = calculateMaxWidth()
-      setWidth(Math.min(newWidth, maxWidth))
+      setWidth(Math.min(newWidth, measureMaxSidebarWidth()))
+      // A manual drag is an explicit width choice — leave maximize mode. Guarded
+      // so it fires once; the effect re-binds with maximized=false afterward.
+      if (maximized) setMaximized(false)
     }
 
     const handleMouseUp = (): void => {
@@ -73,7 +103,7 @@ export function useResizableSidebar(): ResizableSidebarResult {
       document.body.style.userSelect = ''
       document.body.style.cursor = ''
     }
-  }, [isDragging, setWidth])
+  }, [isDragging, setWidth, maximized, setMaximized])
 
   return { width, isDesktop, isDragging, handleMouseDown }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -297,11 +297,16 @@ body {
 /* Float the CM search panel in a fixed viewport position so it stays
    visible when scrolling long documents. The panel is in .cm-panels-top
    (via search({ top: true })), and position: fixed removes it from the
-   flex layout so .cm-scroller expands to fill — no layout gap. */
+   flex layout so .cm-scroller expands to fill — no layout gap.
+
+   The right offset tracks --right-sidebar-margin (set on #main-content by
+   Layout) so the panel shifts with the content instead of hiding behind the
+   right sidebar when it's open. Defaults to 0 when no sidebar is present, and
+   transitions in step with the content's margin animation. */
 .cm-editor .cm-panels-top {
   position: fixed !important;
   top: auto !important;
-  right: 2rem !important;
+  right: calc(var(--right-sidebar-margin, 0px) + 2rem) !important;
   left: auto !important;
   bottom: 0 !important;
   height: auto !important;
@@ -309,6 +314,7 @@ body {
   z-index: 50;
   border: none !important;
   background: transparent !important;
+  transition: right 200ms;
 }
 
 /* Style the CM search panel to match the app's design system */

--- a/frontend/src/shortcuts/registry.test.ts
+++ b/frontend/src/shortcuts/registry.test.ts
@@ -155,6 +155,7 @@ describe('global-shortcut policy invariants', () => {
       'app.commandPalette',
       'app.toggleSidebar',
       'app.toggleHistorySidebar',
+      'app.toggleSidebarMaxWidth',
       'app.escape',
     ])
     for (const shortcut of getAllShortcuts()) {

--- a/frontend/src/shortcuts/registry.ts
+++ b/frontend/src/shortcuts/registry.ts
@@ -147,6 +147,18 @@ export const SHORTCUTS = [
     allowInInputs: true,
   },
   {
+    // Global (bubble-phase) shortcut, so `code` is safe here even though it's
+    // the convention for capture-phase editor entries: `code: 'Backslash'`
+    // avoids the macOS Option-key character shift (Option+\ reports key '«').
+    // Pairs with ⌘⇧\ (history sidebar) on the same physical key.
+    id: 'app.toggleSidebarMaxWidth',
+    label: 'Maximize Sidebar Width',
+    section: 'View',
+    keys: ['⌘', '⌥', '\\'],
+    match: { mod: true, alt: true, code: 'Backslash' },
+    allowInInputs: true,
+  },
+  {
     id: 'app.showShortcuts',
     label: 'Show Shortcuts',
     section: 'View',

--- a/frontend/src/shortcuts/types.ts
+++ b/frontend/src/shortcuts/types.ts
@@ -41,11 +41,13 @@ interface ShortcutMatchBase {
  *
  * - `key`: compares against `event.key`. Used for almost everything (Cmd+B,
  *   Cmd+Shift+/, Escape). Single-letter keys compare case-insensitively.
- * - `code`: compares against `event.code` (physical key). Use ONLY where
- *   macOS Option-key conversion forces our hand (Option+Z reports
- *   `event.key === 'Ω'`). e.g. 'KeyZ', 'KeyL', 'KeyM', 'KeyT'.
- *   Belongs to the capture-phase listener path; the CM keymap adapter throws
- *   on these.
+ * - `code`: compares against `event.code` (physical key). Use where macOS
+ *   Option-key conversion forces our hand (Option+Z reports `event.key === 'Ω'`,
+ *   Option+\ reports '«'). e.g. 'KeyZ', 'KeyL', 'KeyM', 'KeyT', 'Backslash'.
+ *   Capture-phase editor entries must use `code`, and the CM keymap adapter
+ *   throws on `code` — but global (bubble-phase) entries dispatched via
+ *   useGlobalShortcuts may also use `code`, since the matcher handles it and
+ *   such entries never reach the CM adapter (e.g. app.toggleSidebarMaxWidth).
  */
 export type ShortcutMatch =
   & ShortcutMatchBase

--- a/frontend/src/stores/rightSidebarStore.test.ts
+++ b/frontend/src/stores/rightSidebarStore.test.ts
@@ -4,13 +4,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   useRightSidebarStore,
+  computeMaxWidth,
   DEFAULT_SIDEBAR_WIDTH,
   MIN_SIDEBAR_WIDTH,
+  MIN_CONTENT_WIDTH,
 } from './rightSidebarStore'
 
 describe('rightSidebarStore', () => {
   beforeEach(() => {
-    useRightSidebarStore.setState({ activePanel: null, width: DEFAULT_SIDEBAR_WIDTH })
+    useRightSidebarStore.setState({ activePanel: null, width: DEFAULT_SIDEBAR_WIDTH, maximized: false })
     localStorage.clear()
   })
 
@@ -182,7 +184,76 @@ describe('rightSidebarStore', () => {
     })
   })
 
+  describe('computeMaxWidth', () => {
+    it('subtracts left sidebar and reserved content width from the viewport', () => {
+      // 1440 - 288 (expanded left) - 600 reserved = 552
+      expect(computeMaxWidth(1440, 288)).toBe(1440 - 288 - MIN_CONTENT_WIDTH)
+    })
+
+    it('grows when the left sidebar is collapsed', () => {
+      // Same viewport, collapsed left sidebar (48) leaves more room.
+      expect(computeMaxWidth(1440, 48)).toBeGreaterThan(computeMaxWidth(1440, 288))
+    })
+
+    it('floors at MIN_SIDEBAR_WIDTH on narrow viewports', () => {
+      // 900 - 288 - 600 = 12, below the floor.
+      expect(computeMaxWidth(900, 288)).toBe(MIN_SIDEBAR_WIDTH)
+    })
+  })
+
+  describe('maximize', () => {
+    it('toggleMaximized flips and persists the flag', () => {
+      const { toggleMaximized } = useRightSidebarStore.getState()
+      toggleMaximized()
+      expect(useRightSidebarStore.getState().maximized).toBe(true)
+      expect(localStorage.getItem('right-sidebar-maximized')).toBe('true')
+
+      toggleMaximized()
+      expect(useRightSidebarStore.getState().maximized).toBe(false)
+      expect(localStorage.getItem('right-sidebar-maximized')).toBe('false')
+    })
+
+    it('setMaximized does not touch the stored width (restore target preserved)', () => {
+      const { setWidth, setMaximized } = useRightSidebarStore.getState()
+      setWidth(700)
+      setMaximized(true)
+      expect(useRightSidebarStore.getState().width).toBe(700)
+      setMaximized(false)
+      expect(useRightSidebarStore.getState().width).toBe(700)
+    })
+
+    it('handles localStorage errors gracefully', () => {
+      const { setMaximized } = useRightSidebarStore.getState()
+      const originalSetItem = localStorage.setItem
+      localStorage.setItem = vi.fn(() => {
+        throw new Error('Storage quota exceeded')
+      })
+
+      expect(() => setMaximized(true)).not.toThrow()
+      expect(useRightSidebarStore.getState().maximized).toBe(true)
+
+      localStorage.setItem = originalSetItem
+    })
+  })
+
   describe('initialization from localStorage', () => {
+    it('should initialize maximized from localStorage when set to true', async () => {
+      vi.resetModules()
+      localStorage.clear()
+      localStorage.setItem('right-sidebar-maximized', 'true')
+
+      const { useRightSidebarStore: freshStore } = await import('./rightSidebarStore')
+      expect(freshStore.getState().maximized).toBe(true)
+    })
+
+    it('should default maximized to false when localStorage is empty', async () => {
+      vi.resetModules()
+      localStorage.clear()
+
+      const { useRightSidebarStore: freshStore } = await import('./rightSidebarStore')
+      expect(freshStore.getState().maximized).toBe(false)
+    })
+
     it('should use default width when localStorage is empty', async () => {
       vi.resetModules()
       localStorage.clear()

--- a/frontend/src/stores/rightSidebarStore.ts
+++ b/frontend/src/stores/rightSidebarStore.ts
@@ -12,9 +12,21 @@ export const MIN_SIDEBAR_WIDTH = 280
 /** Minimum space reserved for content area (header buttons + padding) */
 export const MIN_CONTENT_WIDTH = 600
 
+/**
+ * Largest the right sidebar may grow to, given the viewport and the current
+ * left-sidebar width. Pure so it can be unit-tested without a DOM/window;
+ * callers supply the measured values (see measureMaxSidebarWidth). Floored at
+ * MIN_SIDEBAR_WIDTH so it never returns a negative or sub-minimum width on
+ * narrow viewports.
+ */
+export function computeMaxWidth(innerWidth: number, leftSidebarWidth: number): number {
+  return Math.max(MIN_SIDEBAR_WIDTH, innerWidth - leftSidebarWidth - MIN_CONTENT_WIDTH)
+}
+
 // Storage keys for persisting state
 const WIDTH_STORAGE_KEY = 'right-sidebar-width'
 const PANEL_STORAGE_KEY = 'right-sidebar-panel'
+const MAXIMIZED_STORAGE_KEY = 'right-sidebar-maximized'
 
 // Load initial width from localStorage
 function getInitialWidth(): number {
@@ -37,17 +49,32 @@ function getInitialPanel(): SidebarPanel | null {
   return null
 }
 
+// Load initial maximized state from localStorage
+function getInitialMaximized(): boolean {
+  if (typeof window === 'undefined') return false
+  return localStorage.getItem(MAXIMIZED_STORAGE_KEY) === 'true'
+}
+
 interface RightSidebarState {
   activePanel: SidebarPanel | null
   width: number
+  /**
+   * When true, the sidebar renders at its current maximum width instead of
+   * `width`. `width` is preserved untouched as the restore target — toggling
+   * off returns to it. A property of the sidebar shell, shared across panels.
+   */
+  maximized: boolean
   setActivePanel: (panel: SidebarPanel | null) => void
   togglePanel: (panel: SidebarPanel) => void
   setWidth: (width: number) => void
+  setMaximized: (maximized: boolean) => void
+  toggleMaximized: () => void
 }
 
 export const useRightSidebarStore = create<RightSidebarState>((set, get) => ({
   activePanel: getInitialPanel(),
   width: getInitialWidth(),
+  maximized: getInitialMaximized(),
   setActivePanel: (panel) => {
     // Only persist 'history' to localStorage; 'toc' is session-only
     // (ToC requires specific page support and shouldn't restore on reload/navigation)
@@ -76,5 +103,16 @@ export const useRightSidebarStore = create<RightSidebarState>((set, get) => ({
       // Ignore storage errors - in-memory state still updates
     }
     set({ width: clampedWidth })
+  },
+  setMaximized: (maximized) => {
+    try {
+      localStorage.setItem(MAXIMIZED_STORAGE_KEY, String(maximized))
+    } catch {
+      // Ignore storage errors - in-memory state still updates
+    }
+    set({ maximized })
+  },
+  toggleMaximized: () => {
+    get().setMaximized(!get().maximized)
   },
 }))

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -10,6 +10,15 @@ if (!Range.prototype.getClientRects) {
 // jsdom doesn't implement scrollIntoView
 Element.prototype.scrollIntoView = vi.fn()
 
+// jsdom doesn't implement ResizeObserver (used to track left-sidebar width changes)
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+}
+
 // Mock react-diff-viewer-continued to avoid ESM module resolution issues in tests
 vi.mock('react-diff-viewer-continued', () => ({
   default: ({ oldValue, newValue }: { oldValue: string; newValue: string }) =>


### PR DESCRIPTION
## Summary

Two right-sidebar improvements for content detail pages (version history / table of contents):

1. Fixes the CodeMirror Cmd+F find/replace panel rendering *behind* the right sidebar instead of shifting with the editor content.
2. Adds a max-width toggle (header button + `⌘⌥\` shortcut) that expands the sidebar to its maximum and restores the previous width on a second toggle.

Frontend-only. Both ship behind the same width-calculation path, so the Cmd+F offset tracks the maximized sidebar without a separate code path.

## Changes

- **Cmd+F panel fix:** the search panel offsets its `right` by a new `--right-sidebar-margin` CSS variable (set on `#main-content` from the same value as the content margin), so it shifts with content instead of hiding behind the sidebar. Defaults to no offset when closed.
- **Max-width toggle:** a `maximized` flag in the right-sidebar store, persisted across reloads and shared by both panels; the user's chosen width is preserved as the restore target. Shared toggle button in both sidebar headers with state-dependent tooltip/aria-label and active styling; new `app.toggleSidebarMaxWidth` shortcut (`⌘⌥\`).
- **Restore-width bug fix:** a transient viewport shrink no longer overwrites the persisted width — viewport changes now clamp only the rendered width.
- **Left-sidebar tracking:** a `ResizeObserver` on the desktop sidebar keeps the right sidebar width and content margin (and Cmd+F offset) in sync across the left sidebar's collapse/expand animation.
- **Shared helper/constant:** pure `computeMaxWidth()` (unit-tested) with a thin DOM wrapper used by both the hook and `Layout`; `DESKTOP_SIDEBAR_ID` constant replaces the magic string across its read sites.
- **Tests:** store, hook, Layout, and registry coverage including restore-width integrity, exit-maximize-on-drag, and the desktop-only shortcut gating; `ResizeObserver` jsdom stub added to test setup.

## Impact

No breaking changes; no new dependencies; no backend or deployment changes. The `⌘⌥\` shortcut and toggle button appear automatically in the registry-driven shortcuts dialog and docs. The maximize action is desktop-only (button hidden and shortcut gated on mobile, where the sidebar is already full-width).

**Reviewer note:** the left-sidebar invalidation deliberately uses a `ResizeObserver` rather than an `isCollapsed` store subscription — the subscription reads stale geometry mid-animation (rationale documented in the implementation plan under `docs/implementation_plans/`).
