### PR TITLE
Remove the Auth0 token-verification path — Clerk becomes the sole accepted issuer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,10 +42,11 @@ REDIS_URL=redis://localhost:${REDIS_HOST_PORT}
 # API_WORKERS=4         # Set in Railway Variables tab
 
 # -----------------------------------------------------------------------------
-# Auth0 (BACKEND ONLY during the dual-accept window; removed at M6b)
-# The frontend no longer speaks Auth0 (M3 flipped it to Clerk) — the old
-# VITE_AUTH0_* variables are gone. Backend verification of Auth0 tokens
-# continues until decommission.
+# Auth0 (retained transitional variables; removed in the M6b cleanup phase)
+# No code verifies Auth0 tokens anymore — the backend's Auth0 verification
+# path was removed at the M6b expand deploy. These variables are still
+# required by retained Settings validators and exist only as rollback/staging
+# surface until the cleanup phase deletes both together.
 # -----------------------------------------------------------------------------
 # Custom claim namespace for reading email/email_verified from Auth0 tokens.
 # This URL prefix is used to extract namespaced claims (e.g., {namespace}/email);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ cd frontend && npx vitest run src/path/to/file.test.ts
 - **PYTHONPATH is `backend/src`** — all imports relative to this root (e.g., `from api.routers import bookmarks`, `from services.bookmark_service import BookmarkService`). Never use `from backend.src...` or relative imports.
 - **Entry point**: `api/main.py`. Routers in `api/routers/`, services in `services/`, models in `models/`, schemas in `schemas/`.
 - **`BaseEntityService`** provides shared CRUD for bookmark/note/prompt services. `ContentService` handles unified cross-type search. `LLMService` wraps LiteLLM for multi-provider AI.
-- **Auth** (`core/auth.py`): IdP session JWTs — dual-accept during the Auth0 → Clerk migration window, routed by issuer (see `docs/architecture.md` §5) — plus Personal Access Tokens (`bm_` prefix). Dev mode bypass via `VITE_DEV_MODE=true`. Cached in Redis (5-min TTL).
+- **Auth** (`core/auth.py`): Clerk-issued JWTs (session tokens + OAuth access tokens; Clerk is the sole accepted issuer — see `docs/architecture.md` §5) plus Personal Access Tokens (`bm_` prefix). Dev mode bypass via `VITE_DEV_MODE=true`. Cached in Redis (5-min TTL).
 - **Inbound webhooks** (`api/routers/webhooks.py`): Clerk delivers `user.deleted` (Svix-signed) to `POST /webhooks/clerk` — signature verified on the raw body before anything else; deletion = identity tombstone (blocks JIT resurrection) + cascade delete + auth-cache invalidation. Fails closed (503) without `CLERK_WEBHOOK_SIGNING_SECRET`.
 - **Models**: UUIDv7 PKs, soft delete (`deleted_at`), archiving (`archived_at`), trigger-maintained FTS vectors.
 

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -239,11 +239,11 @@ CLERK_AUTHORIZED_PARTIES=https://tiddly.me
 API_WORKERS=4
 ```
 
-**Clerk (dual-accept window — Auth0 → Clerk migration):** `CLERK_FRONTEND_API` (the production instance's Frontend API domain) and `CLERK_AUTHORIZED_PARTIES` (comma-separated web origins accepted as the `azp` claim) are **required** — Settings validation refuses to start without them in non-dev mode, same as `AUTH0_CUSTOM_CLAIM_NAMESPACE`. Clerk has been the **primary production IdP since the M6a cutover (2026-07-15)**. Two flags gate just-in-time user *creation* per issuer; both were flipped at the cutover and are actively set (non-default) on the api service:
+**Clerk (the sole IdP):** `CLERK_FRONTEND_API` (the production instance's Frontend API domain) and `CLERK_AUTHORIZED_PARTIES` (comma-separated web origins accepted as the `azp` claim) are **required** — Settings validation refuses to start without them in non-dev mode (as is `AUTH0_CUSTOM_CLAIM_NAMESPACE`, a retained validator scheduled for removal in the M6b cleanup phase). Clerk has been the **primary production IdP since the M6a cutover (2026-07-15)** and the **only accepted token issuer since the M6b expand deploy (2026-07-31)**. Two JIT-create flags are actively set (non-default) on the api service; only the Clerk one still gates anything — the Auth0 flag's code path was removed with the Auth0 verifier, and the flag itself goes in M6b cleanup:
 
 ```
 CLERK_JIT_CREATE_ENABLED=true    # flipped at the 2026-07-15 cutover (code default: false)
