### PR TITLE
Sandbox Jinja2 prompt-template rendering

### DIFF
--- a/backend/src/services/prompt_service.py
+++ b/backend/src/services/prompt_service.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
-from jinja2 import Environment, TemplateSyntaxError, meta
+from jinja2 import TemplateSyntaxError, meta
+from jinja2.sandbox import SandboxedEnvironment
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,8 +25,11 @@ from services.tag_service import get_or_create_tags, update_prompt_tags
 
 logger = logging.getLogger(__name__)
 
-# Jinja2 environment for template validation
-_jinja_env = Environment()
+# Jinja2 environment for template validation (parse + meta-analysis only; this
+# instance never renders). Sandboxed for consistency with the render path and to
+# prevent future misuse if someone later calls .render() on it — not load-bearing
+# for security here, since validation does not execute the template.
+_jinja_env = SandboxedEnvironment()
 
 
 class NameConflictError(Exception):
@@ -49,11 +53,14 @@ def validate_template(content: str | None, arguments: list[dict[str, Any]]) -> N
                     uses undefined variables, or has unused arguments.
 
     Note:
-        This validation uses meta.find_undeclared_variables() which also flags Jinja2
-        built-in globals (e.g., range, loop, cycler, namespace) as "undefined" if used.
-        Currently, templates should use simple {{ variable }} substitution. If control
-        structures with builtins are needed, add a JINJA_BUILTINS allowlist to exclude
-        from the undefined check.
+        This is an argument-coverage / ergonomics check, NOT a security control. It
+        verifies syntax and that the set of undeclared variables used in the template
+        matches the declared `arguments` (no undefined, no unused). It does not restrict
+        attribute access or otherwise sandbox the template — sandboxing happens at render
+        time via SandboxedEnvironment (see services/template_renderer.py). Jinja2's
+        built-in globals (e.g. range, cycler, namespace) are NOT reported by
+        meta.find_undeclared_variables(), so they pass validation without needing to be
+        declared as arguments.
     """
     # Content is required - a prompt without content is useless
     if not content or not content.strip():
@@ -67,10 +74,9 @@ def validate_template(content: str | None, arguments: list[dict[str, Any]]) -> N
     except TemplateSyntaxError as e:
         raise ValueError(f"Invalid Jinja2 syntax: {e.message}") from e
 
-    # Check for undefined variables
-    # Note: This will flag Jinja2 builtins (range, loop, etc.) as undefined.
-    # For simple variable substitution templates, this is fine. If builtins are
-    # needed in the future, add an allowlist here.
+    # Find variables referenced in the template but not bound within it. Jinja2's
+    # built-in globals (range, cycler, namespace, ...) are NOT reported here, so they
+    # pass without needing to be declared as arguments.
     template_vars = meta.find_undeclared_variables(ast)
 
     # Check for undefined variables (used in template but not in arguments)

--- a/backend/src/services/template_renderer.py
+++ b/backend/src/services/template_renderer.py
@@ -6,9 +6,14 @@ validating that required arguments are present and
 rejecting unknown arguments.
 """
 
+import logging
 from typing import Any
 
-from jinja2 import Environment, StrictUndefined, TemplateSyntaxError, UndefinedError
+from jinja2 import StrictUndefined, TemplateSyntaxError, UndefinedError
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
+
+logger = logging.getLogger(__name__)
 
 
 class TemplateError(Exception):
@@ -17,8 +22,11 @@ class TemplateError(Exception):
     pass
 
 