-AUTH0_JIT_CREATE_ENABLED=false   # flipped at the 2026-07-15 cutover (code default: true)
+AUTH0_JIT_CREATE_ENABLED=false   # inert since the M6b expand deploy; removed in M6b cleanup
 ```
 
 **Account-deletion webhook:** `CLERK_WEBHOOK_SIGNING_SECRET` (the `whsec_...` secret of the production instance's webhook endpoint — see Step 6f). API service only. Unset, `POST /webhooks/clerk` fails closed with 503; Svix retries on a finite ~28-hour schedule and then marks deliveries Failed (manual replay only — see the Step 6f runbook).
@@ -386,7 +386,7 @@ Clerk provides authentication for the web app (embedded sign-in components, no h
 
 This section is deliberately specific about WHAT must exist in Clerk and gives only general dashboard direction — dashboard click-paths rot; settings do not. Nearly everything below is scriptable through the Clerk CLI (`clerk auth login` once, then `clerk apps create`, `clerk config pull/patch/put`, `clerk deploy`, `clerk env pull`); the committed `clerk/config.dev.json` is the reviewable source of truth for instance configuration (see `clerk/README.md`).
 
-> **Migration status (see `docs/implementation_plans/2026-07-02-clerk-migration.md`):** the frontend cutover **executed 2026-07-15 (M6a)** — Clerk is the live production web IdP and the frontend service carries `VITE_CLERK_PUBLISHABLE_KEY`. The backend still **dual-accepts** Auth0 and Clerk tokens: the legacy Auth0 tenant keeps serving already-issued sessions (chiefly iOS) until decommission (M6b), so its backend env var (`AUTH0_CUSTOM_CLAIM_NAMESPACE`) stays set. To recreate the Auth0 side from scratch mid-window, see this file's pre-M3 version in git history.
+> **Migration status (see `docs/implementation_plans/2026-07-02-clerk-migration.md`):** the frontend cutover **executed 2026-07-15 (M6a)** — Clerk is the live production web IdP and the frontend service carries `VITE_CLERK_PUBLISHABLE_KEY`. The backend accepts **Clerk tokens only** as of the M6b expand deploy (2026-07-31): the Auth0 verification path is removed, and an Auth0-issued token gets the generic unknown-issuer 401. The Auth0 env vars, `users.auth0_id` column, and tenants are temporarily retained as rollback/staging surfaces and are removed in the M6b contract/cleanup phases (see the decommission run sheet). To recreate the Auth0 side from scratch, see this file's pre-M3 version in git history.
 
 #### 6a. Application and instances
 

--- a/backend/src/core/auth.py
+++ b/backend/src/core/auth.py
@@ -1,5 +1,5 @@
 """
-Authentication module: IdP JWT verification (dual-accept) and PAT support.
+Authentication module: Clerk JWT verification and PAT support.
 
 Provider seam containment (architecture-level intent — keep it this way): every
 provider-specific shape in the backend lives in this module plus its immediate
@@ -7,11 +7,12 @@ collaborators (`core/config.py`, `core/auth_cache.py`, `core/request_context.py`
 `schemas/cached_user.py`). Nothing outside the seam may parse tokens, read
 provider claims, or know which IdP issued a credential.
 
-Dual-accept window (Auth0 → Clerk migration, see
-docs/implementation_plans/2026-07-02-clerk-migration.md): JWTs are routed by
-their `iss` claim to the Auth0 or Clerk verifier; both resolve to the same user
-rows (Auth0 tokens via users.auth0_id, Clerk tokens via users.external_auth_id).
-The Auth0 path is removed at decommission (M6b).
+Clerk is the only accepted JWT issuer. The Auth0 verification arm from the
+migration's dual-accept window (see
+docs/implementation_plans/2026-07-02-clerk-migration.md) was removed at
+decommission (M6b); tokens from any other issuer get a 401. The `users.auth0_id`
+keying in get_or_create_user remains until the M6b contract phase drops the
+column.
 """
 import logging
 from typing import Annotated
@@ -159,39 +160,6 @@ def _jwt_error_to_http(e: jwt.PyJWTError) -> HTTPException:
         detail=detail,
         headers={"WWW-Authenticate": "Bearer"},
     )
-
-
-def decode_jwt(token: str, settings: Settings) -> dict:
-    """
-    Decode and validate a JWT token from Auth0. (Removed in M6b.).
-
-    Raises:
-        HTTPException: If token is invalid, expired, or has wrong audience/issuer.
-    """
-    try:
-        jwks_client = get_jwks_client(settings.auth0_jwks_url)
-        signing_key = jwks_client.get_signing_key_from_jwt(token)
-
-        return jwt.decode(
-            token,
-            signing_key.key,
-            algorithms=["RS256"],
-            audience=settings.auth0_audience,
-            issuer=settings.auth0_issuer,
-        )
-
-    # Order matters: PyJWKClientConnectionError IS a PyJWTError, so the
-    # provider-unreachable case must be caught first — it's an outage (503,
-    # retryable), not a bad token (401, which would sign the user out).
-    except jwt.PyJWKClientConnectionError as e:
-        # Log full details for debugging (server-side only)
-        logger.error("Failed to fetch JWKS from Auth0: %s", e, exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Could not validate credentials",
-        )
-    except jwt.PyJWTError as e:
-        raise _jwt_error_to_http(e)
 
 
 def decode_clerk_jwt(token: str, settings: Settings) -> dict:
@@ -370,8 +338,9 @@ async def get_or_create_user(
     WARNING: Do NOT access ORM relationships like .bookmarks, .tokens on the return value.
     Those only exist on User, not CachedUser.
 
-    JIT-create gating (dual-accept window rule, AD5): lookup is always allowed;
-    when `jit_create_allowed` is False an unknown identity is rejected with a
+    JIT-create gating (introduced as a dual-accept window rule, AD5; now gates
+    Clerk-path creation only): lookup is always allowed; when
+    `jit_create_allowed` is False an unknown identity is rejected with a
     generic 401 plus a warning log naming the identity — the loud, observable
     failure mode for identities leaking past a provider-side sign-up control.
 
@@ -588,10 +557,12 @@ async def _reject_deleted_identity(
     Block JIT resurrection of a deleted account (M8 anti-resurrection guard).
 
     A deleted user's tokens can outlive the deletion — a not-yet-expired Clerk
-    JWT, or an Auth0 session kept alive by refresh tokens (iOS) for the whole
-    dual-accept window. Without this check, the next validly-signed token
-    would JIT-create an empty resurrected row. The tombstone is written by the
-    deletion path (services/user_service.delete_user_by_external_auth_id).
+    JWT (and, during the migration's dual-accept window, an Auth0 session kept
+    alive by refresh tokens on iOS — that token route is gone, but the
+    auth0-keyed guard stays until the column does). Without this check, the
+    next validly-signed token would JIT-create an empty resurrected row. The
+    tombstone is written by the deletion path
+    (services/user_service.delete_user_by_external_auth_id).
     """
     if await _is_identity_tombstoned(db, auth0_id, external_auth_id):
         _raise_deleted_identity(auth0_id, auth0_id or external_auth_id)
@@ -803,7 +774,8 @@ async def _authenticate_user(
     Internal: authenticate user without consent check.
 
     Supports:
-    - IdP-issued JWTs, routed by issuer (Auth0 or Clerk — dual-accept window)
+    - Clerk-issued JWTs (session tokens and OAuth access tokens; any other
+      issuer is rejected)
     - Personal Access Tokens (PATs) starting with 'bm_' (for CLI/MCP/scripts)
 
     In DEV_MODE, bypasses auth and returns a test user.
@@ -823,10 +795,11 @@ async def _authenticate_user(
             Policy decision (M4 security review, deliberate): Clerk OAuth access
             tokens (`at+jwt` — day-lived, programmatic) DO count as session auth
             on PAT-blocked surfaces (/tokens/*, fetch-metadata, AI endpoints).
-            This is parity with today: the CLI's Auth0 device-flow JWTs already
-            pass these checks, and the PAT block's purpose is limiting leaked
-            long-lived static credentials, not interactive-grade OAuth grants
-            (which require a browser sign-in and expire daily).
+            This preserved parity with the pre-migration behavior (the CLI's
+            Auth0 device-flow JWTs passed these checks), and the PAT block's
+            purpose is limiting leaked long-lived static credentials, not
+            interactive-grade OAuth grants (which require a browser sign-in
+            and expire daily).
     """
     token_prefix: str | None = None
 
@@ -857,43 +830,15 @@ async def _authenticate_user(
         else:
             # IdP JWT: dispatch on the (unverified) `iss` claim — see _peek_issuer
             # for why that is safe. The selected verifier enforces everything.
+            # Clerk is the only accepted issuer (M6b removed the Auth0 arm);
+            # any other issuer — including a still-valid Auth0 token — is a 401.
             auth_type = AuthType.SESSION
             issuer = _peek_issuer(token)
 
-            if issuer == settings.auth0_issuer:
-                payload = decode_jwt(token, settings)
-
-                # Extract user info from JWT claims
-                auth0_id = payload.get("sub")
-                if not auth0_id:
-                    raise HTTPException(
-                        status_code=status.HTTP_401_UNAUTHORIZED,
-                        detail="Invalid token: missing sub claim",
-                        headers={"WWW-Authenticate": "Bearer"},
-                    )
-
-                # The cutover signal (M6a→M6b): during the window, `ios` should be
-                # the only source still authenticating via Auth0. Decommission is
-                # gated on this log going quiet.
-                logger.info(
-                    "auth0_path_authentication source=%s sub=%s", source, auth0_id,
-                )
-
-                namespace = settings.auth0_custom_claim_namespace
-                email = payload.get(f"{namespace}/email") if namespace else payload.get("email")
-                email_verified = payload.get(f"{namespace}/email_verified") if namespace else None
-                user = await get_or_create_user(
-                    db,
-                    auth0_id=auth0_id,
-                    email=email,
-                    email_verified=email_verified,
-                    jit_create_allowed=settings.auth0_jit_create_enabled,
-                )
             # Clerk config is optional in dev; guard before comparing
             # clerk_issuer so an unset Frontend API doesn't route tokens into
-            # a malformed Clerk verifier. Auth0 needs no equivalent guard —
-            # its settings are startup-required for the dual-accept window.
-            elif settings.clerk_frontend_api and issuer == settings.clerk_issuer:
+            # a malformed Clerk verifier.
+            if settings.clerk_frontend_api and issuer == settings.clerk_issuer:
                 payload = decode_clerk_jwt(token, settings)
 
                 # `sub` presence is enforced by decode_clerk_jwt's require list.
@@ -976,8 +921,8 @@ async def get_current_user_session_only(
     """
     Dependency: session-only auth + rate limiting + consent check (blocks PAT access).
 
-    "Session" = an IdP-issued JWT (either issuer during dual-accept), as opposed
-    to a PAT. Returns User ORM object on cache miss, CachedUser on cache hit.
+    "Session" = a Clerk-issued JWT (session token or OAuth access token), as
+    opposed to a PAT. Returns User ORM object on cache miss, CachedUser on cache hit.
     Use this to block PAT access and help prevent unintended programmatic use.
 
     Examples:

--- a/backend/src/core/auth_cache.py
+++ b/backend/src/core/auth_cache.py
@@ -39,9 +39,10 @@ class AuthCache:
     A user entry is cached under every identifier that can authenticate it:
     - `id:{user_id}` — PAT flow lookups
     - `ext:{external_auth_id}` — Clerk JWT lookups (token `sub`)
-    - `auth0:{auth0_id}` — Auth0 JWT lookups. Transitional: this segment (and
-      everything else auth0-shaped here) is removed in M6b when the Auth0
-      verification path is decommissioned.
+    - `auth0:{auth0_id}` — retained transitional segment. No auth path reads
+      it anymore (the Auth0 verifier was removed at the M6b expand deploy);
+      it is kept only as rollback/staging structure and is removed, with the
+      column, in the M6b contract phase.
 
     Invalidation must cover every segment the user may be cached under —
     see invalidate().
@@ -124,8 +125,9 @@ class AuthCache:
         Cache user data from ORM User object.
 
         Caches by user_id always, and by each provider identifier the row
-        carries — so any auth path (PAT, Auth0 JWT, Clerk JWT) hits the same
-        entry.
+        carries — so any auth path (PAT, Clerk JWT) hits the same entry.
+        (The auth0 segment is still written for rows carrying auth0_id, but
+        nothing authenticates through it — retained transitional structure.)
 
         Args:
             user: The User ORM object to cache.

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -23,7 +23,10 @@ class Settings(BaseSettings):
     db_max_overflow: int = Field(default=10, validation_alias="DB_MAX_OVERFLOW")
     db_pool_recycle: int = Field(default=3600, validation_alias="DB_POOL_RECYCLE")
 
-    # Auth0 - shared with frontend (VITE_ prefix for Vite exposure)
+    # Auth0 — retained transitional fields (VITE_ prefix is historical). No
+    # code path verifies Auth0 tokens anymore (removed at the M6b expand
+    # deploy); these fields and their env vars exist only as rollback/staging
+    # surface and are removed in the M6b cleanup phase.
     auth0_domain: str = Field(default="", validation_alias="VITE_AUTH0_DOMAIN")
     auth0_audience: str = Field(default="", validation_alias="VITE_AUTH0_AUDIENCE")
     auth0_client_id: str = Field(default="", validation_alias="VITE_AUTH0_CLIENT_ID")
@@ -34,7 +37,7 @@ class Settings(BaseSettings):
         validation_alias="AUTH0_CUSTOM_CLAIM_NAMESPACE",
     )
 
-    # Clerk (dual-accept window, Auth0 → Clerk migration)
+    # Clerk — the sole IdP
     # Frontend API domain of the Clerk instance (e.g. "clerk.tiddly.me" in
     # production, "<slug>.clerk.accounts.dev" for the dev instance); issuer and
     # JWKS URL are derived from it, mirroring the auth0_domain pattern.
@@ -137,16 +140,19 @@ class Settings(BaseSettings):
             self.auth0_custom_claim_namespace = self.auth0_custom_claim_namespace.rstrip("/")
 
         if not self.dev_mode:
-            # Production requires namespace to read email from Auth0 access tokens
+            # Retained transitional validator: nothing reads this namespace
+            # anymore (the Auth0 verifier is gone), but the requirement stays
+            # until the M6b cleanup phase removes the field and env var
+            # together — dropping the validator before the field would let a
+            # rollback deploy start half-configured.
             if not self.auth0_custom_claim_namespace:
                 raise ValueError(
                     "AUTH0_CUSTOM_CLAIM_NAMESPACE is required when DEV_MODE is disabled. "
-                    "Without it, email cannot be read from Auth0 access tokens.",
+                    "(Retained transitional check; removed with the field in M6b cleanup.)",
                 )
-            # Same safety check for the Clerk side of dual-accept: fail loudly at
-            # startup instead of silently rejecting every Clerk token. (Railway env
-            # vars must be set before the M1 merge - see the migration plan's M1
-            # operator step.)
+            # Fail loudly at startup instead of silently rejecting every Clerk
+            # token — Clerk is the sole IdP, so an unset Frontend API would be
+            # a fully broken deployment.
             if not self.clerk_frontend_api:
                 raise ValueError(
                     "CLERK_FRONTEND_API is required when DEV_MODE is disabled. "

--- a/backend/src/core/request_context.py
+++ b/backend/src/core/request_context.py
@@ -7,10 +7,11 @@ class AuthType(StrEnum):
     """
     Authentication method used for the request.
 
-    SESSION covers IdP-issued JWTs regardless of issuer (mechanism-descriptive,
-    provider-neutral — during the Auth0 → Clerk dual-accept window it spans both
-    issuers). Historical content_history rows persisted the pre-rename value
-    "auth0"; those are audit facts and are never backfilled.
+    SESSION covers IdP-issued JWTs (mechanism-descriptive, provider-neutral —
+    today that means Clerk session and OAuth tokens; during the Auth0 → Clerk
+    dual-accept window it spanned both issuers). Historical content_history
+    rows persisted the pre-rename value "auth0"; those are audit facts and are
+    never backfilled.
     """
 
     SESSION = "session"

--- a/backend/src/schemas/cached_user.py
+++ b/backend/src/schemas/cached_user.py
@@ -15,9 +15,10 @@ class CachedUser:
     the previous schema) are ignored and expire naturally via TTL. Without bumping
     the version, deserialization will fail or return stale/incorrect data.
 
-    Identity columns (dual-accept window): a user row carries auth0_id,
+    Identity columns (staged decommission): a user row carries auth0_id,
     external_auth_id, or both — at least one is always present (DB CHECK
-    constraint). auth0_id is dropped in M6b.
+    constraint). auth0_id no longer participates in authentication; it is
+    retained until the M6b contract phase drops it.
 
     Safe attributes (available on both CachedUser and User ORM):
     - id: UUID

--- a/backend/src/services/template_renderer.py
+++ b/backend/src/services/template_renderer.py
@@ -96,7 +96,7 @@ def render_template(
         # used in server-side template injection). Log full detail server-side for
         # attack detection and false-positive triage; return a generic message to
         # the caller so we don't echo the offending expression back. Mirrors the
-        # decode_jwt pattern in core/auth.py (detail logged, generic to client).
+        # decode_clerk_jwt pattern in core/auth.py (detail logged, generic to client).
         # Per-caller prompt_id/user_id logging is deliberately deferred: this branch
         # collapses SecurityError into the generic TemplateError, so callers can't
         # distinguish a security block from a benign template error without a

--- a/backend/tests/core/test_auth_clerk.py
+++ b/backend/tests/core/test_auth_clerk.py
@@ -1,10 +1,11 @@
 """
-Tests for the Clerk half of dual-accept token verification (M1).
+Tests for Clerk token verification (M1 dual-accept, Clerk-only since M6b).
 
-Unlike the Auth0-path tests (which patch decode_jwt), these mint REAL RS256
-JWTs with a test keypair and patch only the JWKS client — the azp rule,
-clock-skew leeway, and expiry checks live inside decode_clerk_jwt, so patching
-the decoder would bypass exactly what needs testing.
+These mint REAL RS256 JWTs with a test keypair and patch only the JWKS
+client — the azp rule, clock-skew leeway, and expiry checks live inside
+decode_clerk_jwt, so patching the decoder would bypass exactly what needs
+testing. (TEST_AUTH0_ISSUER survives only to prove the old issuer is now
+rejected at dispatch.)
 
 Note: Imports from core.auth are done inside test methods to avoid triggering
 Settings validation during test collection (before DATABASE_URL is set by fixtures).
@@ -53,14 +54,11 @@ def mock_request() -> Request:
 
 @pytest.fixture
 def clerk_settings() -> Settings:
-    """Mock settings with the Clerk dual-accept configuration populated."""
+    """Mock settings with the Clerk configuration populated."""
     settings = MagicMock(spec=Settings)
     settings.dev_mode = False
     settings.frontend_url = "http://localhost:5173"
     settings.api_url = "http://localhost:8000"
-    settings.auth0_issuer = TEST_AUTH0_ISSUER
-    settings.auth0_custom_claim_namespace = "https://test.example.com"
-    settings.auth0_jit_create_enabled = True
     settings.clerk_frontend_api = TEST_CLERK_FRONTEND_API
     settings.clerk_issuer = TEST_CLERK_ISSUER
     settings.clerk_jwks_url = f"{TEST_CLERK_ISSUER}/.well-known/jwks.json"
@@ -640,40 +638,62 @@ class TestIssuerDispatch:
         )
         assert result.scalar_one_or_none() is None
 
-    async def test__auth0_path__emits_source_log_line(
+    async def test__auth0_issuer_token__rejected_as_unknown_issuer(
         self,
         db_session: AsyncSession,
-        redis_client: object,  # noqa: ARG002
         clerk_settings: Settings,
         mock_request: Request,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """
-        Every Auth0-path authentication logs the resolved request source
-        (the M6a→M6b cutover signal).
+        M6b decommission invariant: a token carrying the old Auth0 issuer is
+        an unknown issuer now — generic 401 at dispatch, verifier never
+        invoked, no user row. The token is an old-issuer placeholder rejected
+        before verifier selection (signature is never examined here); the
+        genuinely-valid-Auth0-token proof is the run sheet's H3 production
+        check, not this unit test.
         """
         from core.auth import _authenticate_user  # noqa: PLC0415
 
-        sub = "auth0|log-line-test"
+        # Pin the retained Settings field to the value the token carries: if
+        # the Auth0 dispatch arm were ever restored, the issuer comparison
+        # must genuinely match and route into verification — which the JWKS
+        # patch below turns into a loud failure. On the bare MagicMock the
+        # comparison would be False for the wrong reason and a restored arm
+        # would go undetected.
+        clerk_settings.auth0_issuer = TEST_AUTH0_ISSUER
+        sub = "auth0|straggler-after-decommission"
         token = jwt.encode({"iss": TEST_AUTH0_ISSUER, "sub": sub}, "unused-test-key-0123456789abcdef", algorithm="HS256")
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
         with (
-            caplog.at_level(logging.INFO, logger="core.auth"),
-            patch("core.auth.decode_jwt", return_value={"sub": sub}),
+            caplog.at_level(logging.WARNING, logger="core.auth"),
+            patch(
+                "core.auth.get_jwks_client",
+                side_effect=AssertionError(
+                    "verifier boundary reached for an old-issuer token — "
+                    "the Auth0 dispatch arm has been reintroduced",
+                ),
+            ) as jwks_boundary,
+            pytest.raises(HTTPException) as exc_info,
         ):
             await _authenticate_user(
                 mock_request, credentials, db_session, clerk_settings, source="ios",
             )
 
-        assert any(
-            "auth0_path_authentication" in r.message and "source=ios" in r.getMessage()
-            for r in caplog.records
+        jwks_boundary.assert_not_called()
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid token"
+        assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
+        assert any("unknown or missing issuer" in r.message for r in caplog.records)
+        result = await db_session.execute(
+            select(User).where(User.auth0_id == sub),
         )
+        assert result.scalar_one_or_none() is None
 
 
 class TestJitCreateFlags:
-    """Per-issuer JIT-create gating (AD5 window rules, backend-enforced)."""
+    """Clerk JIT-create gating (single-issuer world since M6b)."""
 
     async def test__clerk_create_disabled__unknown_identity_401_with_log(
         self,
@@ -738,60 +758,6 @@ class TestJitCreateFlags:
         user = await _authenticate_user(
             mock_request, credentials, db_session, clerk_settings, source="web",
         )
-
-        assert user.id == existing.id
-
-    async def test__auth0_create_disabled__unknown_identity_401_with_log(
-        self,
-        db_session: AsyncSession,
-        redis_client: object,  # noqa: ARG002
-        clerk_settings: Settings,
-        mock_request: Request,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """Auth0 JIT-create off (M6a flip state): unknown Auth0 sub → 401 + warning."""
-        from core.auth import _authenticate_user  # noqa: PLC0415
-
-        clerk_settings.auth0_jit_create_enabled = False
-        sub = "auth0|straggler-after-flip"
-        token = jwt.encode({"iss": TEST_AUTH0_ISSUER, "sub": sub}, "unused-test-key-0123456789abcdef", algorithm="HS256")
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-
-        with (
-            caplog.at_level(logging.WARNING, logger="core.auth"),
-            patch("core.auth.decode_jwt", return_value={"sub": sub}),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await _authenticate_user(
-                mock_request, credentials, db_session, clerk_settings, source="web",
-            )
-
-        assert exc_info.value.status_code == 401
-        assert any("JIT user creation rejected" in r.message for r in caplog.records)
-
-    async def test__auth0_create_disabled__existing_user_still_authenticates(
-        self,
-        db_session: AsyncSession,
-        redis_client: object,  # noqa: ARG002
-        clerk_settings: Settings,
-        mock_request: Request,
-    ) -> None:
-        """The iOS-during-window scenario: existing Auth0 users keep working."""
-        from core.auth import _authenticate_user  # noqa: PLC0415
-
-        sub = "auth0|existing-ios-user"
-        existing = User(auth0_id=sub, email="ios@test.com")
-        db_session.add(existing)
-        await db_session.flush()
-
-        clerk_settings.auth0_jit_create_enabled = False
-        token = jwt.encode({"iss": TEST_AUTH0_ISSUER, "sub": sub}, "unused-test-key-0123456789abcdef", algorithm="HS256")
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-
-        with patch("core.auth.decode_jwt", return_value={"sub": sub}):
-            user = await _authenticate_user(
-                mock_request, credentials, db_session, clerk_settings, source="ios",
-            )
 
         assert user.id == existing.id
 
@@ -1092,26 +1058,6 @@ class TestJwksUnavailable:
         assert exc_info.value.status_code == 503
         assert exc_info.value.detail == "Could not validate credentials"
 
-    def test__auth0_jwks_connection_failure__503(
-        self,
-        clerk_signing_key: "RSAPrivateKey",
-        clerk_settings: Settings,
-    ) -> None:
-        from core.auth import decode_jwt  # noqa: PLC0415
-
-        broken = self._broken_jwks_client(
-            jwt.PyJWKClientConnectionError("connection refused"),
-        )
-        token = mint_clerk_token(clerk_signing_key, issuer=TEST_AUTH0_ISSUER)
-        with (
-            patch("core.auth.get_jwks_client", return_value=broken),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            decode_jwt(token, clerk_settings)
-
-        assert exc_info.value.status_code == 503
-        assert exc_info.value.detail == "Could not validate credentials"
-
     def test__clerk_unknown_signing_key__401(
         self,
         clerk_signing_key: "RSAPrivateKey",
@@ -1136,31 +1082,11 @@ class TestJwksUnavailable:
         assert exc_info.value.status_code == 401
         assert exc_info.value.detail == "Invalid token"
 
-    def test__auth0_unknown_signing_key__401(
-        self,
-        clerk_signing_key: "RSAPrivateKey",
-        clerk_settings: Settings,
-    ) -> None:
-        from core.auth import decode_jwt  # noqa: PLC0415
-
-        broken = self._broken_jwks_client(
-            jwt.exceptions.PyJWKClientError("Unable to find a signing key"),
-        )
-        token = mint_clerk_token(clerk_signing_key, issuer=TEST_AUTH0_ISSUER)
-        with (
-            patch("core.auth.get_jwks_client", return_value=broken),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            decode_jwt(token, clerk_settings)
-
-        assert exc_info.value.status_code == 401
-        assert exc_info.value.detail == "Invalid token"
-
 
 class TestDeletedIdentityResurrection:
     """
     M8 anti-resurrection guard: tombstoned identities cannot JIT-recreate
-    users, on either provider path, with the explicit deleted-account 401.
+    users, with the explicit deleted-account 401.
     """
 
     async def test__stale_clerk_jwt_after_deletion__explicit_401_no_resurrection(
@@ -1200,19 +1126,19 @@ class TestDeletedIdentityResurrection:
         )
         assert result.scalar_one_or_none() is None
 
-    async def test__live_auth0_token_after_deletion__cannot_recreate_user(
+    async def test__tombstoned_auth0_identity__cannot_recreate_user(
         self,
         db_session: AsyncSession,
         redis_client: object,  # noqa: ARG002
-        clerk_settings: Settings,
-        mock_request: Request,
     ) -> None:
         """
-        The iOS scenario: an Auth0 session outliving a Clerk-side deletion
-        (Auth0 never learns about it; refresh tokens keep it alive) must not
-        resurrect the user through the Auth0 JIT path.
+        The Auth0-side tombstone still guards the auth0_id-keyed resolution
+        (retained until the M6b contract phase drops the column). No token
+        route reaches this since the Auth0 verification arm was removed —
+        an Auth0 token now 401s at issuer dispatch — but the function-level
+        guard must hold as long as the keying exists.
         """
-        from core.auth import _authenticate_user  # noqa: PLC0415
+        from core.auth import DeletedIdentityError, get_or_create_user  # noqa: PLC0415
         from services.user_service import (  # noqa: PLC0415
             delete_user_by_external_auth_id,
         )
@@ -1229,22 +1155,10 @@ class TestDeletedIdentityResurrection:
 
         assert (await delete_user_by_external_auth_id(db_session, clerk_sub)).deleted is True
 
-        token = jwt.encode(
-            {"iss": TEST_AUTH0_ISSUER, "sub": auth0_sub},
-            "unused-test-key-0123456789abcdef",
-            algorithm="HS256",
-        )
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-        with (
-            patch("core.auth.decode_jwt", return_value={"sub": auth0_sub}),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await _authenticate_user(
-                mock_request, credentials, db_session, clerk_settings, source="ios",
-            )
+        with pytest.raises(DeletedIdentityError) as exc_info:
+            await get_or_create_user(db_session, auth0_id=auth0_sub)
 
         assert exc_info.value.status_code == 401
-        assert exc_info.value.detail == "This account was deleted"
         assert exc_info.value.error_code == "account_deleted"
         result = await db_session.execute(
             select(User).where(User.auth0_id == auth0_sub),

--- a/backend/tests/core/test_auth_request_context.py
+++ b/backend/tests/core/test_auth_request_context.py
@@ -34,7 +34,7 @@ def mock_request() -> Request:
 async def test_user(db_session: AsyncSession) -> User:
     """Create a test user for auth tests."""
     user = User(
-        auth0_id="test-auth0-id-context",
+        external_auth_id="user_test_context",
         email="context@test.com",
     )
     db_session.add(user)
@@ -43,17 +43,18 @@ async def test_user(db_session: AsyncSession) -> User:
     return user
 
 
-TEST_AUTH0_ISSUER = "https://test-tenant.auth0.com/"
+TEST_CLERK_FRONTEND_API = "test-instance.clerk.accounts.dev"
+TEST_CLERK_ISSUER = f"https://{TEST_CLERK_FRONTEND_API}"
 
 
-def auth0_dispatch_token(sub: str) -> str:
+def clerk_dispatch_token(sub: str) -> str:
     """
-    Build a JWT whose (unverified) `iss` routes it to the Auth0 verifier.
+    Build a JWT whose (unverified) `iss` routes it to the Clerk verifier.
 
-    Signature is irrelevant: these tests patch decode_jwt, so only the
+    Signature is irrelevant: these tests patch decode_clerk_jwt, so only the
     dispatch peek reads this token.
     """
-    return jwt.encode({"iss": TEST_AUTH0_ISSUER, "sub": sub}, "unused-test-key-0123456789abcdef", algorithm="HS256")
+    return jwt.encode({"iss": TEST_CLERK_ISSUER, "sub": sub}, "unused-test-key-0123456789abcdef", algorithm="HS256")
 
 
 @pytest.fixture
@@ -63,9 +64,9 @@ def mock_settings_no_dev_mode() -> "Settings":
     settings.dev_mode = False
     settings.frontend_url = "http://localhost:5173"
     settings.api_url = "http://localhost:8000"
-    settings.auth0_issuer = TEST_AUTH0_ISSUER
-    settings.auth0_jit_create_enabled = True
-    settings.clerk_frontend_api = ""
+    settings.clerk_frontend_api = TEST_CLERK_FRONTEND_API
+    settings.clerk_issuer = TEST_CLERK_ISSUER
+    settings.clerk_jit_create_enabled = True
     return settings
 
 
@@ -139,26 +140,26 @@ class TestGetRequestSource:
         assert len(result) == SOURCE_MAX_LENGTH
 
 
-class TestRequestContextWithAuth0:
-    """Tests for RequestContext being set correctly with Auth0 JWT."""
+class TestRequestContextWithSessionJWT:
+    """Tests for RequestContext being set correctly with a Clerk session JWT."""
 
-    async def test__auth0_jwt__sets_auth_type_session(
+    async def test__session_jwt__sets_auth_type_session(
         self,
         db_session: AsyncSession,
         test_user: User,
         mock_settings_no_dev_mode: "Settings",
         mock_request: Request,
     ) -> None:
-        """Auth0 JWT sets auth_type to SESSION (provider-neutral)."""
+        """A Clerk session JWT sets auth_type to SESSION (provider-neutral)."""
         from core.auth import AuthType, _authenticate_user  # noqa: PLC0415
 
         credentials = HTTPAuthorizationCredentials(
             scheme="Bearer",
-            credentials=auth0_dispatch_token(test_user.auth0_id),
+            credentials=clerk_dispatch_token(test_user.external_auth_id),
         )
 
-        mock_payload = {"sub": test_user.auth0_id, "email": test_user.email}
-        with patch("core.auth.decode_jwt", return_value=mock_payload):
+        mock_payload = {"sub": test_user.external_auth_id, "email": test_user.email}
+        with patch("core.auth.decode_clerk_jwt", return_value=mock_payload):
             await _authenticate_user(
                 mock_request, credentials, db_session, mock_settings_no_dev_mode,
                 source="unknown",
@@ -169,23 +170,23 @@ class TestRequestContextWithAuth0:
         assert context.auth_type == AuthType.SESSION
         assert context.token_prefix is None
 
-    async def test__auth0_jwt__sets_source_from_param(
+    async def test__session_jwt__sets_source_from_param(
         self,
         db_session: AsyncSession,
         test_user: User,
         mock_settings_no_dev_mode: "Settings",
         mock_request: Request,
     ) -> None:
-        """Auth0 JWT records the resolved request source on the context."""
+        """A Clerk session JWT records the resolved request source on the context."""
         from core.auth import AuthType, _authenticate_user  # noqa: PLC0415
 
         credentials = HTTPAuthorizationCredentials(
             scheme="Bearer",
-            credentials=auth0_dispatch_token(test_user.auth0_id),
+            credentials=clerk_dispatch_token(test_user.external_auth_id),
         )
 
-        mock_payload = {"sub": test_user.auth0_id, "email": test_user.email}
-        with patch("core.auth.decode_jwt", return_value=mock_payload):
+        mock_payload = {"sub": test_user.external_auth_id, "email": test_user.email}
+        with patch("core.auth.decode_clerk_jwt", return_value=mock_payload):
             await _authenticate_user(
                 mock_request, credentials, db_session, mock_settings_no_dev_mode,
                 source="web",

--- a/backend/tests/core/test_auth_session_only.py
+++ b/backend/tests/core/test_auth_session_only.py
@@ -30,7 +30,7 @@ def mock_request() -> Request:
 async def test_user(db_session: AsyncSession) -> User:
     """Create a test user for auth tests."""
     user = User(
-        auth0_id="test-auth0-id-auth",
+        external_auth_id="user_test_auth",
         email="auth@test.com",
         tier=Tier.FREE.value,
     )
@@ -44,7 +44,7 @@ async def test_user(db_session: AsyncSession) -> User:
 async def test_user_with_consent(db_session: AsyncSession) -> User:
     """Create a test user with valid consent."""
     user = User(
-        auth0_id="test-auth0-id-auth-consent",
+        external_auth_id="user_test_auth_consent",
         email="authconsent@test.com",
         tier=Tier.FREE.value,
     )
@@ -63,17 +63,18 @@ async def test_user_with_consent(db_session: AsyncSession) -> User:
     return user
 
 
-TEST_AUTH0_ISSUER = "https://test-tenant.auth0.com/"
+TEST_CLERK_FRONTEND_API = "test-instance.clerk.accounts.dev"
+TEST_CLERK_ISSUER = f"https://{TEST_CLERK_FRONTEND_API}"
 
 
-def auth0_dispatch_token(sub: str) -> str:
+def clerk_dispatch_token(sub: str) -> str:
     """
-    Build a JWT whose (unverified) `iss` routes it to the Auth0 verifier.
+    Build a JWT whose (unverified) `iss` routes it to the Clerk verifier.
 
-    Signature is irrelevant: these tests patch decode_jwt, so only the
+    Signature is irrelevant: these tests patch decode_clerk_jwt, so only the
     dispatch peek reads this token.
     """
-    return jwt.encode({"iss": TEST_AUTH0_ISSUER, "sub": sub}, "unused-test-key-0123456789abcdef", algorithm="HS256")
+    return jwt.encode({"iss": TEST_CLERK_ISSUER, "sub": sub}, "unused-test-key-0123456789abcdef", algorithm="HS256")
 
 
 @pytest.fixture
@@ -83,10 +84,9 @@ def mock_settings_no_dev_mode() -> Settings:
     settings.dev_mode = False
     settings.frontend_url = "http://localhost:5173"
     settings.api_url = "http://localhost:8000"
-    settings.auth0_custom_claim_namespace = "https://test.example.com"
-    settings.auth0_issuer = TEST_AUTH0_ISSUER
-    settings.auth0_jit_create_enabled = True
-    settings.clerk_frontend_api = ""
+    settings.clerk_frontend_api = TEST_CLERK_FRONTEND_API
+    settings.clerk_issuer = TEST_CLERK_ISSUER
+    settings.clerk_jit_create_enabled = True
     return settings
 
 
@@ -153,7 +153,7 @@ class TestAuthenticateUserAllowPat:
         assert "not available for API tokens" in exc_info.value.detail
         assert "web interface" in exc_info.value.detail
 
-    async def test__allow_pat_false__accepts_auth0_jwt(
+    async def test__allow_pat_false__accepts_session_jwt(
         self,
         db_session: AsyncSession,
         test_user: User,
@@ -161,7 +161,7 @@ class TestAuthenticateUserAllowPat:
         mock_request: Request,
     ) -> None:
         """
-        When allow_pat=False, Auth0 JWTs are still accepted.
+        When allow_pat=False, Clerk session JWTs are still accepted.
 
         The Clerk OAuth (at+jwt) twin of this policy test lives in
         test_auth_clerk.py::TestClerkOAuthAccessTokens — it needs that
@@ -171,18 +171,18 @@ class TestAuthenticateUserAllowPat:
 
         credentials = HTTPAuthorizationCredentials(
             scheme="Bearer",
-            credentials=auth0_dispatch_token(test_user.auth0_id),
+            credentials=clerk_dispatch_token(test_user.external_auth_id),
         )
 
-        # Mock decode_jwt to return valid payload
-        mock_payload = {"sub": test_user.auth0_id, "email": test_user.email}
-        with patch("core.auth.decode_jwt", return_value=mock_payload):
+        # Mock decode_clerk_jwt to return valid payload
+        mock_payload = {"sub": test_user.external_auth_id, "email": test_user.email}
+        with patch("core.auth.decode_clerk_jwt", return_value=mock_payload):
             result = await _authenticate_user(
                 mock_request, credentials, db_session, mock_settings_no_dev_mode,
                 source="unknown", allow_pat=False,
             )
 
-        assert result.auth0_id == test_user.auth0_id
+        assert result.external_auth_id == test_user.external_auth_id
 
     async def test__allow_pat_false__dev_mode_bypasses_check(
         self,
@@ -255,26 +255,26 @@ class TestGetCurrentUserSessionOnly:
 
         assert exc_info.value.status_code == 403
 
-    async def test__with_auth0_jwt_and_valid_consent__returns_user(
+    async def test__with_session_jwt_and_valid_consent__returns_user(
         self,
         db_session: AsyncSession,
         test_user_with_consent: User,
         mock_settings_no_dev_mode: Settings,
         mock_request: Request,
     ) -> None:
-        """Auth0 JWT with valid consent returns user successfully."""
+        """A Clerk session JWT with valid consent returns user successfully."""
         from core.auth import _authenticate_user, _check_consent  # noqa: PLC0415
 
         credentials = HTTPAuthorizationCredentials(
             scheme="Bearer",
-            credentials=auth0_dispatch_token(test_user_with_consent.auth0_id),
+            credentials=clerk_dispatch_token(test_user_with_consent.external_auth_id),
         )
 
         mock_payload = {
-            "sub": test_user_with_consent.auth0_id,
+            "sub": test_user_with_consent.external_auth_id,
             "email": test_user_with_consent.email,
         }
-        with patch("core.auth.decode_jwt", return_value=mock_payload):
+        with patch("core.auth.decode_clerk_jwt", return_value=mock_payload):
             user = await _authenticate_user(
                 mock_request, credentials, db_session, mock_settings_no_dev_mode,
                 source="unknown", allow_pat=False,
@@ -289,23 +289,23 @@ class TestGetCurrentUserSessionOnly:
         # Should not raise - valid consent
         _check_consent(user_with_consent, mock_settings_no_dev_mode)
 
-    async def test__with_auth0_jwt_no_consent__returns_451(
+    async def test__with_session_jwt_no_consent__returns_451(
         self,
         db_session: AsyncSession,
         test_user: User,
         mock_settings_no_dev_mode: Settings,
         mock_request: Request,
     ) -> None:
-        """Auth0 JWT without consent returns 451."""
+        """A Clerk session JWT without consent returns 451."""
         from core.auth import _authenticate_user, _check_consent  # noqa: PLC0415
 
         credentials = HTTPAuthorizationCredentials(
             scheme="Bearer",
-            credentials=auth0_dispatch_token(test_user.auth0_id),
+            credentials=clerk_dispatch_token(test_user.external_auth_id),
         )
 
-        mock_payload = {"sub": test_user.auth0_id, "email": test_user.email}
-        with patch("core.auth.decode_jwt", return_value=mock_payload):
+        mock_payload = {"sub": test_user.external_auth_id, "email": test_user.email}
+        with patch("core.auth.decode_clerk_jwt", return_value=mock_payload):
             user = await _authenticate_user(
                 mock_request, credentials, db_session, mock_settings_no_dev_mode,
                 source="unknown", allow_pat=False,
@@ -345,23 +345,23 @@ class TestGetCurrentUserSessionOnlyWithoutConsent:
 
         assert exc_info.value.status_code == 403
 
-    async def test__with_auth0_jwt_no_consent__returns_user(
+    async def test__with_session_jwt_no_consent__returns_user(
         self,
         db_session: AsyncSession,
         test_user: User,
         mock_settings_no_dev_mode: Settings,
         mock_request: Request,
     ) -> None:
-        """Auth0 JWT without consent still returns user (no consent check)."""
+        """A Clerk session JWT without consent still returns user (no consent check)."""
         from core.auth import _authenticate_user  # noqa: PLC0415
 
         credentials = HTTPAuthorizationCredentials(
             scheme="Bearer",
-            credentials=auth0_dispatch_token(test_user.auth0_id),
+            credentials=clerk_dispatch_token(test_user.external_auth_id),
         )
 
-        mock_payload = {"sub": test_user.auth0_id, "email": test_user.email}
-        with patch("core.auth.decode_jwt", return_value=mock_payload):
+        mock_payload = {"sub": test_user.external_auth_id, "email": test_user.email}
+        with patch("core.auth.decode_clerk_jwt", return_value=mock_payload):
             # This simulates get_current_user_session_only_without_consent
             # which calls _authenticate_user with allow_pat=False but no consent check
             user = await _authenticate_user(
@@ -370,7 +370,7 @@ class TestGetCurrentUserSessionOnlyWithoutConsent:
             )
 
         # Should succeed even without consent
-        assert user.auth0_id == test_user.auth0_id
+        assert user.external_auth_id == test_user.external_auth_id
 
 
 class TestErrorMessages:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,6 @@ flowchart LR
     end
 
     subgraph ExternalDeps["External dependencies"]
-        Auth0[(Auth0)]
         Clerk[(Clerk)]
         LLMs[(OpenAI / Gemini / Anthropic)]
         Scrape[External URLs\nSSRF-protected scraping]
@@ -75,8 +74,7 @@ flowchart LR
     %% API fan-out
     API -->|"async SQLAlchemy"| Postgres
     API -->|"rate limits / auth cache /\nAI cost buckets"| Redis
-    API -->|"JWKS for JWT verify\n(Clerk primary)"| Clerk
-    API -->|"JWKS for legacy\nAuth0 sessions"| Auth0
+    API -->|"JWKS for JWT verify"| Clerk
     API -->|"LiteLLM"| LLMs
     API -->|"metadata fetch"| Scrape
 
@@ -169,8 +167,8 @@ Each cron runs as its own Railway service with its own schedule and failure mode
 
 ### External dependencies
 
-- **Auth0** — legacy JWT verifier only, during the dual-accept window (RS256, custom email claim namespace `https://tiddly.me`): web login moved to Clerk at the M6a cutover (2026-07-15), so Auth0 now exists solely so the backend can honor lingering Auth0 sessions (chiefly the iOS app) until M6b decommissions it.
-- **Clerk** — the primary IdP as of the M6a cutover (2026-07-15): web login, CLI OAuth (M4), and MCP OAuth connectors (M5) all authenticate against Clerk; the backend dual-accepts Auth0 tokens by issuer until M6b (see §5). Also the one inbound provider-calls-us surface: Clerk delivers `user.deleted` webhooks (Svix-signed) to `POST /webhooks/clerk` for account deletion (see §5).
+- **Auth0** — **no longer an authentication path**: the backend stopped verifying Auth0 tokens at the M6b expand deploy (2026-07-31); an Auth0-issued token now gets the generic unknown-issuer 401. The tenants, `users.auth0_id` column, Settings fields, and env vars are temporarily retained as rollback/staging surfaces only, and are deleted by the M6b contract/cleanup phases (see the decommission run sheet).
+- **Clerk** — the sole IdP: web login, CLI OAuth (M4), MCP OAuth connectors (M5), and the Chrome extension's session sync (M7) all authenticate against Clerk; the backend accepts Clerk-issued JWTs only (see §5). Also the one inbound provider-calls-us surface: Clerk delivers `user.deleted` webhooks (Svix-signed) to `POST /webhooks/clerk` for account deletion (see §5).
 - **OpenAI / Google Gemini / Anthropic** — LLM providers accessed via LiteLLM. Only `OPENAI_API_KEY` is required today (platform default for suggestions is `openai/gpt-5.4-nano`). Gemini/Anthropic keys are optional until more AI use cases ship.
 - **External URLs** — the api scrapes target URLs for bookmark metadata (`services/url_scraper.py`), wrapped in SSRF protection (see §10).
 
@@ -253,11 +251,10 @@ Relationships are bidirectional with canonical ordering (no duplicate "A → B" 
 
 **Two authentication mechanisms** converge in `core/auth.py`:
 
-1. **IdP-issued JWTs (dual-accept — Auth0 → Clerk migration window).** The token's `iss` claim is read *unverified for dispatch only* and routes to the matching verifier; the selected verifier then enforces signature (RS256 against that issuer's cached JWKS, 1-hour TTL), issuer, expiry, and per-issuer claims from scratch. Both paths resolve to the same `users` rows:
-   - **Auth0**: verifies audience + issuer; `auth0_id` (= `sub`), `email`, `email_verified` read with custom email claims under the `AUTH0_CUSTOM_CLAIM_NAMESPACE` prefix (Auth0 Post-Login Action — see README_DEPLOY.md Step 6d). Looks up/creates users by `users.auth0_id`. Every Auth0-path authentication logs `auth0_path_authentication source=<client>` — the cutover signal watched during M6a→M6b. **Removed at decommission (M6b).**
-   - **Clerk**: one verifier, two token kinds, discriminated by the signature-covered JWT header `typ` (see `decode_clerk_jwt`). *Session tokens* (`typ: JWT`, ~60s lifetime): no audience claim exists; the equivalent check is `azp` (authorized party) against `CLERK_AUTHORIZED_PARTIES` — present → must match, absent → tolerated (non-browser tokens carry none); plain `email`/`email_verified` claims (instance session-token customization). *OAuth access tokens* (`typ: at+jwt` per RFC 9068, 24h lifetime — the CLI's tokens, and MCP's later): same issuer and JWKS; `client_id` must be present (logged, deliberately not allowlisted — rationale in code); no email claims (null-email-tolerant resolution). The azp rule applies to both kinds. Verified with an explicit 5s clock-skew leeway. Both kinds look up/create users by `users.external_auth_id` (= `sub`).
-   - **Per-issuer JIT-create flags** (`CLERK_JIT_CREATE_ENABLED`, default off; `AUTH0_JIT_CREATE_ENABLED`, default on): lookup always works; *creation* of a first-seen identity is gated per issuer. A denied create is a generic 401 plus a warning log naming the identity — the backend-enforced version of the migration window rules (no pre-import Clerk accounts, no post-flip Auth0 accounts). Removed in M6b.
-   - **Anti-resurrection tombstones** (M8): before any JIT create, the identity is checked against `deleted_identities` — a still-valid token for a deleted account (a not-yet-expired Clerk JWT, or an Auth0 session kept alive by refresh tokens on iOS) must not re-create an empty user row. A tombstoned identity gets an explicit `401` carrying `error_code: "account_deleted"` (with a human-readable `detail: "This account was deleted"`) — a recorded exception to the generic-401 policy: only a holder of a validly-signed token for that identity can see it. Clients bind to the stable `error_code`, not the prose, to show a terminal state instead of a re-auth loop. Tombstones block dead credentials, not people — providers never reuse `sub` values, so a returning user signs up as a brand-new identity.
+1. **IdP-issued JWTs — Clerk is the sole accepted issuer** (the migration's dual-accept window closed at the M6b expand deploy, 2026-07-31). The token's `iss` claim is read *unverified for dispatch only*; a Clerk issuer routes to the Clerk verifier, which then enforces signature (RS256 against the instance's cached JWKS, 1-hour TTL), issuer, expiry, and claims from scratch. **Any other issuer — including a still-valid token from the old Auth0 tenant — gets the generic 401** with a warning log naming the unknown issuer.
+   - **Clerk**: one verifier, two token kinds, discriminated by the signature-covered JWT header `typ` (see `decode_clerk_jwt`). *Session tokens* (`typ: JWT`, ~60s lifetime): no audience claim exists; the equivalent check is `azp` (authorized party) against `CLERK_AUTHORIZED_PARTIES` — present → must match, absent → tolerated (non-browser tokens carry none); plain `email`/`email_verified` claims (instance session-token customization). *OAuth access tokens* (`typ: at+jwt` per RFC 9068, 24h lifetime — the CLI's and MCP connectors' tokens): same issuer and JWKS; `client_id` must be present (logged, deliberately not allowlisted — rationale in code); no email claims (null-email-tolerant resolution). The azp rule applies to both kinds. Verified with an explicit 5s clock-skew leeway. Both kinds look up/create users by `users.external_auth_id` (= `sub`).
+   - **JIT-create flag** (`CLERK_JIT_CREATE_ENABLED`, default off; enabled in production since the M6a cutover): lookup always works; *creation* of a first-seen identity is gated. A denied create is a generic 401 plus a warning log naming the identity. (`AUTH0_JIT_CREATE_ENABLED` still exists as a Settings field but gates nothing — the Auth0 path it gated is gone; the field is removed in the M6b cleanup phase.)
+   - **Anti-resurrection tombstones** (M8): before any JIT create, the identity is checked against `deleted_identities` — a still-valid token for a deleted account (a not-yet-expired Clerk JWT; during the migration window, also an Auth0 session kept alive by refresh tokens on iOS) must not re-create an empty user row. A tombstoned identity gets an explicit `401` carrying `error_code: "account_deleted"` (with a human-readable `detail: "This account was deleted"`) — a recorded exception to the generic-401 policy: only a holder of a validly-signed token for that identity can see it. Clients bind to the stable `error_code`, not the prose, to show a terminal state instead of a re-auth loop. Tombstones block dead credentials, not people — providers never reuse `sub` values, so a returning user signs up as a brand-new identity.
    - A non-PAT bearer that isn't parseable as a JWT at all → generic 401 plus a warning log naming the cause (the observable symptom of an OAuth app misconfigured to issue opaque tokens).
 2. **Personal Access Tokens (PAT)** for CLI, MCP servers, Chrome extension, and scripts. Format: `bm_<random>`. Validated by `TokenService` against `api_tokens.token_hash` (SHA-256). A 12-char plaintext `token_prefix` is stored for UI display and audit. Untouched by the migration (AD1).
 
@@ -270,7 +267,7 @@ Relationships are bidirectional with canonical ordering (no duplicate "A → B" 
 5. Enforce **consent**: authenticated routes (except the consent endpoints themselves and `/health`) check that the user has accepted current privacy-policy and terms versions. Mismatch returns HTTP 451 with instructions; the frontend opens a consent dialog. Skipped in `DEV_MODE`. The consent-accept flow invalidates **every** cache segment the user can be cached under (`id`, `auth0`, `ext`).
 6. Apply the matching **rate limit** bucket (see §6).
 
-**Identity columns during the window**: `users.auth0_id` and `users.external_auth_id` are both nullable-unique; the DB CHECK constraint `ck_user_has_identity` guarantees at least one is present. M6b drops `auth0_id` + the constraint and makes `external_auth_id` NOT NULL.
+**Identity columns (staged decommission)**: `users.auth0_id` and `users.external_auth_id` are both nullable-unique; the DB CHECK constraint `ck_user_has_identity` guarantees at least one is present. `auth0_id` no longer participates in token authentication (the Auth0 verification path is gone); it is retained as rollback/staging structure until the M6b contract phase drops it + the constraint and makes `external_auth_id` NOT NULL.
 
 **DEV_MODE bypass**: set `VITE_DEV_MODE=true` locally. Creates a synthetic user (`auth0_id="dev|local-development-user"`) without any auth header and is exempt from the JIT-create gates. Settings validation refuses to let DEV_MODE coexist with a non-local database as a safety guard.
 


### PR DESCRIPTION
First stage (expand) of the Auth0 decommission, per the staged run sheet ([2026-07-14-m6b-decommission-runsheet.md](https://github.com/shane-kercheval/tiddly/blob/main/docs/implementation_plans/2026-07-14-m6b-decommission-runsheet.md), governing the decommission half of the [Auth0 → Clerk migration plan](https://github.com/shane-kercheval/tiddly/blob/main/docs/implementation_plans/2026-07-02-clerk-migration.md)).

**What changes:** the backend's Auth0 JWT verifier and the Auth0 arm of the issuer dispatch are removed — a token from any issuer other than Clerk (including a still-valid Auth0 token) now gets the generic unknown-issuer 401. A new invariant test proves rejection happens at dispatch with the verifier boundary never invoked (mutation-tested: restoring the Auth0 arm fails it even when the restored branch mimics the 401 exactly).

**What deliberately does NOT change (rollback surfaces, removed in later staged deploys):** the `users.auth0_id` column and its lookup keying, the Auth0 Settings fields/validators, cache segments, env vars, and the Auth0 tenants. This deploy is cleanly revertible; the schema migration (drop `auth0_id`, `SET NOT NULL` on `external_auth_id`) ships separately after a production observation window, staged so no rolling-deploy instance ever references a dropped column.

**Gate evidence (window closed):** cohort of two iOS users + one CLI user directly confirmed on Clerk on every device; newest Auth0 tenant `last_login` is 2026-07-16 (pre-dating the Clerk iOS build); zero Auth0 identities created since the cutover; all 13 production users Clerk-linked (zero `external_auth_id IS NULL`).

Docs/comments describing dual-accept as live are updated to Clerk-only in the same change, so the repo is truthful at the deploy boundary; retained structures are documented as rollback/staging machinery. Reviewed in two rounds by three agents; `make backend-verify` green (3,518 passed).

**Merge note:** merging deploys this to production. Pre-merge operator steps (fresh DB snapshot + final Auth0 export) come first — do not merge until those are recorded.