-# Jinja2 environment with strict undefined variable handling
-_jinja_env = Environment(undefined=StrictUndefined)
+# Sandboxed Jinja2 environment: blocks unsafe attribute access (the attribute
+# traversal that server-side template injection relies on) while keeping strict
+# undefined-variable handling. Prompt content is user-authored and untrusted, so
+# a plain Environment is NOT a safe boundary here — only SandboxedEnvironment is.
+_jinja_env = SandboxedEnvironment(undefined=StrictUndefined)
 
 
 def render_template(
@@ -83,3 +91,15 @@ def render_template(
         raise TemplateError(f"Template syntax error: {e.message}") from e
     except UndefinedError as e:
         raise TemplateError(f"Template variable error: {e}") from e
+    except SecurityError as e:
+        # The sandbox blocked an unsafe operation (e.g. the attribute traversal
+        # used in server-side template injection). Log full detail server-side for
+        # attack detection and false-positive triage; return a generic message to
+        # the caller so we don't echo the offending expression back. Mirrors the
+        # decode_jwt pattern in core/auth.py (detail logged, generic to client).
+        # Per-caller prompt_id/user_id logging is deliberately deferred: this branch
+        # collapses SecurityError into the generic TemplateError, so callers can't
+        # distinguish a security block from a benign template error without a
+        # dedicated TemplateSecurityError subclass (tracked as a follow-up).
+        logger.warning("Blocked sandboxed template render: %s", e, exc_info=True)
+        raise TemplateError("Template uses a disallowed operation.") from e

--- a/backend/tests/api/test_prompts.py
+++ b/backend/tests/api/test_prompts.py
@@ -1258,6 +1258,29 @@ async def test__render_prompt__unknown_argument(client: AsyncClient) -> None:
     assert "extra" in response.json()["detail"]
 
 
+async def test__render_prompt__sandbox_blocks_ssti_escape(client: AsyncClient) -> None:
+    """SSTI escape via attribute traversal returns 400, not 500 or a rendered escape."""
+    # Declares `x` (optional), so create-time validation passes; the render-time
+    # sandbox must block the attribute traversal.
+    create_response = await client.post(
+        "/prompts/",
+        json={
+            "name": "render-ssti-escape",
+            "content": "{{ x.__class__.__mro__[1].__subclasses__() }}",
+            "arguments": [{"name": "x", "required": False}],
+        },
+    )
+    assert create_response.status_code == 201
+    prompt_id = create_response.json()["id"]
+
+    response = await client.post(
+        f"/prompts/{prompt_id}/render",
+        json={"arguments": {}},
+    )
+    assert response.status_code == 400
+    assert "disallowed operation" in response.json()["detail"]
+
+
 async def test__render_prompt__optional_argument_omitted(client: AsyncClient) -> None:
     """Test that optional arguments default to empty string for conditionals."""
     # Create prompt with optional argument

--- a/backend/tests/prompt_mcp_server/test_handlers_integration.py
+++ b/backend/tests/prompt_mcp_server/test_handlers_integration.py
@@ -222,6 +222,33 @@ async def test__get_prompt__not_found_error(
     assert "not found" in str(exc_info.value).lower()
 
 
+async def test__get_prompt__sandbox_blocks_ssti_escape(
+    mcp_integration_client: AsyncClient,
+) -> None:
+    """
+    SSTI escape template surfaces as INVALID_PARAMS over MCP, not an unhandled crash.
+
+    The render path is shared with the REST surface, so the renderer-level test covers
+    the genuinely-new behavior; this guards the MCP layer's TemplateError ->
+    INVALID_PARAMS translation for the sandbox SecurityError case (the second of the
+    two reachable surfaces).
+    """
+    create = await mcp_integration_client.post(
+        "/prompts/",
+        json={
+            "name": "mcp-ssti-escape",
+            "content": "{{ x.__class__ }}",
+            "arguments": [{"name": "x", "required": False}],
+        },
+    )
+    assert create.status_code == 201
+
+    with pytest.raises(McpError) as exc_info:
+        await handle_get_prompt("mcp-ssti-escape", {})
+
+    assert exc_info.value.error.code == types.INVALID_PARAMS
+
+
 async def test__list_prompts__pagination_with_real_data(
     mcp_integration_client: AsyncClient,
 ) -> None:

--- a/backend/tests/security/deployed/test_live_penetration.py
+++ b/backend/tests/security/deployed/test_live_penetration.py
@@ -1669,6 +1669,88 @@ class TestHistoryIDOR:
                 )
 
 
+class TestPromptSSTI:
+    """
+    Verify prompt template rendering is sandboxed against server-side template injection.
+
+    Prompt content is a user-authored Jinja2 template rendered server-side. A non-sandboxed
+    environment would let attribute traversal (__class__/__mro__/__subclasses__) escape to
+    arbitrary Python. The render path uses SandboxedEnvironment, which must reject the escape
+    as a 400 rather than rendering the object graph (or 500ing).
+    OWASP Reference: A03:2021 - Injection
+    """
+
+    async def test__render_attribute_traversal_escape__returns_400(
+        self,
+        headers_user_a: dict[str, str],
+    ) -> None:
+        """An SSTI escape template renders as a 400, not a 500 or a leaked object graph."""
+        async with httpx.AsyncClient() as client:
+            payload = {
+                "name": "ssti-test-prompt-12345",
+                "content": "{{ x.__class__.__mro__[1].__subclasses__() }}",
+                "arguments": [{"name": "x", "required": False}],
+                "tags": ["ssti-test"],
+            }
+
+            create_response = await client.post(
+                f"{API_URL}/prompts/",
+                headers=headers_user_a,
+                json=payload,
+            )
+
+            # Handle case where name already exists (409 conflict): clean up and retry.
+            if create_response.status_code == 409:
+                list_response = await client.get(
+                    f"{API_URL}/prompts/",
+                    headers=headers_user_a,
+                    params={"q": "ssti-test-prompt-12345"},
+                )
+                if list_response.status_code == 200:
+                    for item in list_response.json().get("items", []):
+                        await client.delete(
+                            f"{API_URL}/prompts/{item['id']}",
+                            headers=headers_user_a,
+                            params={"permanent": "true"},
+                        )
+                create_response = await client.post(
+                    f"{API_URL}/prompts/",
+                    headers=headers_user_a,
+                    json=payload,
+                )
+
+            assert create_response.status_code == 201, f"Failed to create prompt: {create_response.text}"
+            prompt_id = create_response.json()["id"]
+
+            try:
+                render_response = await client.post(
+                    f"{API_URL}/prompts/{prompt_id}/render",
+                    headers=headers_user_a,
+                    json={"arguments": {}},
+                )
+
+                # The sandbox must block the escape: 400, not a 500 and not a 200 that
+                # leaked the Python object graph.
+                assert render_response.status_code == 400, (
+                    f"SECURITY VULNERABILITY: SSTI escape was not blocked! "
+                    f"Status: {render_response.status_code}, Body: {render_response.text}"
+                )
+                body = render_response.text
+                assert "__subclasses__" not in body, (
+                    f"SECURITY VULNERABILITY: render leaked the object graph! Body: {body}"
+                )
+                assert "<class" not in body, (
+                    f"SECURITY VULNERABILITY: render leaked the object graph! Body: {body}"
+                )
+
+            finally:
+                await client.delete(
+                    f"{API_URL}/prompts/{prompt_id}",
+                    headers=headers_user_a,
+                    params={"permanent": "true"},
+                )
+
+
 if __name__ == "__main__":
     # Allow running directly: python test_live_penetration.py
     pytest.main([__file__, "-v"])

--- a/backend/tests/services/test_template_renderer.py
+++ b/backend/tests/services/test_template_renderer.py
@@ -1,5 +1,7 @@
 """Tests for template renderer."""
 
+import logging
+
 import pytest
 
 from services.template_renderer import TemplateError, render_template
@@ -195,3 +197,76 @@ def test__render_template__nested_conditionals_and_loops() -> None:
     ]
     result = render_template(content, {"items": items}, args)
     assert result == "[A][C]"
+
+
+def test__render_template__blocks_attribute_traversal_escape() -> None:
+    """
+    SSTI escape via attribute traversal off a declared arg is blocked.
+
+    A non-sandboxed environment would let a template walk from an ordinary string
+    value to arbitrary Python via __class__/__mro__/__subclasses__. The sandbox must
+    reject this as a disallowed operation rather than render the object graph. The
+    arg is declared (and optional, defaulting to ""), so validation passes and the
+    render-time sandbox is the load-bearing defense.
+    """
+    content = "{{ x.__class__.__mro__[1].__subclasses__() }}"
+    args = [{"name": "x", "required": False}]
+
+    with pytest.raises(TemplateError, match="disallowed operation"):
+        render_template(content, {}, args)
+
+
+def test__render_template__blocks_dunder_access_on_builtin_global() -> None:
+    """
+    SSTI escape via a Jinja built-in global is also blocked.
+
+    Built-in globals like `cycler` are NOT flagged by argument-coverage validation,
+    so a template referencing one needs no declared argument at all — confirming the
+    render-time sandbox, not validation, is what closes the hole.
+    """
+    content = "{{ cycler.__init__.__globals__ }}"
+
+    with pytest.raises(TemplateError, match="disallowed operation"):
+        render_template(content, {}, [])
+
+
+def test__render_template__blocked_escape_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A blocked render emits a server-side WARNING for attack detection/triage."""
+    content = "{{ x.__class__ }}"
+    args = [{"name": "x", "required": False}]
+
+    with caplog.at_level(logging.WARNING, logger="services.template_renderer"):
+        with pytest.raises(TemplateError):
+            render_template(content, {}, args)
+
+    assert any(
+        record.levelno == logging.WARNING
+        and "Blocked sandboxed template render" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test__render_template__blocks_attr_filter_escape() -> None:
+    """
+    The |attr() filter is an alternate syntactic path to the escape; also blocked.
+
+    This is not testing Jinja2 internals — it confirms that *our* environment config
+    closes the |attr() door, not just dotted access. A future change to the sandbox
+    config could plausibly regress one path and not the other, so both are locked.
+    """
+    content = '{{ x|attr("__class__") }}'
+    args = [{"name": "x", "required": False}]
+
+    with pytest.raises(TemplateError, match="disallowed operation"):
+        render_template(content, {}, args)
+
+
+def test__render_template__blocks_str_format_escape() -> None:
+    """`str.format` is a historic SSTI bypass; the sandbox blocks it via our env too."""
+    content = '{{ "{0.__class__}".format(x) }}'
+    args = [{"name": "x", "required": False}]
+
+    with pytest.raises(TemplateError, match="disallowed operation"):
+        render_template(content, {}, args)

--- a/docs/implementation_plans/2026-06-19-sandbox-template-rendering.md
+++ b/docs/implementation_plans/2026-06-19-sandbox-template-rendering.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Sandbox Jinja2 Prompt-Template Rendering
+
+**Branch:** `security/sandbox-template-rendering`
+**Severity:** Critical — authenticated server-side template injection (SSTI) leading to arbitrary code execution.
+
+## Background
+
+Prompt `content` is a **user-authored Jinja2 template** that the backend renders server-side. Today that rendering uses a plain `jinja2.Environment`, which does **not** restrict attribute access. Because Jinja2 exposes the underlying Python object graph through attribute traversal, a plain environment lets a template author walk from an ordinary value to arbitrary Python objects — the classic SSTI escape. A plain environment is **not** a security boundary for untrusted template input; only `jinja2.sandbox.SandboxedEnvironment` is.
+
+The only gate before rendering is `validate_template` (`backend/src/services/prompt_service.py`), which checks (a) Jinja2 **syntax** and (b) that every undeclared variable name used in the template is also declared in the prompt's `arguments`. It performs **no** restriction on attribute access, so it is not a mitigation for this issue. (See "Correct the misleading validation docstrings" below — its docstrings currently overstate what it does, which is part of why this gap persisted.)
+
+This is reachable by any authenticated user (including Personal Access Tokens), operating only on **their own** prompt, via:
+
+- `POST /prompts/{prompt_id}/render` — `backend/src/api/routers/prompts.py` (`render_prompt`)
+- the Prompt MCP server render path — `backend/src/prompt_mcp_server/server.py` (`render_template` call)
+
+Both call the same `render_template(...)` in `backend/src/services/template_renderer.py`, so fixing the renderer fixes both surfaces.
+
+## Approach: render in a `SandboxedEnvironment`
+
+Replace the plain `jinja2.Environment` used for **rendering** with `jinja2.sandbox.SandboxedEnvironment`. The sandbox overrides attribute/item access and raises `jinja2.exceptions.SecurityError` when a template tries to reach unsafe attributes (the dunder/private attribute traversal that SSTI relies on). This is the **load-bearing fix** — validation tweaks and AST checks are not a substitute for it.
+
+Keep `undefined=StrictUndefined` exactly as today; the sandbox is orthogonal to undefined-variable handling and the existing argument-defaulting behavior must not change.
+
+### Which environments change
+
+There are two `Environment()` instances in play; they are **not** equivalent and the plan treats them differently:
+
+1. **`backend/src/services/template_renderer.py` — the render environment.** This is the one that calls `.render(...)`. **This is the security-critical change.** Switch it to `SandboxedEnvironment(undefined=StrictUndefined)`.
+2. **`backend/src/services/prompt_service.py` — the validation environment.** This instance is used only for `.parse()` + `meta.find_undeclared_variables()`. It **never renders**, so it is not itself an execution vector. Switch it to `SandboxedEnvironment` too **for consistency and to prevent future misuse** (so nobody later calls `.render()` on the "validation" env assuming it's safe), but record in the PR description that this one is hardening-for-consistency, not the load-bearing change. Parsing/meta-analysis behavior is unaffected by the sandbox.
+
+### `SandboxedEnvironment` vs `ImmutableSandboxedEnvironment`
+
+`SandboxedEnvironment` blocks unsafe attribute access (the escape). `ImmutableSandboxedEnvironment` additionally forbids calling mutating methods (`list.append`, `dict.update`, etc.). For prompt templates — which are overwhelmingly `{{ variable }}` substitution plus simple `{% if %}`/`{% for %}` — `ImmutableSandboxedEnvironment` is the stricter, defensible default and is unlikely to break legitimate prompts. **Recommendation:** start with `SandboxedEnvironment` (the minimal change that closes the vulnerability), and raise `ImmutableSandboxedEnvironment` as a follow-up question in review. Decide explicitly; don't pick silently.
+
+### Error handling (do not skip — this affects API behavior)
+
+`render_template` today catches `TemplateSyntaxError` and `UndefinedError` and re-raises them as `TemplateError` (which the router maps to **HTTP 400**). A sandbox violation raises `jinja2.exceptions.SecurityError`, which is **not** currently caught — so without a change it would surface as an uncaught **500**. Add `SecurityError` to the caught set and re-raise as `TemplateError`, so a malicious/blocked template is reported as a client error (400 / MCP invalid-params), consistent with the other template failures. Use a clear, non-leaky message (e.g. "Template uses a disallowed operation.") — do not echo the offending expression back.
+
+## Reference Documentation
+
+The implementing agent **must** read these before writing code:
+
+- [Jinja2 Sandbox docs](https://jinja.palletsprojects.com/en/stable/sandbox/) — `SandboxedEnvironment`, `ImmutableSandboxedEnvironment`, `is_safe_attribute`/`is_safe_callable`, and `SecurityError`.
+- [Jinja2 API — `StrictUndefined`](https://jinja.palletsprojects.com/en/stable/api/#undefined-types) — confirm sandbox composes with the existing undefined handling.
+- In-repo, study first:
+  - `backend/src/services/template_renderer.py` — the render path (`render_template`, the module-level env, the existing `try/except`).
+  - `backend/src/services/prompt_service.py` — the validation env + `validate_template` and its docstrings.
+  - `backend/src/api/routers/prompts.py` (`render_prompt`) and `backend/src/prompt_mcp_server/server.py` (render call) — the two reachable surfaces; confirm both route through `render_template`.
+  - `backend/tests/services/test_template_renderer.py` — existing behavior tests (incl. `{% if %}`/`{% else %}` control flow) that must continue to pass unchanged.
+
+## Agent Behavior Rules
+
+- **Complete each milestone fully (implementation + tests) before moving on.** Stop for human review at each milestone boundary.
+- **Ask, don't guess** — especially on the `SandboxedEnvironment` vs `ImmutableSandboxedEnvironment` decision and on the exact user-facing error message.
+- **Never weaken, skip, or delete a test to make the suite pass.** If an existing prompt-rendering test breaks under the sandbox, that is a signal about legitimate template behavior — investigate and surface it, do not delete it.
+- **Use scoped verify commands:** `make backend-verify`. Do not run the full `make tests`.
+- **No commits or pushes without explicit human approval.** Stage and show diffs.
+
+---
+
+## Milestone 1 — Sandbox the render path
+
+- In `template_renderer.py`, replace the module-level `Environment(undefined=StrictUndefined)` with `SandboxedEnvironment(undefined=StrictUndefined)`.
+- Catch `jinja2.exceptions.SecurityError` in `render_template` and re-raise as `TemplateError` with a generic, non-leaky message (→ 400 / MCP invalid-params).
+- **Log the block server-side** (the client message stays generic). In the new `except SecurityError` branch, before raising, emit `logger.warning("Blocked sandboxed template render: %s", e, exc_info=True)` (add a module-level `logger = logging.getLogger(__name__)` if absent). Log the **exception only**, not the prompt content — Jinja's `SecurityError` message already names the offending access (e.g. *"access to attribute '\_\_class\_\_' of 'str' object is unsafe"*), and the content is by definition attacker-or-mistake input (PII/noise risk). This mirrors the codebase's existing pattern in `decode_jwt` (`core/auth.py:124-125`): full detail server-side, generic message to the client.
+- **Per-caller `prompt_id`/`user_id` logging is deliberately deferred** (not merely optional). Because the step above collapses `SecurityError` into the generic `TemplateError`, the callers (`render_prompt`, MCP handler) can no longer distinguish a *security block* from a *benign* template error (missing arg, syntax typo) — so adding IDs in their catch-blocks would WARNING-log every benign user typo with identifiers, which is noise. The WARNING at the `render_template` locus already provides a distinct "security block" signal in logs; only user/prompt *correlation* is given up. If false-positive triage later needs that correlation, the clean upgrade is a dedicated `TemplateSecurityError(TemplateError)` subclass so callers can catch it specifically and attach IDs (it still maps to 400 via the existing `except TemplateError`). **File that as a follow-up; do not fold it in now.**
+- In `prompt_service.py`, switch the validation env to `SandboxedEnvironment` for consistency (mark as non-load-bearing in the PR notes).
+- Confirm both reachable surfaces (`render_prompt`, MCP render) flow through the updated `render_template` — no separate env anywhere else. Grep for `Environment(` and `from_string(` / `.render(` across `backend/src` to be sure there is no third rendering site.
+
+**Verify:** `make backend-verify`. All existing `test_template_renderer.py` and prompt tests pass unchanged (substitution, multi-var, control-flow, defaults, unknown/missing-arg errors).
+
+## Milestone 2 — Regression tests (security)
+
+Add tests that lock in the fix so it cannot silently regress:
+
+- In `backend/tests/services/test_template_renderer.py` (and/or a focused test under `backend/tests/security/`): assert that rendering a template which performs **attribute traversal to escape the template context** (the standard SSTI gadget shape — reaching `__class__` / `__subclasses__` / `__globals__` off a normal value) **raises** (surfaces as `TemplateError`, not a 500, and not a rendered result). The test asserts the sandbox blocks the escape; it does **not** need to demonstrate any payload that performs a real side effect.
+- Assert the block is **logged**: using `caplog`, verify a blocked render emits a WARNING (covers the server-side observability added in M1). Keep it behavioral — assert a warning is logged on block, not its exact text.
+- Cover **both reachable surfaces**, not just REST:
+  - REST: `POST /prompts/{id}/render` returns **400** (not 500, not a rendered escape) for such a template (`backend/tests/api/test_prompts.py`).
+  - MCP: the prompt MCP render handler surfaces an `McpError` with `INVALID_PARAMS` (not an unhandled exception) for such a template — mock the prompt fetch via the existing `respx` harness (`backend/tests/prompt_mcp_server/`, pattern as in `test_mcp_protocol.py`). *Note: the MCP layer catches `TemplateError` generically, so this guards an adjacent, already-tested, unchanged translation path rather than genuinely-new behavior — it's near-free insurance because the harness exists, not risk-driven.*
+- Add a "benign templates still work" assertion covering plain substitution, `{% if %}`, and `{% for %}`, to prove the sandbox didn't break legitimate prompt usage.
+
+**Verify:** `make backend-verify`.
+
+## Milestone 3 — Correct the misleading validation docstrings + docs sync
+
+- **Fix the validation docstrings in `prompt_service.py`.** `validate_template`'s docstring/comments currently assert that `meta.find_undeclared_variables()` flags Jinja2 builtin globals (e.g. `range`, `cycler`, `namespace`) as undefined. In the installed Jinja2 version that is **not** true — those globals are not flagged — so the comment describes behavior the code does not have. Correct (or remove) the claim so the next reader isn't misled about what validation does or does not protect against. Validation is an argument-coverage/ergonomics check, **not** a security control — say so plainly.
+- **Files-to-keep-in-sync review per AGENTS.md:** check whether the security-tests section, `docs/architecture.md` (it mentions template rendering / "Things that are easy to miss"), or any LLM-facing artifact needs a note that prompt rendering is sandboxed. Update only what genuinely changed.
+- **Deployed security tests:** per AGENTS.md, after this change remind the human to run `backend/tests/security/deployed/test_live_penetration.py` against production once deployed, and consider adding an SSTI case there.
+
+**Verify:** `make backend-verify`.
+
+---
+
+## Dependency assumption (conscious, worth watching)
+
+The correctness of this fix rests on Jinja2's `SandboxedEnvironment` being a sound boundary — including against the historically-patched bypasses (`str.format`, `|attr()`, which the regression tests confirm our env blocks). That is Jinja2's maintained contract and the idiomatic choice (vs. a brittle hand-rolled AST denylist). The trade-off: if a future Jinja2 sandbox-escape CVE lands, **this is the dependency to watch**. Keep Jinja2 current so security patches flow in — do **not** pin it back.
+
+## Out of scope
+
+- Any change to outbound HTTP / URL handling — tracked separately, not part of this branch.
+- Broader template-feature changes (custom filters, allowlists, AST-level rejection of private-attribute access). An AST check is at best secondary defense-in-depth and is brittle (filters, `|attr()`); the sandbox is the correct boundary. If raised in review, file as a follow-up rather than expanding this PR.
+
+## Done criteria
+
+- Render path uses a sandboxed environment; SSTI escape attempts raise and map to a 400 (and MCP invalid-params), not a 500 or a successful render.
+- Blocked renders are logged server-side at WARNING (exception only, generic client message); per-caller ID logging consciously deferred to a `TemplateSecurityError` follow-up.
+- All pre-existing prompt/template tests pass unchanged; new regression tests added and green (renderer-level block of dotted-access, `|attr()`, and `str.format` escapes + WARNING-logged + REST 400 + MCP `INVALID_PARAMS` + benign-templates-still-render).
+- Misleading validation docstrings corrected.
+- Deployed SSTI case added to `test_live_penetration.py` (inert locally; runs only against a configured prod target).
+- `make backend-verify` green; human reminded to **run** the deployed pen tests against prod post-deploy.


### PR DESCRIPTION
Prompt content is a user-authored Jinja2 template rendered server-side. It was rendered through a plain (non-sandboxed) `Environment`, which does not restrict attribute access — so a template could traverse the Python object graph (`__class__`/`__globals__`/`__subclasses__`) and reach arbitrary code execution. The only prior gate, `validate_template`, is an argument-coverage check and provides no protection against this; builtin globals such as `cycler` aren't even flagged, so a no-argument template could reach the render path. Any authenticated user could exploit this on their own prompt via `POST /prompts/{id}/render` or the prompt MCP render tool.

- Render through `SandboxedEnvironment`, which blocks the unsafe attribute access that SSTI relies on; switch the parse-only validation env too for consistency
- Map a sandbox `SecurityError` to a generic `TemplateError` (REST 400 / MCP `INVALID_PARAMS`) and log full detail server-side at WARNING so blocks are triageable without echoing the offending expression back
- Add regression tests covering dotted-access, builtin-global, `|attr()`, and `str.format` escapes across the renderer plus both reachable surfaces (REST and MCP), and a deployed pen-test case for the production surface
- Correct misleading `validate_template` docstrings that claimed it flags builtins / acts as a security control

Sandbox soundness now rests on Jinja2's maintained contract — keep the dependency current and watch for sandbox-escape advisories (noted in the implementation plan).