### PR TITLE
Persist reading mode, add table of contents to reading and public views, and support callouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,21 @@ PYTHONPATH=backend/src uv run pytest backend/tests/path/to/test_file.py::test_na
 cd frontend && npx vitest run src/path/to/file.test.ts
 ```
 
+**Dev environment in a fresh checkout/worktree:** secondary checkouts start bare — before dev servers will run you likely need: (1) `.env` at the repo root — copy it from the primary checkout (`~/repos/bookmarks/.env`); it's gitignored and holds local config including `CORS_ORIGINS`. (2) `cd frontend && npm ci`. (3) Postgres + Redis via `make docker-up` — but check `docker ps` first: the containers are shared per-machine, so the primary checkout's instances (ports 5435/6379) serve every checkout and are usually already running. The Python venv creates itself on first `uv run`/`make api-run`.
+
+**One API, one frontend per port — and CORS is read at startup:** only one API can hold port 8000; an instance from another checkout serves fine when your branch has no backend changes. But `CORS_ORIGINS` is read once at startup (`--reload` watches code, not `.env`) — if the frontend runs on a port the running API predates (e.g. a worktree's frontend on 5174), API calls fail as axios "Network Error" despite a healthy `/health`. Fix: ensure the port is in `CORS_ORIGINS`, then restart the API.
+
+**Leaving dev servers running for the user (agents):** any process an agent launches through its shell — including "background" tool modes — is killed when the agent's session ends. If the user needs a server still running after you're done (e.g. for manual testing), launch it **detached** with output to a log file:
+
+```bash
+# Frontend (pin the port — another checkout's dev server may hold 5173)
+cd frontend && nohup npm run dev -- --port 5174 --strictPort > /tmp/tiddly-frontend.log 2>&1 & disown
+# Backend API
+nohup make api-run > /tmp/tiddly-api.log 2>&1 & disown
+```
+
+Then verify it responds (`curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/`) before handing the user a URL, and tell them the actual port, the log path, and how to stop it (`kill $(lsof -t -iTCP:<port>)`). Check first whether a server is already up — port 8000 or 5173 already listening usually means another checkout's instance is running and may serve fine (the API does, when the branch has no backend changes).
+
 ## Architecture
 
 ### Backend (`backend/src/`)

--- a/docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md
+++ b/docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md
@@ -212,6 +212,13 @@ The CodeMirror styling layer (`utils/markdownStyleExtension.ts`) approximates ma
 - **Lazy continuation** (a `>`-less line continuing a quote): part of the callout in rendered views, unstyled in the editor.
 - **Nested-blockquote callouts** (`> > [!tip]`): honored only by the docs pipeline (its visitor is recursive); the editor and reading view treat them as plain quotes.
 
+### Public share pages: chrome does not adapt to the sidebar-reduced width
+
+When the ToC opens, the whole public page box shrinks (header, content, footer together). Two width limitations follow, both pending a real-browser check at 768/879/880/1920-maximized, logged out:
+
+- **The 600px content reserve holds only from ~880px viewport up.** `computeMaxWidth` reserves `MIN_CONTENT_WIDTH` but floors the sidebar at `MIN_SIDEBAR_WIDTH` (280px), so between the 768px desktop breakpoint and 880px the content column is 488–599px. The authenticated app shares this squeeze (its editor content narrows the same way — to 440px at 768px with a collapsed left sidebar, 200px expanded), so this is a property of the shared sidebar geometry, not of this work.
+- **`PublicHeader`/`Footer` still lay out for the viewport, not their box.** Their `sm:`/`md:` breakpoints are media queries, so at a wide viewport with a maximized sidebar they render desktop arrangements inside a ~600px box. Unlike the point above this IS specific to these pages — the app never renders its footer inside a sidebar-margined layout, and doesn't use `PublicHeader` at all. Container queries on the chrome are the durable fix; a narrow-band overlay guard would address only the 768–879px case, not the maximized one.
+
 **Follow-up (deliberately not in this work):** incremental line-parser improvements — tilde-fence tracking and up-to-3-space quote/construct indentation — would narrow the gap for every construct, short of a full syntax-tree-based restyle of the extension (a separate project, if ever). Cross-pipeline tests are scoped accordingly: they pin parity for contiguous explicitly-quoted lines only.
 
 ## Cross-cutting notes

--- a/docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md
+++ b/docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md
@@ -150,7 +150,7 @@ Blockquote-style callouts render with an icon, tinted left rule, and (in rendere
   | CAUTION | caution, danger, error, bug, failure | red | stop octagon |
 
 - Unrecognized keywords (`> [!FOO]`) render as a plain blockquote — fail soft, never break rendering.
-- Callouts render consistently in **all three pipelines**: the CodeMirror editor (line-decoration styling, marker text stays visible and editable), the reading-mode rendered view (marker restyled as a title with icon), and the docs prose pipeline.
+- Callouts render in **all three pipelines**: the CodeMirror editor (line-decoration styling, marker text stays visible and editable), the reading-mode rendered view (marker restyled as a title with icon), and the docs prose pipeline. What is shared — and cannot drift — is the marker **grammar and variant resolution** (one module, three consumers), plus the structural rule that a marker is honored only on a blockquote's opening line. Host markdown **block recognition** remains consumer-specific: the editor uses its long-standing line-based approximation, the other two use real markdown ASTs (see the recorded limitation below).
 - **The docs pipeline keeps its existing three visual styles** (info/tip/warning). It already renders callouts today via its own remark plugin with a narrower grammar (`!` required, three-way alias collapse); this milestone unifies the *grammar* (what parses as a callout, and which canonical variant it is) while mapping the five canonical variants onto the docs' three existing styles — so no shipped docs page changes appearance. Expanding docs to the five-style palette is a decoupled, deliberately deferred visual decision. Grammar unification slightly broadens what docs accepts (optional `!`, more aliases, inline titles); docs content is curated, so this is harmless.
 
 ### Implementation Outline
@@ -202,6 +202,17 @@ Three independent rendering pipelines must agree on what counts as a callout, so
 Genuinely small. `components/markdown/remarkCallouts.ts` replaces its private marker regex and three-way alias table with the 3a module (marker-core + canonical resolution), keeping everything else it does today: its mdast surgery (marker stripping, class tagging) and a local five-canonical → three-docs-styles mapping onto the existing `CalloutVariant` type (`note/info/information/important` → info, `tip/hint/success/check/done` → tip, `warning/attention/caution/danger/error/bug/failure` → warning). Record in its docstring that the grammar is shared and the 3-style collapse is a deliberate docs presentation choice. Done = existing docs markdown tests stay green (no visual change to shipped pages); new spot-checks through the remark path for the broadened grammar (`[!danger]` → docs warning, optional-`!` accepted); `frontend-verify` passes.
 
 ---
+
+## Recorded limitation & follow-up — editor line-model vs. AST block recognition
+
+The CodeMirror styling layer (`utils/markdownStyleExtension.ts`) approximates markdown block structure per line, by long-standing design — this predates callouts and applies to every construct it styles. Callouts are deliberately exactly as approximate as the blockquote styling they extend (making them alone tree-accurate would put callout tinting on lines the editor doesn't even style as quotes). Residual editor/rendered-view differences, all pre-existing line-model limits:
+
+- **Indented blockquotes** (`  > quote`): styled by the rendered views, unstyled (and so un-callouted) in the editor.
+- **Tilde fences** (`~~~`): not recognized as code by the styling layer, so a marker inside one is styled in the editor but rendered as code.
+- **Lazy continuation** (a `>`-less line continuing a quote): part of the callout in rendered views, unstyled in the editor.
+- **Nested-blockquote callouts** (`> > [!tip]`): honored only by the docs pipeline (its visitor is recursive); the editor and reading view treat them as plain quotes.
+
+**Follow-up (deliberately not in this work):** incremental line-parser improvements — tilde-fence tracking and up-to-3-space quote/construct indentation — would narrow the gap for every construct, short of a full syntax-tree-based restyle of the extension (a separate project, if ever). Cross-pipeline tests are scoped accordingly: they pin parity for contiguous explicitly-quoted lines only.
 
 ## Cross-cutting notes
 

--- a/docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md
+++ b/docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md
@@ -1,0 +1,210 @@
+# Editor improvements: reading-mode persistence, ToC in reading mode, callout syntax
+
+Three related improvements to the markdown editor, shipped as one PR:
+
+1. **Reading-mode persistence** — reading mode currently resets to raw markdown on page refresh and on every editor remount triggered by a server sync (conflict refresh, version restore, draft restore, bookmark metadata fetch). It should be remembered per item.
+2. **Table of Contents in reading mode** — the ToC toolbar button and shortcut are hidden while reading mode is on, even though a ToC is equally applicable there. Also: add the ToC to the public shared note and prompt views, which currently have no sidebar support. Bookmarks are deliberately excluded from ToC everywhere (rationale in Milestone 2c).
+3. **Callout syntax** — support GitHub-style alerts (`> [!WARNING]` etc.) and common variations in the CodeMirror editor, the rendered reading view, and the docs prose pipeline (which already has a narrower callout implementation that this work generalizes rather than duplicates).
+
+All three land in the same subsystem: `ContentEditor` → `CodeMirrorEditor` and the read-only Milkdown preview it hosts in reading mode. Milestones are ordered by dependency: persistence first (it makes reading-mode features testable without the mode resetting underneath you), then ToC, then callouts (independent of the other two, largest diff).
+
+**Required reading before implementing** (beyond the code itself):
+
+- GitHub alerts syntax: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
+- Obsidian callouts (the `[!note] Custom title` variant we also accept): https://help.obsidian.md/callouts
+- CodeMirror 6 decorations: https://codemirror.net/docs/ref/#view.Decoration
+- ProseMirror decorations (Milkdown plugins are thin wrappers over these): https://prosemirror.net/docs/ref/#view.Decorations
+- mdast (the AST both remark and Milkdown's parser produce; Milestone 3a's shared parser serves an mdast consumer): https://github.com/syntax-tree/mdast
+
+Rationale recorded in this plan for non-obvious decisions must survive into code comments — several existing comments in these files (e.g. the `contentKey` remount notes in `Note.tsx`, the semi-controlled-value note in `CodeMirrorEditor.tsx`) are load-bearing precisely because past decisions were written down at the point of use. Follow that convention.
+
+---
+
+## Milestone 1 — Reading mode survives refresh and server syncs
+
+### Goal & Outcome
+
+Reading mode becomes a remembered, per-item setting instead of transient component state that silently resets.
+
+- Toggling reading mode on a note/bookmark/prompt is remembered for that item: refreshing the page, navigating away and back, or any server-sync remount (conflict resolution, "Load Latest Version", version restore, draft restore, bookmark content fetch) reopens the item in the mode it was left in.
+- This includes items whose reading mode was toggled *while being created*: create → toggle reading on → save → refresh restores reading mode.
+- An item never toggled opens in markdown (source) mode — the current default.
+- Creating a new item always opens in markdown mode with a usable editor (never a blank read-only preview).
+- Public shared views are unaffected: they keep opening in reading mode (notes/bookmarks) or raw source (prompts), and a visitor toggling the mode there does not perturb the remembered modes of their own account's items.
+
+### Implementation Outline
+
+**Root cause.** `readingMode` is plain `useState` local to `CodeMirrorEditor` (commented "local, not persisted"). Nothing writes it anywhere (refresh loses it), and the parent components remount the whole editor subtree by bumping `contentKey` — the React `key` on `<ContentEditor>` — whenever server content replaces local content, which re-seeds the state from `defaultReadingMode` (false in the app views).
+
+**Chosen approach: a per-item LRU map in localStorage.** Alternatives considered and rejected:
+
+- *Global preference* (like the existing wrap/line-numbers/mono-font preferences): rejected because one item's mode would leak to all items, including opening the create view as a blank read-only preview, and would regress prompts, which deliberately default to raw source.
+- *Small LRU (~10 entries)*: rejected because an eviction here is a visible behavior change ("this note used to open rendered") with an invisible cause. The cap exists as a runaway guard, not a UX mechanism, so it should be large enough that eviction effectively never fires in normal use.
+
+Decisions, all deliberate:
+
+- **Storage**: one localStorage entry holding a map of item ID → entry, capped at **100** entries, least-recently-*used* evicted on overflow. Both a successful read (at editor initialization) and a write refresh an entry's recency — read-refresh matters because an item the user *opens* in reading mode daily but toggled only once must not age out. **Only `readingMode = true` is stored**: toggling an item back to markdown deletes its entry (markdown is the miss-default, so a `false` entry carries no information), which means the cap bounds only meaningful overrides. Follow the key-naming and try/catch-on-storage-errors conventions established by `utils/drafts.ts` and the preference loaders in `ContentEditor.tsx`.
+- **Lookup contract**: cache hit → reading mode. Cache miss → markdown mode. No per-type fallback logic; this was explicitly simplified away in design discussion (markdown-on-miss is already what prompts want).
+- **Create mode needs no special *seed* case**: a new item has no ID → no cache entry → markdown mode. Do not add one.
+- **Create mode does need a *write* case**: if the user toggles reading mode while creating and then saves, the toggle happened before an ID existed, and the create→edit transition deliberately does not remount the editor — so without explicit handling the mode is never written and a later refresh loses it. Handle exactly the `undefined → ID` transition (previous-ID ref local to the editor), but the transition alone is **not sufficient**: navigating from the create view to an *existing* item also delivers an ID in place — the old instance renders once with that item's ID before the parent's corrective `contentKey` remount — and writing on it would poison the existing item's remembered mode with the draft's toggle state (caught in code review). The write therefore additionally requires an explicit create-provenance assertion passed down as a *behavioral* prop (`itemIdWasJustCreated`), which Note/Prompt derive from their existing `fromCreate` contract; the low-level editor must not receive router semantics directly nor infer provenance itself. Record this in a comment at the site.
+- **Accepted limitation — bookmark create-toggles are not persisted**: bookmarks have no in-place create→edit transition (create-saves navigate away, and the bookmark editor's key includes the ID, forcing a remount), so they never assert the create signal and a reading-mode toggle made *while creating* a bookmark is lost on save. Accepted: the trigger is narrow (the content editor sits behind a collapsed-by-default panel and is usually auto-scraped, not composed pre-save) and it self-heals on the first toggle after save. Recorded at the Bookmark call site; threading the toggle through the create mutation was considered and rejected as permanent plumbing for a one-time, self-correcting papercut.
+- **The reading-mode toggle must reject `disabled` centrally**: the toggle writes durable state, and on a disabled (deleted-item) view `effectiveReadingMode` masks the flip visually — so an unguarded keyboard shortcut would silently mutate the persisted preference. Guard inside the toggle *and* have the capture-phase case decline to consume the event when disabled (matching the file's matcher/handler-symmetry pattern). Do **not** also gate on `readOnly`: toggling on a public-share view is a deliberate visitor feature.
+- **Plumbing**: pass the item ID into `ContentEditor` → `CodeMirrorEditor` as an ordinary prop. The warnings in `Note.tsx`/`Prompt.tsx` against using the item ID apply **only** to the React `key` (remount behavior); a plain prop is fine. Seed the reading-mode state from the cache **at state initialization**, not as a live effect — a live override would flip the mode mid-session on the create→edit transition. Because every path that needs the mode re-derived (document switch, server sync) already remounts via `contentKey`, initializer-time seeding plus the transition write above is sufficient. Record this reasoning in a comment at the seed site.
+- **Public/reader view isolation**: when `readerMode` is true, neither read from nor write to the cache. Seed from `defaultReadingMode` exactly as today. This preserves the existing split — notes/bookmarks pass `defaultReadingMode={readOnly}`, prompts intentionally omit it so shared templates open as raw source (Jinja syntax is the point of a template; the CodeMirror view has dedicated Jinja highlighting that the rendered view discards). Do not "fix" the prompt inconsistency.
+- **Account deletion**: the cache module exports its own clear function, and `AuthProvider.tsx` invokes it as a new discrete `safe('clear-reading-mode-cache', …)` step alongside the existing `clear-drafts` / `clear-byok-keys` steps. Do **not** extend `clearAllDrafts()` — it is prefix-scoped to draft keys and this cache is not a draft.
+
+Whether the mode state continues to live in `CodeMirrorEditor` or moves up to `ContentEditor` alongside the other persisted preferences is the implementer's call after reading the code — the contract above (per-item seed at init, write-through on toggle, the `undefined → ID` transition write, reader-mode isolation) is what matters.
+
+### Definition of Done
+
+- Unit tests for the LRU module: hit/miss; **read refreshes recency** — the decisive sequence is: fill the cache with item A plus 99 others, read A, insert one new entry → A survives and the oldest *untouched* entry is evicted (note: "read A, then insert 100 more" would correctly evict A — that is not a valid survival test); toggle-off deletes the entry; re-toggle reinserts; corrupted/unparseable stored JSON treated as empty (not a crash); storage errors swallowed.
+- Component tests (extend `ContentEditorReaderMode.test.tsx` and/or a new file): mode restored after remount with the same item ID (the `contentKey` bump scenario); miss → markdown; no item ID (create mode) → markdown editor is editable; create → toggle on → save (ID appears with the create signal) → remount → reading mode restored; an in-place ID assignment *without* the create signal writes nothing (the `/new` → existing-item poison regression); document switch between two existing items does not cross-write entries; the shortcut on a disabled editor can neither insert nor delete an entry; `readerMode` neither reads nor writes the cache.
+- `AuthProvider` account-deletion test asserts the new clear step runs; unit test on the clear function.
+- `frontend-verify` passes.
+
+---
+
+## Milestone 2 — Table of Contents in reading mode and on public pages
+
+Scope decisions made during planning, recorded here so implementation doesn't relitigate them:
+
+- **Public-view ToC is in scope for notes and prompts only.** The original ask was to *investigate* feasibility; the investigation happened (the sidebar component is layout-agnostic, the store already treats the ToC panel as session-only, and the real gap is the content-margin handling addressed in 2c).
+- **Bookmarks are excluded from ToC entirely** — no app-side ToC (unchanged), no public-side ToC, no ToC wiring in the bookmark component. Rationale in 2c.
+- **The editor command menu stays closed in reading mode** — see 2b.
+
+Sub-milestone order is load-bearing: **2a before 2b**. The `!effectiveReadingMode` guards that 2b removes are currently the only thing hiding a control that does not work in reading mode — the scroll target is a hidden CodeMirror view, so heading clicks would silently no-op. Unhiding before fixing ships a visibly broken button.
+
+### 2a — Heading navigation works in reading mode
+
+#### Goal & Outcome
+
+- Clicking a ToC heading while reading mode is on scrolls the rendered view to that heading — including in documents with repeated heading names, setext headings, and headings containing links.
+- The scrolled-to heading is not hidden under the sticky header.
+- Side benefit for both modes: setext headings appear in the ToC panel, and headings containing links/images display as clean text instead of raw markdown syntax.
+
+#### Implementation Outline
+
+The ToC's `onHeadingClick` flows through `scrollToLineRef`, whose current implementation dispatches a CodeMirror scroll-into-view — a no-op when reading mode has CodeMirror inside a `hidden` wrapper (and its `view.focus()` would be wrong there). Add a reading-mode branch that targets the rendered Milkdown DOM instead. The reading-mode branch must not focus CodeMirror.
+
+**Resolution strategy: candidate-set parity, then ordinal matching, with verification.** The source parser and the rendered DOM must agree on *which* headings exist before index-based matching can be trusted. Naive ordinal matching (and equally, naive same-text occurrence counting) fails whenever one side sees a heading the other doesn't — e.g. `# Usage` / `> # Usage` / `# Usage`: the anchored source regex skips the blockquote-nested heading, but it renders as a real `h1`, so "the 2nd parsed Usage" is the 3rd rendered heading and an index-or-occurrence match lands inside the blockquote. Achieve parity from both directions:
+
+- **Source side** — extend `utils/markdownHeadings.ts` to recognize setext headings (`Title` / `===` → h1, `---` → h2) and ATX headings indented up to 3 spaces (CommonMark-permitted), which remark renders but the current anchored regex skips. Extend `cleanInlineFormatting` to reduce links and images to their text (`[t](u)` → `t`, `![alt](u)` → alt), both so text verification doesn't reject correct targets and because the ToC panel currently displays the raw syntax.
+- **Rendered side** — resolve only against *top-level* heading elements (direct children of the ProseMirror document, excluding headings nested in blockquotes/list items — which the source parser also excludes, preserving parity).
+- **Safety net** — verify the resolved element's normalized text + level against the parsed heading; on mismatch (residual skew from constructs neither side handles), fall back to selecting the Nth rendered heading with the same normalized text + level, where N is the heading's occurrence index among parsed headings. Record in a comment why parity is required and what the fallback covers.
+
+Reading-mode scrolling moves the page (or nearest scroll container), not a `.cm-scroller` — the heading needs a scroll offset (e.g. `scroll-margin-top`) clearing the sticky header.
+
+#### Definition of Done
+
+- Tests: ordinal resolution scrolls the right element; the adversarial parity case above (duplicate-name heading nested in a blockquote between two top-level duplicates — must reach the correct one); duplicate headings straddling a setext heading; a heading containing a markdown link (verification passes, panel shows clean text); out-of-range ordinal is a safe no-op; markdown-mode path unchanged.
+- `markdownHeadings.test.ts` gains the setext, indented-ATX, and link/image-normalization cases.
+
+### 2b — ToC control visible in reading mode
+
+Remove the `!effectiveReadingMode` conditions gating the ToC toolbar button and its capture-phase keyboard shortcut in `CodeMirrorEditor.tsx`. Button active-state and toggle behavior are already wired through the sidebar store.
+
+**The editor command menu (Cmd+/) intentionally stays closed in reading mode.** There is no ToC-specific gate in the menu to remove — the gate is on opening the menu itself, and that same gate is currently the *only* thing preventing the menu's mutating commands (bold, insert link, …) from dispatching real edits into the hidden CodeMirror document: the execute path checks only CodeMirror's `readOnly` state, which is false in ordinary app-side reading mode. Opening the menu in reading mode would therefore require a per-command safety audit for one redundant access path to a feature already reachable via toolbar and shortcut. Keep the gate; record this rationale in a comment at the gate site.
+
+Done = button and shortcut toggle the ToC panel in both modes; a test pins that Cmd+/ does *not* open the command menu in reading mode (intent, not accident); existing toolbar tests updated; `frontend-verify` passes.
+
+### 2c — ToC on public shared note and prompt views
+
+#### Goal & Outcome
+
+- Visitors to a public shared note or prompt can open the ToC sidebar and navigate by heading, in both reading and source modes.
+- On desktop, opening the sidebar pushes the content over (no overlay); on mobile the existing full-width panel behavior applies.
+- The panel does not persist across page loads, and never leaks onto other public pages (pricing, changelog, roadmap) — neither via a stale in-memory panel nor via panel state persisted from a prior app session.
+- Public shared **bookmarks** get no ToC. Rationale, recorded here and in a comment where bookmarks are excluded: bookmark content is scraped with formatting deliberately stripped (it exists to make bookmarks searchable), so it essentially never contains markdown headings — verified empirically against real scraped content, where pages with rich section structure produced zero headings. A bookmark ToC would render its empty state almost always, while requiring from-scratch wiring in the bookmark component plus handling for its collapsed-by-default content panel (ToC open + panel collapsed would orphan the sidebar). The app-side bookmark page already closes the ToC panel on mount ("bookmarks don't support ToC"); that behavior stays. If bookmark authoring habits change, the incremental path is: wire the component → enable public → enable app-side.
+
+#### Implementation Outline
+
+- **Do not put the sidebar margin in `PublicPageLayout`.** That layout wraps pricing, changelog, and roadmap in addition to the three shared-item pages, and the sidebar store can hold panel state those pages must ignore: `history` can be restored from localStorage at store init, and an open `toc` survives client-side navigation (the store has no route cleanup). A layout-level margin keyed on `activePanel !== null` would shift pricing/changelog content ~400px with nothing in the gap. Instead, apply the offset in the shared-item shell (`PublicItemShell` or an equivalent wrapper rendered only by the shared note/prompt pages), conditioned on `activePanel === 'toc'` specifically — never `history`, which no public page can render. Note the layout centers content (`max-w-5xl mx-auto`); the offset must account for centering rather than assuming the app layout's flush-left geometry.
+- **Close the ToC when leaving the shared-item pages** (unmount/route-leave), so navigating shared note → pricing doesn't strand an open panel. Precedent for close-on-unsupported-page already exists in the app-side bookmark page.
+- Reuse the store's exported `computeMaxWidth` rather than duplicating margin constants; the public layout has no left sidebar, so the ported logic should be simpler than `Layout.tsx`'s, not a copy.
+- Then enable `showTocToggle` on the public note and prompt pages (currently explicitly `false`). No changes to the bookmark component or public bookmark page.
+- Depends on 2a: public pages open in reading mode by default, so without 2a the control would be visible but broken there.
+
+#### Definition of Done
+
+- Tests: public note/prompt page renders the ToC toggle; opening the panel applies the content offset on desktop; heading click navigates (reading mode); panel absent by default on load; **persisted `history` panel state → public pages render unshifted**; **open ToC on a shared item, navigate to pricing → no offset and panel closed**; public bookmark page has no ToC toggle.
+- Manual check of shared note and prompt pages at desktop and mobile widths.
+- `frontend-verify` passes.
+
+---
+
+## Milestone 3 — Callout syntax across the rendering pipelines
+
+### Goal & Outcome
+
+Blockquote-style callouts render with an icon, tinted left rule, and (in rendered views) background tint — whether typed by the user, pasted from GitHub, or written by an agent guessing at syntax.
+
+- `> [!WARNING]`, `> [warning]`, `> [!Warning] Custom title` and similar all render as callouts; keyword matching is case-insensitive and the `!` is optional.
+- Common aliases map onto five canonical variants:
+
+  | Canonical | Accepted keywords | Color | Icon |
+  |---|---|---|---|
+  | NOTE | note, info, information | blue | info circle |
+  | TIP | tip, hint, success, check, done | green | lightbulb |
+  | IMPORTANT | important | purple | exclamation circle |
+  | WARNING | warning, attention | amber | warning triangle |
+  | CAUTION | caution, danger, error, bug, failure | red | stop octagon |
+
+- Unrecognized keywords (`> [!FOO]`) render as a plain blockquote — fail soft, never break rendering.
+- Callouts render consistently in **all three pipelines**: the CodeMirror editor (line-decoration styling, marker text stays visible and editable), the reading-mode rendered view (marker restyled as a title with icon), and the docs prose pipeline.
+- **The docs pipeline keeps its existing three visual styles** (info/tip/warning). It already renders callouts today via its own remark plugin with a narrower grammar (`!` required, three-way alias collapse); this milestone unifies the *grammar* (what parses as a callout, and which canonical variant it is) while mapping the five canonical variants onto the docs' three existing styles — so no shipped docs page changes appearance. Expanding docs to the five-style palette is a decoupled, deliberately deferred visual decision. Grammar unification slightly broadens what docs accepts (optional `!`, more aliases, inline titles); docs content is curated, so this is harmless.
+
+### Implementation Outline
+
+Three independent rendering pipelines must agree on what counts as a callout, so the parsing/classification logic is a single shared module all three consume — that anti-drift constraint is the reason sub-milestone 3a exists and must come first. The docs pipeline's existing `remarkCallouts.ts` is prior art with its own private grammar; it becomes a consumer of the shared module, not a fourth parser.
+
+### 3a — Shared callout parser
+
+- New pure module (in `utils/`) with a layered contract shaped by its consumers' inputs:
+  - **Marker-core**: operates on text *without* the blockquote `>` prefix — because two of the three consumers (ProseMirror decorations, mdast/remark) see post-parse text where the blockquote marker is already consumed. Matches a leading `[!keyword]` / `[keyword]` (case-insensitive, optional bang, optional trailing custom title on the same line), returning the canonical variant, the custom title if any, and the marker's span offsets (so consumers can style or strip exactly the marker).
+  - **Raw-source adapter** for CodeMirror: strips the leading `>` and whitespace from a source line and delegates to marker-core, offsetting positions back to line coordinates.
+  - **Keyword → canonical-variant resolution** per the alias table above. Unknown keyword → not a callout (`null`), so every consumer falls through to plain-blockquote behavior.
+- The mdast-facing usage must be robust to the marker paragraph's *inline structure*: a paragraph's first line isn't always a single text node (a hard line-break after the marker produces `[text, break, text]`). Match against the first paragraph's joined leading inline content, not only `children[0]` — the existing docs plugin has this narrower behavior as a latent wart; the shared module, as the single source of truth, must not inherit it.
+- Record in the module docstring *why* it exists (three pipelines, must not drift), the fail-soft rule, and the marker-core/adapter layering rationale (post-parse consumers never see `>`).
+
+**Done**: exhaustive unit tests — every alias × case variations × bang/no-bang × with/without title × leading whitespace; non-matches (no brackets, empty brackets, non-alpha keyword); marker-core positions correct for title styling; the raw-source adapter's offset math. Detection is line-based; whether a mid-quote marker starts a callout is decided by consumers, which only check a block's first line.
+
+### 3b — Callouts in the CodeMirror editor
+
+#### Implementation Outline
+
+- `utils/markdownStyleExtension.ts` currently collapses every `>`-prefixed line into one `blockquote` line type, styled with an indigo left border. Extend the line parser to detect a callout marker via the 3a raw-source adapter, and thread the *current callout variant* through the document walk in `buildDecorations` the same way the existing `inCodeBlock` boolean is threaded — a callout starts at a marker line and its variant applies to subsequent `>` continuation lines until the blockquote ends. This threading pattern is the established convention in that file; do not invent a parallel one.
+- Per-variant line classes drive the left-border color and a subtle background tint from the existing theme object, alongside the current blockquote rule.
+- **Marker stays visible and editable, styled dim** (like the existing syntax-marker treatment) — this is a live editor; hiding the marker behind a replace decoration fights the cursor. Record this rationale in a comment. Icons in the editor view: at most a modest `::before` on the marker line; if positioning fights the CodeMirror line layout, editor-side icons are droppable — the colored rule is the signal that matters while editing. Ship icons in 3c regardless.
+
+#### Definition of Done
+
+- Tests in the existing `markdownStyleExtension` test file: marker line gets the variant class; continuation lines inherit it; the blockquote ending resets state; a second marker mid-document starts fresh; unknown keyword renders as plain blockquote; callout markers inside fenced code blocks are ignored; adjacent distinct callouts don't bleed into each other.
+- No visual regression to plain blockquotes.
+
+### 3c — Callouts in the reading-mode rendered view
+
+#### Implementation Outline
+
+- **Critical shape constraint that drives this design**: in the parsed document, the canonical multi-line form `> [!WARNING]` + `> body` on consecutive quoted lines is **one paragraph** — the marker and the first body line share a paragraph, separated by a soft break (confirmed via the docs pipeline's remark parser, which runs on the same mdast engine Milkdown's parser uses; its marker regex ends `\n?` for exactly this reason). Only the blank-line form (`> [!WARNING]`, `>`, `> body`) yields a separate marker paragraph. Any design that decorates "the marker paragraph" as a title therefore styles body text as title in the most common case. Decorations must be **span-scoped, not paragraph-scoped**.
+- **Decoration-only ProseMirror plugin — no schema node, no remark extension.** A `$prose` plugin walks blockquotes, runs the 3a marker-core against the first paragraph's leading inline content, and applies: a node decoration on the blockquote (variant class) and **inline decorations covering only the marker span** (and the custom-title span, if present) within that first paragraph, using the offsets 3a returns. Body text — same-paragraph-after-softbreak or subsequent paragraphs — keeps normal body styling. `MilkdownEditor.tsx` already contains this plugin shape twice (`createCodeBlockCopyPlugin`, `createPlaceholderPlugin`) — follow it.
+- Why decoration-only is safe and right here (record in a comment): `MilkdownEditor` has exactly one production consumer — the reading-mode preview inside `CodeMirrorEditor`, always `readOnly` — so there is no editing or serialization path to protect. A real schema node + remark parser/serializer would be several times the code and put markdown round-tripping at risk for zero benefit.
+- Styling in `index.css` under the existing `.milkdown-wrapper` scoping: left rule + background tint per variant; the marker span is suppressed/restyled and replaced by a clean title presentation — icon via `::before` on the decorated span, then "Warning" (or the custom title, which the title-span decoration covers). The inline decorations give exact spans, so no CSS heroics against raw text nodes are needed.
+- **Icons: inline SVG via CSS `mask-image` data-URIs, colored via `background-color`/`currentColor`** — not emoji (inconsistent cross-platform rendering) and not decoration widgets (heavier, no benefit). Five icons per the table in the milestone goal; heroicons/lucide outlines are fine sources.
+
+#### Definition of Done
+
+- **Fixture tests that assert against the actual Milkdown-parsed document/DOM** — this is the architecture gate for the shape constraint above, not an afterthought: (a) marker + soft-break body on consecutive quoted lines — body text retains body styling and the raw `[!WARNING]` text is not visible as-is; (b) marker + custom title + body; (c) blank-line-separated body (separate paragraphs); (d) marker alone. Plus: each canonical variant gets its class; alias/case spot-checks (exhaustive coverage lives in 3a); unknown keyword → plain blockquote; blockquote with no marker unaffected; marker not at the start of the first paragraph → plain blockquote.
+- Visual check of all five variants in reading mode, plus one in the public shared view (same component, but confirm the CSS scoping reaches it).
+- `frontend-verify` passes.
+
+### 3d — Docs pipeline adopts the shared grammar
+
+Genuinely small. `components/markdown/remarkCallouts.ts` replaces its private marker regex and three-way alias table with the 3a module (marker-core + canonical resolution), keeping everything else it does today: its mdast surgery (marker stripping, class tagging) and a local five-canonical → three-docs-styles mapping onto the existing `CalloutVariant` type (`note/info/information/important` → info, `tip/hint/success/check/done` → tip, `warning/attention/caution/danger/error/bug/failure` → warning). Record in its docstring that the grammar is shared and the 3-style collapse is a deliberate docs presentation choice. Done = existing docs markdown tests stay green (no visual change to shipped pages); new spot-checks through the remark path for the broadened grammar (`[!danger]` → docs warning, optional-`!` accepted); `frontend-verify` passes.
+
+---
+
+## Cross-cutting notes
+
+- **Keep in sync** (per `AGENTS.md`): callouts are a user-facing markdown capability — check whether the docs prose (`content/prose/*.md`), FAQ, changelog, or `llms-app-usage.txt` mention supported markdown syntax and update accordingly. Reading-mode persistence and public ToC likely warrant a changelog entry.
+- **Testing scope**: frontend-only work — run `make frontend-verify`; backend suites are not affected.
+- The three milestones are one PR but should remain separately revertible commits in the order above.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,8 @@
         "react-router-dom": "^7.10.1",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.5",
         "zustand": "^5.0.9"
       },
       "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,8 @@
     "react-router-dom": "^7.10.1",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/frontend/public/llms-app-usage.txt
+++ b/frontend/public/llms-app-usage.txt
@@ -43,6 +43,7 @@ Link any item to any other across types (bookmark ↔ note ↔ prompt) — e.g. 
 ## Editing (the markdown editor)
 
 - **Slash menu:** type `/` at the start of a line to insert blocks — headings, bulleted/numbered/checklist, code block, blockquote, link, horizontal rule. In a *prompt*, the menu also offers Jinja2 blocks (variable, if-block). It does not trigger mid-line or inside a code fence.
+- **Callouts:** a blockquote whose first line is a GitHub-style alert marker (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) renders with variant coloring in the editor, and with icon, label, and color in reading mode and on public share pages. Forgiving syntax: the `!` is optional, keywords are case-insensitive, common aliases work (`info`, `hint`, `danger`, `error`, ...), and `> [!note] Custom title` sets a title. Unknown keywords render as a plain blockquote.
 - **All shortcuts:** open the shortcuts dialog with `Mod+Shift+/`. Useful editor toggles: reading/preview mode `Mod+Shift+M`, word wrap `Alt+Z`. Full, OS-correct set: https://tiddly.me/data/shortcuts.json.
 - **Quick-add a bookmark:** paste a URL anywhere with `Mod+V` and Tiddly starts a new bookmark pre-filled from that URL.
 - **Authoring prompts** (Jinja2 templates: variables, conditionals, filters, loops, strict mode): see https://tiddly.me/prose/prompts.md.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,9 @@ import { LoadingSpinnerPage } from './components/ui'
 // Lazy-loaded routes — keep in sync with routePrefetch.ts
 // Lazy-loaded layouts (only used by lazy routes)
 const DocsLayout = lazy(() => import('./components/DocsLayout').then(m => ({ default: m.DocsLayout })))
-const PublicPageLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicPageLayout })))
+const PublicChromeLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicChromeLayout })))
+const PublicContentLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicContentLayout })))
+const PublicSharedTocLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicSharedTocLayout })))
 
 // Lazy-loaded detail pages (heavy — pulls in CodeMirror + Milkdown)
 const BookmarkDetail = lazy(() => import('./pages/BookmarkDetail').then(m => ({ default: m.BookmarkDetail })))
@@ -129,19 +131,33 @@ const router = createBrowserRouter([
         ],
       },
 
-      // Top-level public routes with shared header/footer
+      // Top-level public routes with shared header/footer. Chrome is
+      // single-sourced; the content area splits into the standard centered
+      // layout and the ToC-capable shared-item layout (see PublicPageLayout).
       {
-        element: <PublicPageLayout />,
+        element: <PublicChromeLayout />,
         children: [
-          { path: '/changelog', element: <Changelog /> },
-          { path: '/roadmap', element: <Roadmap /> },
-          { path: '/pricing', element: <Pricing /> },
-
+          {
+            element: <PublicContentLayout />,
+            children: [
+              { path: '/changelog', element: <Changelog /> },
+              { path: '/roadmap', element: <Roadmap /> },
+              { path: '/pricing', element: <Pricing /> },
+              // Shared bookmarks are deliberately ToC-less (scraped content
+              // has no headings), so they use the standard layout — the
+              // sidebar margin structurally cannot apply to them.
+              { path: '/shared/bookmarks/:token', element: <PublicBookmark /> },
+            ],
+          },
           // Public read-only share views (no auth). The render components run in
           // readOnly mode; the only action is the auth-aware "Save a copy".
-          { path: '/shared/bookmarks/:token', element: <PublicBookmark /> },
-          { path: '/shared/notes/:token', element: <PublicNote /> },
-          { path: '/shared/prompts/:token', element: <PublicPrompt /> },
+          {
+            element: <PublicSharedTocLayout />,
+            children: [
+              { path: '/shared/notes/:token', element: <PublicNote /> },
+              { path: '/shared/prompts/:token', element: <PublicPrompt /> },
+            ],
+          },
         ],
       },
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,8 +15,7 @@ import { LoadingSpinnerPage } from './components/ui'
 // Lazy-loaded routes — keep in sync with routePrefetch.ts
 // Lazy-loaded layouts (only used by lazy routes)
 const DocsLayout = lazy(() => import('./components/DocsLayout').then(m => ({ default: m.DocsLayout })))
-const PublicChromeLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicChromeLayout })))
-const PublicContentLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicContentLayout })))
+const PublicPageLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicPageLayout })))
 const PublicSharedTocLayout = lazy(() => import('./components/PublicPageLayout').then(m => ({ default: m.PublicSharedTocLayout })))
 
 // Lazy-loaded detail pages (heavy — pulls in CodeMirror + Milkdown)
@@ -135,29 +134,25 @@ const router = createBrowserRouter([
       // single-sourced; the content area splits into the standard centered
       // layout and the ToC-capable shared-item layout (see PublicPageLayout).
       {
-        element: <PublicChromeLayout />,
+        element: <PublicPageLayout />,
         children: [
-          {
-            element: <PublicContentLayout />,
-            children: [
-              { path: '/changelog', element: <Changelog /> },
-              { path: '/roadmap', element: <Roadmap /> },
-              { path: '/pricing', element: <Pricing /> },
-              // Shared bookmarks are deliberately ToC-less (scraped content
-              // has no headings), so they use the standard layout — the
-              // sidebar margin structurally cannot apply to them.
-              { path: '/shared/bookmarks/:token', element: <PublicBookmark /> },
-            ],
-          },
-          // Public read-only share views (no auth). The render components run in
-          // readOnly mode; the only action is the auth-aware "Save a copy".
-          {
-            element: <PublicSharedTocLayout />,
-            children: [
-              { path: '/shared/notes/:token', element: <PublicNote /> },
-              { path: '/shared/prompts/:token', element: <PublicPrompt /> },
-            ],
-          },
+          { path: '/changelog', element: <Changelog /> },
+          { path: '/roadmap', element: <Roadmap /> },
+          { path: '/pricing', element: <Pricing /> },
+          // Shared bookmarks are deliberately ToC-less (scraped content has no
+          // headings), so they use the standard layout — the sidebar margin
+          // structurally cannot apply to them.
+          { path: '/shared/bookmarks/:token', element: <PublicBookmark /> },
+        ],
+      },
+      // Public read-only share views with ToC support (no auth). The render
+      // components run in readOnly mode; the only action is the auth-aware
+      // "Save a copy".
+      {
+        element: <PublicSharedTocLayout />,
+        children: [
+          { path: '/shared/notes/:token', element: <PublicNote /> },
+          { path: '/shared/prompts/:token', element: <PublicPrompt /> },
         ],
       },
 

--- a/frontend/src/components/AuthProvider.test.tsx
+++ b/frontend/src/components/AuthProvider.test.tsx
@@ -11,6 +11,7 @@ import { useAuthActions } from '../hooks/useAuthActions'
 import { queryClient } from '../queryClient'
 import { useAIStore } from '../stores/aiStore'
 import { useSessionExpiryStore } from '../stores/sessionExpiryStore'
+import { readReadingMode, writeReadingMode } from '../utils/readingModeCache'
 
 // The global setup (test/setup.ts) mocks the seam hooks module-wide; these
 // tests exist to verify the REAL seam bridge (seam call -> SDK call), so the
@@ -156,9 +157,10 @@ describe('AuthProvider', () => {
       return fn as () => void
     }
 
-    it("clears the deleted user's BYOK keys + drafts and navigates to the terminal page", async () => {
+    it("clears the deleted user's BYOK keys + drafts + reading-mode cache and navigates to the terminal page", async () => {
       useAIStore.getState().setApiKey('suggestions', 'sk-secret')
       localStorage.setItem('tiddly:draft:note:x', 'draft')
+      writeReadingMode('note-x', true)
 
       const onAccountDeleted = await getOnAccountDeleted()
       onAccountDeleted()
@@ -168,6 +170,7 @@ describe('AuthProvider', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/account-deleted', { replace: true })
       expect(useAIStore.getState().useCaseConfigs.suggestions.apiKey).toBeNull()
       expect(localStorage.getItem('tiddly:draft:note:x')).toBeNull()
+      expect(readReadingMode('note-x')).toBe(false)
       expect(queryClient.clear).toHaveBeenCalled()
       // Sign-out pinned to the terminal page so Clerk can't redirect off it.
       expect(mockSignOut).toHaveBeenCalledWith({ redirectUrl: '/account-deleted' })

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -6,6 +6,7 @@ import { setupAuthInterceptor } from '../services/api'
 import { useAIStore } from '../stores/aiStore'
 import { useSessionExpiryStore } from '../stores/sessionExpiryStore'
 import { clearAllDrafts } from '../utils/drafts'
+import { clearReadingModeCache } from '../utils/readingModeCache'
 import { queryClient } from '../queryClient'
 import { toSafeReturnTo } from '../utils/returnTo'
 import { AuthSeamProvider } from './AuthSeamProvider'
@@ -181,6 +182,7 @@ function AuthInterceptorSetup({ children }: AuthProviderProps): ReactNode {
     safe('clear-queries', () => queryClient.clear())
     safe('clear-byok-keys', () => useAIStore.getState().clearAllKeys())
     safe('clear-drafts', clearAllDrafts)
+    safe('clear-reading-mode-cache', clearReadingModeCache)
     safe('reset-session-expiry', () => useSessionExpiryStore.getState().reset())
     safe('begin-deliberate-logout', () => useSessionExpiryStore.getState().beginDeliberateLogout())
     // `replace` so Back doesn't return to the dead session.

--- a/frontend/src/components/Bookmark.tsx
+++ b/frontend/src/components/Bookmark.tsx
@@ -1166,6 +1166,12 @@ export function Bookmark({
             </Tooltip>
           </div>
           {isContentExpanded && (
+            // No itemIdWasJustCreated: bookmark create-saves navigate away
+            // (BookmarkDetail) and this editor's key includes the id, so there
+            // is no in-place create→edit transition. Accepted consequence: a
+            // reading-mode toggle made while creating is not persisted
+            // (self-heals on the first toggle after save) — see the
+            // editor-improvements implementation plan.
             <ContentEditor
               key={`${bookmark?.id ?? 'new'}-${contentKey}`}
               value={current.content}
@@ -1174,6 +1180,7 @@ export function Bookmark({
               readOnly={isSaving}
               readerMode={readOnly}
               defaultReadingMode={readOnly}
+              itemId={bookmark?.id}
               hasError={!!errors.content}
               minHeight="200px"
               placeholder="Paste or type content to make this bookmark searchable. Auto-filled when you retrieve URL info."

--- a/frontend/src/components/CodeMirrorEditor.tsx
+++ b/frontend/src/components/CodeMirrorEditor.tsx
@@ -68,6 +68,7 @@ import {
 } from '../utils/editorFormatting'
 import { buildEditorCommands, type MenuCallbacks, type EditorCommand } from './editor/editorCommands'
 import { EditorCommandMenu } from './editor/EditorCommandMenu'
+import { readReadingMode, touchReadingMode, writeReadingMode } from '../utils/readingModeCache'
 
 /** Markdown formatting markers for wrap-style formatting. */
 const MARKERS = {
@@ -94,8 +95,28 @@ interface CodeMirrorEditorProps {
    * content stays selectable/copyable but not editable.
    */
   readerMode?: boolean
-  /** Initial value for the reading-mode toggle (renders Milkdown preview by default). */
+  /** Initial value for the reading-mode toggle in reader mode (renders Milkdown preview by default). */
   defaultReadingMode?: boolean
+  /**
+   * Item ID for per-item reading-mode persistence (see utils/readingModeCache).
+   * Undefined during create (no ID yet → no entry → markdown mode). Unlike the
+   * parents' React `key` (which must NOT contain the item ID — see the
+   * contentKey comments in Note/Prompt), this is an ordinary prop and does not
+   * affect remounting.
+   */
+  itemId?: string
+  /**
+   * Asserts that an in-place `undefined → itemId` assignment continues the
+   * create→edit transition (the parent just saved a brand-new item without
+   * remounting this editor), authorizing migration of the current reading mode
+   * to the new ID. The editor cannot infer this itself: navigating from a
+   * create view to an EXISTING item also delivers an ID in place (one render
+   * before the parent's corrective contentKey remount), and writing on that
+   * would poison the existing item's remembered mode. Parents derive this from
+   * their fromCreate contract; parents without an in-place create→edit
+   * transition simply never assert it.
+   */
+  itemIdWasJustCreated?: boolean
   /** Minimum height for the editor */
   minHeight?: string
   /** Placeholder text shown when empty */
@@ -247,6 +268,8 @@ export function CodeMirrorEditor({
   readOnly = false,
   readerMode = false,
   defaultReadingMode = false,
+  itemId,
+  itemIdWasJustCreated = false,
   minHeight = '200px',
   placeholder = 'Write your content in markdown...',
   wrapText = false,
@@ -276,15 +299,63 @@ export function CodeMirrorEditor({
   // Forward-declared ref for openCommandMenu (defined later, used by document-level keydown handler and CM keybinding)
   const openCommandMenuRef = useRef<() => void>(() => {})
 
-  // Reading mode state (local, not persisted). Defaults on for reader mode so
-  // notes/bookmarks open in the rendered Milkdown view rather than raw source.
-  const [readingMode, setReadingMode] = useState(defaultReadingMode)
+  // Reading mode state, remembered per item (see utils/readingModeCache).
+  //
+  // Seeded at INITIALIZATION only, never as a live effect: a live cache
+  // override would flip the mode mid-session on the create→edit transition
+  // (which deliberately does not remount this editor — see the contentKey
+  // comments in Note/Prompt). Every path that needs the mode re-derived
+  // (document switch, server sync, refresh) already remounts via the parent's
+  // contentKey, so the initializer re-runs exactly when it should.
+  //
+  // Reader mode (public share view) is fully isolated from the cache — it
+  // seeds from defaultReadingMode (on for notes/bookmarks, omitted for prompts
+  // so shared templates open as raw source) and never reads or writes, so a
+  // visitor toggling a shared page can't perturb their own account's items.
+  // The truthiness check on itemId also covers the public adapters'
+  // synthesized empty-string IDs.
+  const persistable = !readerMode && !!itemId
+  const [readingMode, setReadingMode] = useState(
+    () => readerMode ? defaultReadingMode : (!!itemId && readReadingMode(itemId)),
+  )
+
+  // Opening a remembered item refreshes its LRU recency (touch is a no-op on
+  // miss); without this, an item read daily but toggled once would age out.
+  useEffect(() => {
+    if (persistable && itemId) touchReadingMode(itemId)
+  }, [persistable, itemId])
+
+  // Persist a mode toggled during create once the item first gains an ID: the
+  // create→edit transition doesn't remount, so the initializer never re-runs,
+  // and the pre-save toggle happened before there was an ID to write under.
+  //
+  // The `undefined → ID` transition alone does NOT prove a create→edit save —
+  // navigating from /new to an EXISTING item renders this same instance once
+  // with that item's ID before the parent's sync effect bumps contentKey (child
+  // effects run before parent effects), and an unguarded write here would
+  // poison the existing item's remembered mode with the draft's toggle state.
+  // So the write additionally requires itemIdWasJustCreated — the parent's
+  // explicit assertion of create provenance, which this editor must not infer.
+  // Parents with no in-place create→edit transition (bookmarks: navigate-away
+  // save, ID-keyed remount) never assert it and are excluded structurally.
+  const prevItemIdRef = useRef(itemId)
+  useEffect(() => {
+    const prevId = prevItemIdRef.current
+    prevItemIdRef.current = itemId
+    if (prevId === undefined && persistable && itemId && itemIdWasJustCreated && readingMode) {
+      writeReadingMode(itemId, true)
+    }
+  }, [itemId, itemIdWasJustCreated, persistable, readingMode])
 
   // Store scroll position when toggling modes to preserve reading position
   const scrollPositionRef = useRef<number>(0)
 
-  // Toggle reading mode with scroll position preservation
+  // Toggle reading mode with scroll position preservation.
+  // Central disabled guard: the toggle now writes durable per-item state, and
+  // effectiveReadingMode would mask the flip visually on a disabled (e.g.
+  // deleted-item) view — an invisible mutation of the persisted preference.
   const toggleReadingMode = useCallback((): void => {
+    if (disabled) return
     if (!readingMode) {
       // Switching TO reading mode - save scroll position
       const scroller = containerRef.current?.querySelector('.cm-scroller')
@@ -292,8 +363,11 @@ export function CodeMirrorEditor({
         scrollPositionRef.current = scroller.scrollTop
       }
     }
+    if (persistable && itemId) {
+      writeReadingMode(itemId, !readingMode)
+    }
     setReadingMode((prev) => !prev)
-  }, [readingMode])
+  }, [readingMode, persistable, itemId, disabled])
 
   // Restore scroll position when switching back from reading mode
   useEffect(() => {
@@ -379,8 +453,13 @@ export function CodeMirrorEditor({
       let didHandle = false
       switch (id) {
         case 'editor.toggleReadingMode':
-          s.toggleReadingMode()
-          didHandle = true
+          // disabled only — NOT readOnly: toggling on a public-share (readOnly)
+          // view is a deliberate visitor feature. Disabled must not consume the
+          // event either, since the toggle it maps to is rejected.
+          if (!s.disabled) {
+            s.toggleReadingMode()
+            didHandle = true
+          }
           break
         case 'editor.toggleWordWrap':
           if (!s.effectiveReadingMode && s.onWrapTextChange) {

--- a/frontend/src/components/CodeMirrorEditor.tsx
+++ b/frontend/src/components/CodeMirrorEditor.tsx
@@ -69,6 +69,7 @@ import {
 import { buildEditorCommands, type MenuCallbacks, type EditorCommand } from './editor/editorCommands'
 import { EditorCommandMenu } from './editor/EditorCommandMenu'
 import { readReadingMode, touchReadingMode, writeReadingMode } from '../utils/readingModeCache'
+import { findRenderedHeading } from '../utils/headingNavigation'
 
 /** Markdown formatting markers for wrap-style formatting. */
 const MARKERS = {
@@ -151,7 +152,13 @@ interface CodeMirrorEditorProps {
   originalContent?: string
   /** Whether the editor has unsaved changes (controls discard command disabled state) */
   isDirty?: boolean
-  /** Ref that receives a scroll-to-line callback for external navigation (e.g., ToC) */
+  /**
+   * Ref that receives a scroll-to-line callback for external navigation
+   * (e.g., ToC). Mode-dependent semantics, by design: in markdown mode any
+   * valid line scrolls; in reading mode the line must identify a parsed
+   * heading (resolved against the rendered DOM via headingNavigation.ts) and
+   * anything else safely no-ops — a dead click beats a wrong jump.
+   */
   scrollToLineRef?: React.MutableRefObject<((line: number) => void) | null>
   /** Whether to show the ToC toggle button in the toolbar */
   showTocToggle?: boolean
@@ -480,12 +487,22 @@ export function CodeMirrorEditor({
           }
           break
         case 'editor.toggleToc':
-          if (s.showTocToggle && !s.effectiveReadingMode) {
+          // Works in reading mode too — the ToC navigates the rendered view
+          // via the reading-mode branch of scrollToLineRef. Rejects disabled
+          // (deleted-item views) to match the toolbar button, leaving the
+          // event unconsumed per the handler contract above.
+          if (s.showTocToggle && !s.disabled) {
             s.togglePanel('toc')
             didHandle = true
           }
           break
         case 'editor.commandMenu':
+          // The command menu intentionally stays closed in reading mode: this
+          // gate is also the guard keeping the menu's mutating commands (bold,
+          // insert link, ...) from dispatching edits into the hidden CodeMirror
+          // doc — handleCommandExecute only checks CM's readOnly, which is
+          // false in ordinary app-side reading mode. ToC in reading mode is
+          // reachable via the toolbar button and shortcut instead.
           if (!s.effectiveReadingMode && !s.disabled && !s.readOnly) {
             s.openCommandMenuRef.current()
             didHandle = true
@@ -671,6 +688,19 @@ export function CodeMirrorEditor({
   useEffect(() => {
     if (scrollToLineRef) {
       scrollToLineRef.current = (lineNumber: number): void => {
+        // Reading mode: the CodeMirror view is inside a hidden wrapper, so
+        // scrolling it is a no-op (and focusing it would steal focus into a
+        // hidden element). Resolve the heading against the rendered Milkdown
+        // DOM instead — see headingNavigation.ts for the parity/verification
+        // strategy. scroll-margin-top on the rendered headings (index.css)
+        // keeps the target clear of the sticky toolbars/headers.
+        if (effectiveReadingMode) {
+          const wrapper = containerRef.current?.querySelector('.milkdown-wrapper')
+          if (!wrapper) return
+          const el = findRenderedHeading(wrapper, value, lineNumber)
+          el?.scrollIntoView({ block: 'start' })
+          return
+        }
         const view = getView()
         if (view) {
           const maxLine = view.state.doc.lines
@@ -898,8 +928,9 @@ export function CodeMirrorEditor({
             </Tooltip>
           )}
 
-          {/* Table of Contents toggle - only shown when enabled and not in reading mode */}
-          {showTocToggle && !effectiveReadingMode && (
+          {/* Table of Contents toggle - shown in both modes (the ToC navigates
+              the rendered view in reading mode) */}
+          {showTocToggle && (
             <Tooltip content={shortcutTooltipContent('editor.toggleToc')} compact>
               <button
                 type="button"

--- a/frontend/src/components/CodeMirrorEditorReadingModePersistence.test.tsx
+++ b/frontend/src/components/CodeMirrorEditorReadingModePersistence.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Tests for per-item reading-mode persistence in CodeMirrorEditor
+ * (see utils/readingModeCache.ts for the storage semantics).
+ *
+ * Covers the seeding contract (cache hit → reading mode, miss/create →
+ * markdown), write-through on toggle, the create→save (undefined → ID)
+ * transition write, and reader-mode isolation (public views neither read nor
+ * write the cache).
+ *
+ * Reading mode is toggled via the registry shortcut (Mod+Shift+M, matched on
+ * code KeyM) dispatched at the document, exercising the real capture-phase
+ * path. jsdom reports a non-Mac platform, so Mod maps to ctrlKey.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { act } from 'react'
+import { CodeMirrorEditor } from './CodeMirrorEditor'
+import { readReadingMode, writeReadingMode } from '../utils/readingModeCache'
+import { vi } from 'vitest'
+
+// Reading mode renders the (heavy) Milkdown preview; stub it to a marker div.
+vi.mock('./MilkdownEditor', () => ({
+  MilkdownEditor: ({ value }: { value: string }) => <div data-testid="reading">{value}</div>,
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+function isReadingMode(container: HTMLElement): boolean {
+  return container.querySelector('[data-testid="reading"]') !== null
+}
+
+function toggleReadingModeViaShortcut(): void {
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        code: 'KeyM',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+  })
+}
+
+describe('CodeMirrorEditor — per-item reading-mode persistence', () => {
+  it('cache hit seeds reading mode, and it survives a remount (refresh / contentKey bump)', () => {
+    writeReadingMode('item-1', true)
+
+    const first = render(<CodeMirrorEditor value="# hi" onChange={() => {}} itemId="item-1" />)
+    expect(isReadingMode(first.container)).toBe(true)
+    first.unmount()
+
+    // Remount simulates both a page refresh and the parents' contentKey bump
+    // on server sync — the initializer re-reads the cache either way.
+    const second = render(<CodeMirrorEditor value="# hi" onChange={() => {}} itemId="item-1" />)
+    expect(isReadingMode(second.container)).toBe(true)
+  })
+
+  it('cache miss opens in markdown mode', () => {
+    const { container } = render(
+      <CodeMirrorEditor value="# hi" onChange={() => {}} itemId="never-toggled" />,
+    )
+    expect(isReadingMode(container)).toBe(false)
+  })
+
+  it('create mode (no itemId) opens an editable markdown editor', () => {
+    const { container } = render(<CodeMirrorEditor value="" onChange={() => {}} />)
+    expect(isReadingMode(container)).toBe(false)
+    expect(container.querySelector('.cm-content')?.getAttribute('contenteditable')).toBe('true')
+  })
+
+  it('toggling writes through: on inserts the entry, off deletes it', () => {
+    const { container } = render(
+      <CodeMirrorEditor value="# hi" onChange={() => {}} itemId="item-2" />,
+    )
+    expect(isReadingMode(container)).toBe(false)
+
+    toggleReadingModeViaShortcut()
+    expect(isReadingMode(container)).toBe(true)
+    expect(readReadingMode('item-2')).toBe(true)
+
+    toggleReadingModeViaShortcut()
+    expect(isReadingMode(container)).toBe(false)
+    expect(readReadingMode('item-2')).toBe(false)
+  })
+
+  it('a mode toggled during create is written when the item first gains an ID (with the create signal)', () => {
+    // create → toggle reading on → save (ID appears without a remount, parent
+    // asserts itemIdWasJustCreated per its fromCreate contract) → the pre-save
+    // toggle must be persisted under the new ID, and a later fresh mount
+    // (refresh) must restore it.
+    const { rerender, unmount } = render(<CodeMirrorEditor value="# hi" onChange={() => {}} />)
+
+    toggleReadingModeViaShortcut()
+    expect(readReadingMode('new-id')).toBe(false) // no ID yet — nothing written
+
+    rerender(<CodeMirrorEditor value="# hi" onChange={() => {}} itemId="new-id" itemIdWasJustCreated />)
+    expect(readReadingMode('new-id')).toBe(true)
+    unmount()
+
+    const refreshed = render(<CodeMirrorEditor value="# hi" onChange={() => {}} itemId="new-id" />)
+    expect(isReadingMode(refreshed.container)).toBe(true)
+  })
+
+  it('an in-place ID assignment WITHOUT the create signal never writes (poison regression)', () => {
+    // Browser-back (or sidebar click) from /new to an EXISTING item: the same
+    // editor instance renders once with the existing item's ID before the
+    // parent's corrective contentKey remount. The draft's toggled-on mode must
+    // NOT be written under that item — without the itemIdWasJustCreated gate,
+    // this poisoned the existing item's remembered mode.
+    const { rerender, unmount } = render(<CodeMirrorEditor value="# draft" onChange={() => {}} />)
+
+    toggleReadingModeViaShortcut()
+
+    rerender(<CodeMirrorEditor value="# draft" onChange={() => {}} itemId="existing-note" />)
+    expect(readReadingMode('existing-note')).toBe(false)
+    expect(localStorage.getItem('tiddly:reading-mode')).toBeNull()
+    unmount()
+
+    // After the corrective remount (fresh mount), the item opens per its own
+    // (absent) entry — markdown — and the cache is still clean.
+    const remounted = render(<CodeMirrorEditor value="# note" onChange={() => {}} itemId="existing-note" />)
+    expect(isReadingMode(remounted.container)).toBe(false)
+    expect(localStorage.getItem('tiddly:reading-mode')).toBeNull()
+  })
+
+  it('a markdown-mode create writes nothing when the ID appears', () => {
+    const { rerender } = render(<CodeMirrorEditor value="# hi" onChange={() => {}} />)
+    rerender(<CodeMirrorEditor value="# hi" onChange={() => {}} itemId="saved-id" itemIdWasJustCreated />)
+    expect(readReadingMode('saved-id')).toBe(false)
+    expect(localStorage.getItem('tiddly:reading-mode')).toBeNull()
+  })
+
+  it('a document switch (remount with a new ID) does not cross-write entries', () => {
+    writeReadingMode('doc-a', true)
+
+    const first = render(<CodeMirrorEditor value="# a" onChange={() => {}} itemId="doc-a" />)
+    expect(isReadingMode(first.container)).toBe(true)
+    first.unmount()
+
+    // Parents remount via contentKey on document switch; the new document must
+    // seed from ITS OWN entry (miss → markdown), not inherit doc-a's mode.
+    const second = render(<CodeMirrorEditor value="# b" onChange={() => {}} itemId="doc-b" />)
+    expect(isReadingMode(second.container)).toBe(false)
+    expect(readReadingMode('doc-b')).toBe(false)
+    expect(readReadingMode('doc-a')).toBe(true)
+  })
+})
+
+describe('CodeMirrorEditor — disabled editor (e.g. deleted item view)', () => {
+  // The shortcut must not mutate the persisted preference on a disabled view:
+  // effectiveReadingMode masks the flip visually, so an unguarded toggle would
+  // silently change durable state. Both persistence directions matter — an
+  // insert (miss → entry) and a delete (entry → gone) are each half the bug.
+  it('the shortcut cannot INSERT an entry (miss stays miss, mode unchanged)', () => {
+    const { container } = render(
+      <CodeMirrorEditor value="# hi" onChange={() => {}} itemId="deleted-1" disabled />,
+    )
+    toggleReadingModeViaShortcut()
+
+    expect(isReadingMode(container)).toBe(false)
+    expect(readReadingMode('deleted-1')).toBe(false)
+    expect(localStorage.getItem('tiddly:reading-mode')).toBeNull()
+  })
+
+  it('the shortcut cannot DELETE an existing entry', () => {
+    writeReadingMode('deleted-2', true)
+    render(<CodeMirrorEditor value="# hi" onChange={() => {}} itemId="deleted-2" disabled />)
+
+    toggleReadingModeViaShortcut()
+    expect(readReadingMode('deleted-2')).toBe(true)
+  })
+})
+
+describe('CodeMirrorEditor — reader mode (public view) cache isolation', () => {
+  it('seeds from defaultReadingMode, ignoring the cache', () => {
+    // No cache entry, yet reader mode opens rendered (notes/bookmarks default).
+    const rendered = render(
+      <CodeMirrorEditor value="# hi" onChange={() => {}} readerMode defaultReadingMode itemId="pub-1" />,
+    )
+    expect(isReadingMode(rendered.container)).toBe(true)
+    rendered.unmount()
+
+    // Cache entry present, yet the prompt-style default (raw source) wins.
+    writeReadingMode('pub-2', true)
+    const raw = render(
+      <CodeMirrorEditor value="{{ x }}" onChange={() => {}} readerMode itemId="pub-2" />,
+    )
+    expect(isReadingMode(raw.container)).toBe(false)
+  })
+
+  it('a visitor toggling the mode does not write to the cache', () => {
+    const { container } = render(
+      <CodeMirrorEditor value="# hi" onChange={() => {}} readerMode defaultReadingMode itemId="pub-3" />,
+    )
+    expect(isReadingMode(container)).toBe(true)
+
+    toggleReadingModeViaShortcut() // off
+    toggleReadingModeViaShortcut() // back on — an insert would happen here if not isolated
+    expect(localStorage.getItem('tiddly:reading-mode')).toBeNull()
+  })
+})

--- a/frontend/src/components/CodeMirrorEditorTocReadingMode.test.tsx
+++ b/frontend/src/components/CodeMirrorEditorTocReadingMode.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Tests for the ToC in reading mode: the scroll-to-line branch that targets
+ * the rendered Milkdown DOM (resolution logic itself is covered in
+ * utils/headingNavigation.test.ts — this exercises the wiring), the ToC
+ * toggle/shortcut being available in reading mode, and the command menu
+ * intentionally staying closed there (it's the guard keeping mutating
+ * commands away from the hidden CodeMirror doc).
+ *
+ * jsdom reports a non-Mac platform, so Mod maps to ctrlKey.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { act } from 'react'
+import type { MutableRefObject } from 'react'
+import { CodeMirrorEditor } from './CodeMirrorEditor'
+import { writeReadingMode } from '../utils/readingModeCache'
+import { useRightSidebarStore } from '../stores/rightSidebarStore'
+
+// Render a minimal reading view: top-level h1 per `# ` line, inside the
+// .milkdown-wrapper the scroll branch queries. Enough DOM for wiring tests.
+vi.mock('./MilkdownEditor', () => ({
+  MilkdownEditor: ({ value }: { value: string }) => (
+    <div className="milkdown-wrapper">
+      <div className="milkdown">
+        {value
+          .split('\n')
+          .filter((line) => line.startsWith('# '))
+          .map((line, i) => (
+            <h1 key={i}>{line.slice(2)}</h1>
+          ))}
+      </div>
+    </div>
+  ),
+}))
+
+const CONTENT = '# Alpha\n\ntext\n\n# Beta'
+
+beforeEach(() => {
+  localStorage.clear()
+  useRightSidebarStore.setState({ activePanel: null })
+  // jsdom doesn't implement scrollIntoView.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+function dispatch(init: KeyboardEventInit): void {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }))
+  })
+}
+
+/** Mount in reading mode (seeded via the per-item cache) with a scroll ref. */
+function renderReading(props: Record<string, unknown> = {}): {
+  container: HTMLElement
+  scrollRef: MutableRefObject<((line: number) => void) | null>
+} {
+  writeReadingMode('item-1', true)
+  const scrollRef: MutableRefObject<((line: number) => void) | null> = { current: null }
+  const { container } = render(
+    <CodeMirrorEditor value={CONTENT} onChange={() => {}} itemId="item-1" scrollToLineRef={scrollRef} {...props} />,
+  )
+  expect(container.querySelector('[class*="milkdown-wrapper"]')).not.toBeNull()
+  return { container, scrollRef }
+}
+
+describe('CodeMirrorEditor — ToC navigation in reading mode', () => {
+  it('scrolls the rendered heading, without focusing the hidden CodeMirror', () => {
+    const { container, scrollRef } = renderReading()
+
+    act(() => scrollRef.current?.(5)) // line of "# Beta"
+
+    const beta = Array.from(container.querySelectorAll('h1')).find((h) => h.textContent === 'Beta')
+    expect(beta).toBeDefined()
+    expect(beta?.scrollIntoView).toHaveBeenCalledWith({ block: 'start' })
+    expect(document.activeElement?.closest('.cm-content')).toBeNull()
+  })
+
+  it('a line with no matching heading is a safe no-op', () => {
+    const { scrollRef } = renderReading()
+    act(() => scrollRef.current?.(3)) // "text" line
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it('markdown mode still scrolls CodeMirror (focus moves into the editor)', () => {
+    const scrollRef: MutableRefObject<((line: number) => void) | null> = { current: null }
+    render(<CodeMirrorEditor value={CONTENT} onChange={() => {}} scrollToLineRef={scrollRef} />)
+
+    act(() => scrollRef.current?.(5))
+
+    expect(document.activeElement?.closest('.cm-content')).not.toBeNull()
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+  })
+})
+
+describe('CodeMirrorEditor — ToC control in reading mode', () => {
+  it('the ToC toolbar button renders in reading mode when enabled', () => {
+    const { container: withToc } = renderReading({ showTocToggle: true })
+    writeReadingMode('item-2', true)
+    const { container: withoutToc } = render(
+      <CodeMirrorEditor value={CONTENT} onChange={() => {}} itemId="item-2" />,
+    )
+    expect(withToc.querySelectorAll('button').length).toBe(
+      withoutToc.querySelectorAll('button').length + 1,
+    )
+  })
+
+  it('the shortcut toggles the ToC panel while reading mode is on', () => {
+    renderReading({ showTocToggle: true })
+
+    dispatch({ code: 'KeyT', altKey: true })
+    expect(useRightSidebarStore.getState().activePanel).toBe('toc')
+
+    dispatch({ code: 'KeyT', altKey: true })
+    expect(useRightSidebarStore.getState().activePanel).toBeNull()
+  })
+
+  it('the shortcut rejects a disabled editor, matching the disabled toolbar button', () => {
+    // Deleted-item views expose showTocToggle with a disabled editor; the
+    // shortcut must not act where the visible control says it can't.
+    render(
+      <CodeMirrorEditor value={CONTENT} onChange={() => {}} showTocToggle disabled />,
+    )
+
+    dispatch({ code: 'KeyT', altKey: true })
+    expect(useRightSidebarStore.getState().activePanel).toBeNull()
+  })
+
+  it('the command menu stays closed in reading mode (mutation guard)', () => {
+    renderReading({ showTocToggle: true })
+
+    dispatch({ code: 'Slash', ctrlKey: true })
+    expect(screen.queryByRole('listbox', { name: 'Editor commands' })).toBeNull()
+  })
+
+  it('the command menu still opens in markdown mode', () => {
+    render(<CodeMirrorEditor value={CONTENT} onChange={() => {}} />)
+
+    dispatch({ code: 'Slash', ctrlKey: true })
+    expect(screen.getByRole('listbox', { name: 'Editor commands' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ContentEditor.tsx
+++ b/frontend/src/components/ContentEditor.tsx
@@ -118,6 +118,13 @@ interface ContentEditorProps {
   readerMode?: boolean
   /** In reader mode, default to the rendered reading view (prose) vs. raw source (prompts). */
   defaultReadingMode?: boolean
+  /** Item ID for per-item reading-mode persistence (undefined during create). */
+  itemId?: string
+  /**
+   * Asserts that an in-place itemId assignment continues a create→edit save
+   * (see CodeMirrorEditor). Parents derive this from their fromCreate contract.
+   */
+  itemIdWasJustCreated?: boolean
   /** Whether there's an error */
   hasError?: boolean
   /** Minimum height for the editor */
@@ -177,6 +184,8 @@ export function ContentEditor({
   readOnly = false,
   readerMode = false,
   defaultReadingMode = false,
+  itemId,
+  itemIdWasJustCreated = false,
   hasError = false,
   minHeight = '200px',
   placeholder = 'Write your content in markdown...',
@@ -268,6 +277,8 @@ export function ContentEditor({
           readOnly={readerMode ? true : readOnly}
           readerMode={readerMode}
           defaultReadingMode={defaultReadingMode}
+          itemId={itemId}
+          itemIdWasJustCreated={itemIdWasJustCreated}
           minHeight={minHeight}
           placeholder={placeholder}
           wrapText={wrapText}

--- a/frontend/src/components/ContentEditorReaderMode.test.tsx
+++ b/frontend/src/components/ContentEditorReaderMode.test.tsx
@@ -12,6 +12,8 @@ interface RecordedProps {
   defaultReadingMode?: boolean
   disabled?: boolean
   readOnly?: boolean
+  itemId?: string
+  itemIdWasJustCreated?: boolean
 }
 let lastProps: RecordedProps = {}
 
@@ -25,13 +27,16 @@ vi.mock('./CodeMirrorEditor', () => ({
 describe('ContentEditor — reader mode', () => {
   it('hides the character counter and drives the editor read-only + selectable', () => {
     render(
-      <ContentEditor value="Hello" onChange={() => {}} maxLength={1000} readerMode defaultReadingMode />
+      <ContentEditor value="Hello" onChange={() => {}} maxLength={1000} readerMode defaultReadingMode itemId="n1" />
     )
     expect(screen.queryByText(/\/\s*1,000/)).toBeNull() // no "5 / 1,000" counter
     expect(lastProps.readerMode).toBe(true)
     expect(lastProps.defaultReadingMode).toBe(true)
     expect(lastProps.disabled).toBe(false)
     expect(lastProps.readOnly).toBe(true)
+    // itemId + create signal thread through for per-item reading-mode persistence.
+    expect(lastProps.itemId).toBe('n1')
+    expect(lastProps.itemIdWasJustCreated).toBe(false)
   })
 
   it('shows the counter and respects disabled when not in reader mode', () => {

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -9,13 +9,21 @@ import type { ReactNode } from 'react'
  * - Terms of Service link
  * - License information (GitHub link)
  * - Copyright notice
+ *
+ * Layout switches on the footer's OWN width (`@container` + `@3xl:` variants),
+ * not the viewport. Viewport media queries were wrong wherever the footer sits
+ * in a box narrower than the window — with the public share pages' ToC sidebar
+ * open, the fixed-height single-row desktop layout stayed active while the
+ * links wrapped, clipping them. `@3xl` is 768px, the same threshold the old
+ * `md:` variants used, so full-width pages are unchanged.
  */
 export function Footer(): ReactNode {
   return (
-    <footer className="bg-white border-t border-gray-100 mt-auto py-2 md:py-0 md:h-12 shrink-0 flex items-center">
+    <footer className="@container bg-white border-t border-gray-100 mt-auto py-2 @3xl:py-0 @3xl:h-12 shrink-0 flex items-center">
       <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12 w-full">
-        <div className="flex flex-col md:flex-row items-center justify-between gap-1 md:gap-0">
-          <div className="flex items-center space-x-6 text-sm text-gray-500">
+        <div className="flex flex-col @3xl:flex-row items-center justify-between gap-1 @3xl:gap-0">
+          {/* gap-x (not space-x) so wrapped rows stay evenly spaced. */}
+          <div className="flex flex-wrap justify-center items-center gap-x-6 gap-y-1 text-sm text-gray-500">
             <Link
               to="/docs"
               className="hover:text-gray-900 transition-colors"
@@ -51,7 +59,7 @@ export function Footer(): ReactNode {
               GitHub
             </a>
           </div>
-          <div className="text-sm text-gray-400">
+          <div className="text-sm text-gray-400 text-center">
             © 2025 Tiddly. Operated by Shane Kercheval.
           </div>
         </div>

--- a/frontend/src/components/HistorySidebar.test.tsx
+++ b/frontend/src/components/HistorySidebar.test.tsx
@@ -34,6 +34,8 @@ vi.mock('../stores/rightSidebarStore', () => ({
   MIN_CONTENT_WIDTH: 400,
   computeMaxWidth: (innerWidth: number, leftSidebarWidth: number) =>
     Math.max(300, innerWidth - leftSidebarWidth - 400),
+  getEffectiveSidebarWidth: (storeWidth: number, maximized: boolean, maxWidth: number) =>
+    maximized ? maxWidth : Math.min(storeWidth, maxWidth),
 }))
 
 function createEntry(overrides: Partial<HistoryEntry> = {}): HistoryEntry {

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -126,6 +126,8 @@ vi.mock('../stores/rightSidebarStore', () => ({
   // Used by measureMaxSidebarWidth (via Layout's getRightSidebarMargin).
   computeMaxWidth: (innerWidth: number, leftSidebarWidth: number) =>
     Math.max(280, innerWidth - leftSidebarWidth - 600),
+  getEffectiveSidebarWidth: (storeWidth: number, maximized: boolean, maxWidth: number) =>
+    maximized ? maxWidth : Math.min(storeWidth, maxWidth),
 }))
 
 function setWindowWidth(width: number): void {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,7 +11,7 @@ import { useSidebarStore } from '../stores/sidebarStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useFiltersStore } from '../stores/filtersStore'
 import { useTagsStore } from '../stores/tagsStore'
-import { useRightSidebarStore } from '../stores/rightSidebarStore'
+import { useRightSidebarStore, getEffectiveSidebarWidth } from '../stores/rightSidebarStore'
 import { useGlobalShortcuts } from '../shortcuts/useGlobalShortcuts'
 import type { ShortcutId } from '../shortcuts/registry'
 import { useLimits } from '../hooks/useLimits'
@@ -166,10 +166,8 @@ export function Layout(): ReactNode {
   // Uses the same logic as sidebar components to ensure they stay in sync
   const getRightSidebarMargin = (): number => {
     if (!rightSidebarOpen || !isDesktop || !isDetailPage) return 0
-    const maxWidth = measureMaxSidebarWidth()
-    // When maximized the sidebar fills the max; otherwise clamp the stored width
-    // to it. Mirrors useResizableSidebar so margin and sidebar width agree.
-    return rightSidebarMaximized ? maxWidth : Math.min(rightSidebarWidth, maxWidth)
+    // Shared clamp/maximize math so margin and sidebar width agree.
+    return getEffectiveSidebarWidth(rightSidebarWidth, rightSidebarMaximized, measureMaxSidebarWidth())
   }
 
   // Single source of truth for the content offset. Exposed as a CSS variable so

--- a/frontend/src/components/MilkdownEditor.tsx
+++ b/frontend/src/components/MilkdownEditor.tsx
@@ -642,7 +642,12 @@ function createCalloutPlugin(): Plugin {
           decorations.push(
             Decoration.inline(
               inlineBase + marker.markerStart,
-              inlineBase + marker.markerEnd,
+              // With a custom title, the hidden span extends through the
+              // whitespace up to the title — otherwise the stray space between
+              // the hidden marker and the block-displayed title strands in its
+              // own anonymous line box, rendering as a blank line above the
+              // title row.
+              inlineBase + (marker.title === null ? marker.markerEnd : marker.titleStart),
               // Without a custom title the marker doubles as the title row:
               // CSS hides its text and renders the icon + the variant label
               // via content: attr(data-callout-label) — so the shared

--- a/frontend/src/components/MilkdownEditor.tsx
+++ b/frontend/src/components/MilkdownEditor.tsx
@@ -173,6 +173,7 @@ import {
 } from './editor/EditorToolbarIcons'
 import { JINJA_VARIABLE, JINJA_IF_BLOCK, JINJA_IF_BLOCK_TRIM } from './editor/jinjaTemplates'
 import { cleanMdastTree } from '../utils/cleanMarkdown'
+import { matchCalloutMarker, CALLOUT_LABELS } from '../utils/callouts'
 import { createLinkExitOnSpacePlugin } from '../utils/linkExitOnSpacePlugin'
 import { shouldHandleEmptySpaceClick, wasEditorFocused } from '../utils/editorUtils'
 import { findCodeBlockNode, findLinkBoundaries, normalizeUrl } from '../utils/milkdownHelpers'
@@ -593,6 +594,87 @@ function createPlaceholderPlugin(placeholder: string): Plugin {
 }
 
 /**
+ * Create a ProseMirror plugin that renders callout blockquotes
+ * (`> [!WARNING] ...` and friends — grammar in utils/callouts.ts).
+ *
+ * Decoration-only, deliberately: no schema node, no remark extension. This
+ * component's single production consumer is the always-readOnly reading-mode
+ * preview inside CodeMirrorEditor, so there is no editing or serialization
+ * path to protect — a real schema node + remark parser/serializer would be
+ * several times the code and put markdown round-tripping at risk for zero
+ * benefit.
+ *
+ * Span-scoped, deliberately: the canonical multi-line form
+ * `> [!WARNING]` + `> body` parses as ONE paragraph (marker and first body
+ * line separated by a soft break), so decorating "the marker paragraph" as a
+ * title would style body text as title. Instead: a node decoration on the
+ * blockquote (variant class) plus inline decorations covering exactly the
+ * marker span and, when present, the custom-title span — offsets from the
+ * shared matcher. CSS (index.css) hides the raw marker and renders the
+ * icon-and-title treatment; body text keeps normal styling.
+ */
+function createCalloutPlugin(): Plugin {
+  return new Plugin({
+    props: {
+      decorations(state) {
+        const decorations: Decoration[] = []
+
+        state.doc.descendants((node, pos) => {
+          if (node.type.name !== 'blockquote') return true
+          const paragraph = node.firstChild
+          // Marker must start the blockquote's first paragraph — anything else
+          // (or an unknown keyword) falls through to a plain blockquote.
+          if (!paragraph || paragraph.type.name !== 'paragraph') return false
+          const firstText = paragraph.firstChild
+          if (!firstText || !firstText.isText) return false
+          const marker = matchCalloutMarker(firstText.text ?? '')
+          if (!marker) return false
+
+          decorations.push(
+            Decoration.node(pos, pos + node.nodeSize, {
+              class: `callout callout-${marker.variant}`,
+            }),
+          )
+          // Inline content of the first paragraph starts at pos + 2
+          // (+1 into the blockquote, +1 into the paragraph); the marker and
+          // title spans both live in the paragraph's first text node.
+          const inlineBase = pos + 2
+          decorations.push(
+            Decoration.inline(
+              inlineBase + marker.markerStart,
+              inlineBase + marker.markerEnd,
+              // Without a custom title the marker doubles as the title row:
+              // CSS hides its text and renders the icon + the variant label
+              // via content: attr(data-callout-label) — so the shared
+              // CALLOUT_LABELS constant, not the stylesheet, owns the text.
+              marker.title === null
+                ? {
+                    class: 'callout-marker callout-marker-labeled',
+                    'data-callout-label': CALLOUT_LABELS[marker.variant],
+                  }
+                : { class: 'callout-marker' },
+            ),
+          )
+          if (marker.title !== null) {
+            decorations.push(
+              Decoration.inline(inlineBase + marker.titleStart, inlineBase + marker.titleEnd, {
+                class: 'callout-title',
+              }),
+            )
+          }
+          // Don't descend — nested-blockquote callouts aren't supported.
+          return false
+        })
+
+        return decorations.length > 0
+          ? DecorationSet.create(state.doc, decorations)
+          : DecorationSet.empty
+      },
+    },
+  })
+}
+
+/**
  * Check if the selection is inside a code_block node.
  */
 function isInCodeBlock(state: EditorState): boolean {
@@ -849,6 +931,9 @@ function MilkdownEditorInner({
   // Create code block copy button plugin
   const codeBlockCopyPluginSlice = $prose(() => createCodeBlockCopyPlugin())
 
+  // Create callout decoration plugin (`> [!WARNING]` blockquotes)
+  const calloutPluginSlice = $prose(() => createCalloutPlugin())
+
   // Create list keymap plugin with Milkdown's $prose utility
   // This plugin handles Tab/Shift+Tab for list indentation and Backspace at list item start
   const listKeymapPluginSlice = $prose((ctx) => {
@@ -935,6 +1020,7 @@ function MilkdownEditorInner({
       .use(remarkCleanMarkdown)
       .use(placeholderPluginSlice)
       .use(codeBlockCopyPluginSlice)
+      .use(calloutPluginSlice)
       .use(listKeymapPluginSlice)
       .use(linkClickPluginSlice)
       .use(linkExitOnSpacePluginSlice),

--- a/frontend/src/components/MilkdownEditorCallouts.test.tsx
+++ b/frontend/src/components/MilkdownEditorCallouts.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Fixture tests for callout rendering in the reading-mode Milkdown preview —
+ * asserting against the ACTUAL Milkdown-parsed document, not a mocked shape.
+ *
+ * This is the architecture gate for the span-scoped decoration design: the
+ * canonical multi-line form `> [!WARNING]` + `> body` parses as ONE paragraph
+ * (marker and body separated by a soft break), so these tests specifically
+ * verify that body text is NOT swept into the marker/title treatment.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { MilkdownEditor } from './MilkdownEditor'
+import { markdownStyleExtension } from '../utils/markdownStyleExtension'
+
+async function renderPreview(value: string): Promise<HTMLElement> {
+  const { container } = render(<MilkdownEditor value={value} onChange={() => {}} readOnly={true} />)
+  await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeTruthy())
+  return container
+}
+
+describe('MilkdownEditor — callout rendering (reading mode)', () => {
+  it('canonical soft-break form: marker isolated, body keeps body styling', async () => {
+    const container = await renderPreview('> [!WARNING]\n> Body text here')
+
+    const blockquote = container.querySelector('blockquote')
+    expect(blockquote?.classList.contains('callout')).toBe(true)
+    expect(blockquote?.classList.contains('callout-warning')).toBe(true)
+
+    // The marker span covers exactly the raw marker (CSS hides it and renders
+    // icon + label in its place)...
+    const marker = container.querySelector('.callout-marker')
+    expect(marker?.textContent).toBe('[!WARNING]')
+    expect(marker?.classList.contains('callout-marker-labeled')).toBe(true)
+
+    // ...and the body — same paragraph, after the soft break — is untouched.
+    expect(blockquote?.textContent).toContain('Body text here')
+    expect(marker?.textContent).not.toContain('Body')
+    expect(container.querySelector('.callout-title')).toBeNull()
+  })
+
+  it('custom title: title span styled, marker unlabeled, body untouched', async () => {
+    const container = await renderPreview('> [!note] My Title\n> Body text')
+
+    expect(container.querySelector('blockquote')?.classList.contains('callout-note')).toBe(true)
+    const title = container.querySelector('.callout-title')
+    expect(title?.textContent).toBe('My Title')
+    const marker = container.querySelector('.callout-marker')
+    expect(marker?.textContent).toBe('[!note]')
+    expect(marker?.classList.contains('callout-marker-labeled')).toBe(false)
+    expect(title?.textContent).not.toContain('Body')
+  })
+
+  it('blank-line-separated body (marker in its own paragraph)', async () => {
+    const container = await renderPreview('> [!TIP]\n>\n> Body paragraph')
+
+    expect(container.querySelector('blockquote')?.classList.contains('callout-tip')).toBe(true)
+    expect(container.querySelector('.callout-marker')?.textContent).toBe('[!TIP]')
+    expect(container.querySelector('blockquote')?.textContent).toContain('Body paragraph')
+  })
+
+  it('marker alone', async () => {
+    const container = await renderPreview('> [!important]')
+
+    expect(container.querySelector('blockquote')?.classList.contains('callout-important')).toBe(true)
+    expect(container.querySelector('.callout-marker-labeled')).not.toBeNull()
+  })
+
+  it('aliases and bang-less markers resolve (grammar spot-check; full coverage in callouts.test)', async () => {
+    const danger = await renderPreview('> [danger]\n> x')
+    expect(danger.querySelector('blockquote')?.classList.contains('callout-caution')).toBe(true)
+
+    const hint = await renderPreview('> [Hint] titled')
+    expect(hint.querySelector('blockquote')?.classList.contains('callout-tip')).toBe(true)
+  })
+
+  it('unknown keyword renders a plain blockquote', async () => {
+    const container = await renderPreview('> [!FOO]\n> Body')
+    const blockquote = container.querySelector('blockquote')
+    expect(blockquote).not.toBeNull()
+    expect(blockquote?.classList.contains('callout')).toBe(false)
+    expect(container.querySelector('.callout-marker')).toBeNull()
+  })
+
+  it('a blockquote with no marker is unaffected', async () => {
+    const container = await renderPreview('> Just a quote')
+    expect(container.querySelector('blockquote')?.classList.contains('callout')).toBe(false)
+  })
+
+  it('a marker not at the start of the first paragraph is not a callout', async () => {
+    const container = await renderPreview('> Text before [!note]')
+    expect(container.querySelector('blockquote')?.classList.contains('callout')).toBe(false)
+  })
+
+  it('the labeled marker carries its display label from the shared constant', async () => {
+    const container = await renderPreview('> [!important]')
+    // CSS renders the label via content: attr(data-callout-label), so the
+    // shared CALLOUT_LABELS constant is the real source of the visible text.
+    expect(container.querySelector('.callout-marker-labeled')?.getAttribute('data-callout-label')).toBe('Important')
+  })
+})
+
+describe('cross-pipeline parity — contiguous explicitly-quoted lines', () => {
+  // Narrow scope by design: this pins agreement between the editor's
+  // line-model and the rendered view for CONTIGUOUS `>`-prefixed lines only.
+  // It is not evidence of general structural parity (indented quotes, tilde
+  // fences, and lazy continuation remain editor line-model limitations — see
+  // the editor-improvements plan).
+  const views: EditorView[] = []
+  afterEach(() => {
+    views.forEach((v) => v.destroy())
+    views.length = 0
+  })
+
+  it('a mid-quote marker yields ONE note callout in both the editor and the reading view', async () => {
+    const doc = '> [!note]\n> [!caution]\n> body'
+
+    // Editor (CodeMirror line model)
+    const parent = document.createElement('div')
+    document.body.appendChild(parent)
+    const view = new EditorView({
+      state: EditorState.create({ doc, extensions: [markdownStyleExtension] }),
+      parent,
+    })
+    views.push(view)
+    const editorLines = Array.from(view.dom.querySelectorAll('.cm-line')).map((el) => el.className)
+    expect(editorLines.every((c) => c.includes('cm-md-callout-note'))).toBe(true)
+    expect(view.dom.querySelector('[class*="cm-md-callout-caution"]')).toBeNull()
+
+    // Reading view (Milkdown)
+    const rendered = await renderPreview(doc)
+    const blockquotes = rendered.querySelectorAll('blockquote')
+    expect(blockquotes).toHaveLength(1)
+    expect(blockquotes[0].classList.contains('callout-note')).toBe(true)
+    expect(rendered.querySelector('.callout-caution')).toBeNull()
+    // The second marker is literal body text in both pipelines.
+    expect(blockquotes[0].textContent).toContain('[!caution]')
+  })
+})

--- a/frontend/src/components/MilkdownEditorCallouts.test.tsx
+++ b/frontend/src/components/MilkdownEditorCallouts.test.tsx
@@ -47,7 +47,11 @@ describe('MilkdownEditor — callout rendering (reading mode)', () => {
     const title = container.querySelector('.callout-title')
     expect(title?.textContent).toBe('My Title')
     const marker = container.querySelector('.callout-marker')
-    expect(marker?.textContent).toBe('[!note]')
+    // The hidden marker span absorbs the whitespace before the title — a bare
+    // text node between the hidden span and the block-displayed title would
+    // strand in its own line box and render as a blank line above the title.
+    expect(marker?.textContent).toBe('[!note] ')
+    expect(title?.previousSibling).toBe(marker)
     expect(marker?.classList.contains('callout-marker-labeled')).toBe(false)
     expect(title?.textContent).not.toContain('Body')
   })

--- a/frontend/src/components/Note.tsx
+++ b/frontend/src/components/Note.tsx
@@ -1010,6 +1010,8 @@ export function Note({
           readOnly={isSaving}
           readerMode={readOnly}
           defaultReadingMode={readOnly}
+          itemId={note?.id}
+          itemIdWasJustCreated={fromCreate}
           hasError={!!errors.content}
           minHeight="200px"
           placeholder="Write your note in markdown..."

--- a/frontend/src/components/Prompt.tsx
+++ b/frontend/src/components/Prompt.tsx
@@ -1266,6 +1266,8 @@ export function Prompt({
             disabled={isReadOnly}
             readOnly={isSaving}
             readerMode={readOnly}
+            itemId={prompt?.id}
+            itemIdWasJustCreated={fromCreate}
             hasError={!!errors.content}
             minHeight="300px"
             placeholder="Write your template in markdown with Jinja2 syntax..."

--- a/frontend/src/components/PublicItemShell.tsx
+++ b/frontend/src/components/PublicItemShell.tsx
@@ -6,12 +6,14 @@
  * not-found state, the "archived" banner, and the auth-aware Save-a-copy bar —
  * so the per-type page wrappers stay thin (fetch + adapt + render).
  */
+import { useEffect } from 'react'
 import type { ReactNode } from 'react'
 import axios from 'axios'
 import { Link } from 'react-router-dom'
 import { LoadingSpinner } from './ui'
 import { SaveACopy } from './SaveACopy'
 import { useAuthStatus } from '../hooks/useAuthStatus'
+import { useRightSidebarStore } from '../stores/rightSidebarStore'
 
 type PublicItemType = 'bookmarks' | 'notes' | 'prompts'
 
@@ -25,6 +27,14 @@ interface PublicItemShellProps {
   /** Retry the fetch (shown for transient errors). */
   onRetry?: () => void
   isArchived: boolean
+  /**
+   * Whether this item type renders the ToC sidebar (notes/prompts; not
+   * bookmarks — scraped bookmark content is formatting-stripped and has no
+   * headings, see the editor-improvements plan). When false, a stale ToC
+   * panel is closed on mount. (The content offset while the panel is open is
+   * owned by PublicSharedTocLayout, scoped by route.)
+   */
+  tocEnabled?: boolean
   children: ReactNode
 }
 
@@ -36,12 +46,31 @@ export function PublicItemShell({
   error,
   onRetry,
   isArchived,
+  tocEnabled = false,
   children,
 }: PublicItemShellProps): ReactNode {
   // Drives the "what is Tiddly?" blurb, shown only to logged-out visitors who
   // may not recognize the product. (In dev mode the user is always
   // "authenticated", so the blurb only appears against a real signed-in session.)
   const { isAuthenticated, isLoading: authLoading } = useAuthStatus()
+
+  const setActivePanel = useRightSidebarStore((state) => state.setActivePanel)
+
+  // The ToC panel is only meaningful on shared pages that render it. Close a
+  // stale one on mount for types without ToC support (mirrors BookmarkDetail's
+  // close-on-mount), and on unmount so navigating within the public chrome to
+  // pricing/changelog — which share the store but render no sidebar — doesn't
+  // leave an orphaned open panel behind.
+  useEffect(() => {
+    if (!tocEnabled && useRightSidebarStore.getState().activePanel === 'toc') {
+      setActivePanel(null)
+    }
+    return () => {
+      if (useRightSidebarStore.getState().activePanel === 'toc') {
+        setActivePanel(null)
+      }
+    }
+  }, [tocEnabled, setActivePanel])
 
   if (isLoading) {
     return (

--- a/frontend/src/components/PublicPageLayout.tsx
+++ b/frontend/src/components/PublicPageLayout.tsx
@@ -6,49 +6,71 @@ import { useRightSidebarStore } from '../stores/rightSidebarStore'
 import { useEffectiveSidebarMetrics } from '../hooks/useResizableSidebar'
 
 /**
- * Layouts for standalone public pages (changelog, roadmap, pricing, shared
- * items). Split into shared chrome + two content variants so header/footer
- * stay single-sourced while the shared note/prompt routes get their own
- * content geometry (the ToC sidebar margin):
+ * Layouts for standalone public pages. Two route-level variants sharing one
+ * chrome component, so header/footer stay single-sourced:
  *
- *   PublicChromeLayout            — PublicHeader + <Outlet/> + Footer
- *   ├─ PublicContentLayout        — standard centered main
- *   │    (changelog, roadmap, pricing, shared bookmarks — no ToC)
- *   └─ PublicSharedTocLayout      — sidebar-margined, then centered, main
- *        (shared notes and prompts — the ToC-capable pages)
+ *   PublicPageLayout       — changelog, roadmap, pricing, shared bookmarks
+ *   PublicSharedTocLayout  — shared notes/prompts (the ToC-capable pages)
+ *
+ * Splitting at the route level (rather than reacting to sidebar state on every
+ * public page) keeps the no-ToC pages structurally incapable of picking up a
+ * sidebar margin — nothing to flash before an effect could clean it up.
  */
 
-export function PublicChromeLayout(): ReactNode {
+interface PublicChromeProps {
+  children: ReactNode
+  /** Right offset reserved for an open sidebar; shrinks header, content, and footer together. */
+  marginRight?: number
+}
+
+function PublicChrome({ children, marginRight = 0 }: PublicChromeProps): ReactNode {
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    // The offset lives on the OUTER box so the sticky header and footer shrink
+    // with the content — the app's Layout likewise puts its whole content
+    // column inside the margined element. Offsetting only <main> leaves the
+    // header's right-aligned actions (e.g. "Open app") under the sidebar.
+    <div
+      className="flex min-h-screen flex-col bg-white transition-[margin] duration-200"
+      style={marginRight > 0 ? { marginRight } : undefined}
+    >
       <PublicHeader />
-      <Outlet />
+      {children}
       <Footer />
     </div>
   )
 }
 
 /** Standard centered content area, without a docs sidebar. */
-export function PublicContentLayout(): ReactNode {
+export function PublicPageLayout(): ReactNode {
   return (
-    <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12 sm:px-8 lg:px-12">
-      <Outlet />
-    </main>
+    <PublicChrome>
+      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12 sm:px-8 lg:px-12">
+        <Outlet />
+      </main>
+    </PublicChrome>
   )
 }
 
 /**
- * Content area for the ToC-capable shared pages (notes/prompts). The sidebar
- * margin is applied to the full-width main BEFORE the max-w-5xl centering —
- * applying it inside an already-centered column can only squeeze that column
- * against its fixed left edge (at large sidebar widths content collapsed to
- * ~56px while real viewport space sat unused). Margin-then-center means the
- * content lays out in `viewport − sidebar`, whose 600px floor the sidebar's
- * own max-width math already guarantees (see computeMaxWidth).
+ * The ToC-capable shared pages (notes/prompts). The sidebar offset shrinks the
+ * whole page box, and the content column then centers INSIDE what's left —
+ * offsetting within an already-centered column can only squeeze it against its
+ * fixed left edge (at large sidebar widths content collapsed to ~56px while
+ * real viewport space sat unused).
  *
- * Scoping this layout to exactly the note/prompt shared routes (not shared
- * bookmarks, which have no ToC) makes the bookmark exclusion synchronous —
- * there is no margin logic on that route to flash before an effect cleans up.
+ * Two known width limitations, both recorded in the editor-improvements plan:
+ *
+ * 1. `computeMaxWidth` reserves MIN_CONTENT_WIDTH (600px) for content, but
+ *    floors the sidebar at MIN_SIDEBAR_WIDTH (280px) — so the floor only
+ *    actually holds from ~880px viewport up. Between the 768px desktop
+ *    breakpoint and 880px the content column is 488–599px. (The authenticated
+ *    app shares this squeeze; its editor content narrows the same way.)
+ * 2. Shrinking this box does NOT change PublicHeader's and Footer's `sm:`/`md:`
+ *    breakpoints, which are keyed to the VIEWPORT — so at a wide viewport with
+ *    a maximized sidebar they lay out for the window, not for the ~600px box
+ *    they're in. Unlike (1) this is specific to the public pages: the app never
+ *    renders its footer inside a sidebar-margined layout. Container queries on
+ *    the chrome are the durable fix if it proves visibly cramped.
  */
 export function PublicSharedTocLayout(): ReactNode {
   const tocOpen = useRightSidebarStore((state) => state.activePanel === 'toc')
@@ -57,13 +79,10 @@ export function PublicSharedTocLayout(): ReactNode {
   const marginRight = tocOpen && isDesktop ? effectiveWidth : 0
 
   return (
-    <main
-      className="w-full flex-1 px-6 py-12 sm:px-8 lg:px-12"
-      style={marginRight > 0 ? { marginRight } : undefined}
-    >
-      <div className="mx-auto w-full max-w-5xl">
+    <PublicChrome marginRight={marginRight}>
+      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12 sm:px-8 lg:px-12">
         <Outlet />
-      </div>
-    </main>
+      </main>
+    </PublicChrome>
   )
 }

--- a/frontend/src/components/PublicPageLayout.tsx
+++ b/frontend/src/components/PublicPageLayout.tsx
@@ -2,19 +2,68 @@ import { Outlet } from 'react-router-dom'
 import type { ReactNode } from 'react'
 import { PublicHeader } from './PublicHeader'
 import { Footer } from './Footer'
+import { useRightSidebarStore } from '../stores/rightSidebarStore'
+import { useEffectiveSidebarMetrics } from '../hooks/useResizableSidebar'
 
 /**
- * Layout wrapper for standalone public pages (changelog, roadmap).
- * Renders PublicHeader + content area + Footer, without a docs sidebar.
+ * Layouts for standalone public pages (changelog, roadmap, pricing, shared
+ * items). Split into shared chrome + two content variants so header/footer
+ * stay single-sourced while the shared note/prompt routes get their own
+ * content geometry (the ToC sidebar margin):
+ *
+ *   PublicChromeLayout            — PublicHeader + <Outlet/> + Footer
+ *   ├─ PublicContentLayout        — standard centered main
+ *   │    (changelog, roadmap, pricing, shared bookmarks — no ToC)
+ *   └─ PublicSharedTocLayout      — sidebar-margined, then centered, main
+ *        (shared notes and prompts — the ToC-capable pages)
  */
-export function PublicPageLayout(): ReactNode {
+
+export function PublicChromeLayout(): ReactNode {
   return (
     <div className="flex min-h-screen flex-col bg-white">
       <PublicHeader />
-      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12 sm:px-8 lg:px-12">
-        <Outlet />
-      </main>
+      <Outlet />
       <Footer />
     </div>
+  )
+}
+
+/** Standard centered content area, without a docs sidebar. */
+export function PublicContentLayout(): ReactNode {
+  return (
+    <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12 sm:px-8 lg:px-12">
+      <Outlet />
+    </main>
+  )
+}
+
+/**
+ * Content area for the ToC-capable shared pages (notes/prompts). The sidebar
+ * margin is applied to the full-width main BEFORE the max-w-5xl centering —
+ * applying it inside an already-centered column can only squeeze that column
+ * against its fixed left edge (at large sidebar widths content collapsed to
+ * ~56px while real viewport space sat unused). Margin-then-center means the
+ * content lays out in `viewport − sidebar`, whose 600px floor the sidebar's
+ * own max-width math already guarantees (see computeMaxWidth).
+ *
+ * Scoping this layout to exactly the note/prompt shared routes (not shared
+ * bookmarks, which have no ToC) makes the bookmark exclusion synchronous —
+ * there is no margin logic on that route to flash before an effect cleans up.
+ */
+export function PublicSharedTocLayout(): ReactNode {
+  const tocOpen = useRightSidebarStore((state) => state.activePanel === 'toc')
+  const { effectiveWidth, isDesktop } = useEffectiveSidebarMetrics()
+  // Desktop only: below the breakpoint the sidebar is a full-width overlay.
+  const marginRight = tocOpen && isDesktop ? effectiveWidth : 0
+
+  return (
+    <main
+      className="w-full flex-1 px-6 py-12 sm:px-8 lg:px-12"
+      style={marginRight > 0 ? { marginRight } : undefined}
+    >
+      <div className="mx-auto w-full max-w-5xl">
+        <Outlet />
+      </div>
+    </main>
   )
 }

--- a/frontend/src/components/__tests__/Footer.test.tsx
+++ b/frontend/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * The footer must size its layout from its OWN width, not the viewport.
+ *
+ * Wherever it sits in a box narrower than the window — public share pages with
+ * the ToC sidebar open, the app's sidebar-offset content column — viewport
+ * media queries kept the fixed-height single-row desktop layout active while
+ * the links wrapped, clipping them. jsdom evaluates no CSS, so this pins the
+ * mechanism (container queries) rather than the rendered geometry.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { Footer } from '../Footer'
+
+function renderFooter(): HTMLElement {
+  const { container } = render(
+    <MemoryRouter>
+      <Footer />
+    </MemoryRouter>,
+  )
+  return container.querySelector('footer') as HTMLElement
+}
+
+describe('Footer', () => {
+  it('renders the legal and repository links', () => {
+    renderFooter()
+    for (const name of ['Docs', 'Privacy Policy', 'Terms of Service', 'License', 'GitHub']) {
+      expect(screen.getByRole('link', { name })).toBeInTheDocument()
+    }
+  })
+
+  it('drives its layout from its own width, not the viewport', () => {
+    const footer = renderFooter()
+
+    // Establishes the footer as a query container...
+    expect(footer.className).toMatch(/\B@container\b/)
+    // ...and no descendant may switch layout on a viewport breakpoint.
+    const viewportVariant = /(?:^|\s)(?:sm|md|lg|xl|2xl):(?:flex-|h-|py-|gap-)/
+    for (const el of [footer, ...footer.querySelectorAll('*')]) {
+      expect(el.className).not.toMatch(viewportVariant)
+    }
+  })
+
+  it('lets the link row wrap instead of overflowing a narrow box', () => {
+    // space-x-* leaves wrapped rows unevenly spaced; gap-x/gap-y is the
+    // wrap-safe equivalent.
+    const linkRow = renderFooter().querySelector('a')?.parentElement
+    expect(linkRow?.className).toMatch(/\bflex-wrap\b/)
+    expect(linkRow?.className).not.toMatch(/\bspace-x-/)
+  })
+})

--- a/frontend/src/components/__tests__/PublicPageLayout.test.tsx
+++ b/frontend/src/components/__tests__/PublicPageLayout.test.tsx
@@ -1,19 +1,16 @@
 /**
  * Tests for the public layout family: chrome composition (header/footer,
- * single-sourced across both content variants) and the ToC-capable shared
- * layout's content geometry — the margin is applied to the full-width main
- * BEFORE centering, so content lays out in `viewport − sidebar` (the previous
- * inside-the-centered-column approach collapsed content to ~56px under a
- * maximized sidebar).
+ * single-sourced across both route-level variants) and the ToC-capable shared
+ * layout's geometry — the sidebar offset shrinks the whole page box (header,
+ * content, and footer together) and the content column centers inside what's
+ * left. Offsetting within an already-centered column collapsed content to
+ * ~56px under a maximized sidebar; offsetting only <main> left the header's
+ * right-aligned actions under the sidebar.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
-import {
-  PublicChromeLayout,
-  PublicContentLayout,
-  PublicSharedTocLayout,
-} from '../PublicPageLayout'
+import { PublicPageLayout, PublicSharedTocLayout } from '../PublicPageLayout'
 import { useRightSidebarStore, computeMaxWidth, getEffectiveSidebarWidth, MIN_CONTENT_WIDTH } from '../../stores/rightSidebarStore'
 
 const REAL_INNER_WIDTH = window.innerWidth
@@ -26,22 +23,17 @@ function renderTree(initialPath: string): HTMLElement {
   const router = createMemoryRouter(
     [
       {
-        element: <PublicChromeLayout />,
+        element: <PublicPageLayout />,
         children: [
-          {
-            element: <PublicContentLayout />,
-            children: [
-              { path: '/changelog', element: <div>Changelog Content</div> },
-              { path: '/roadmap', element: <div>Roadmap Content</div> },
-              { path: '/shared/bookmarks/:token', element: <div>Bookmark Content</div> },
-            ],
-          },
-          {
-            element: <PublicSharedTocLayout />,
-            children: [
-              { path: '/shared/notes/:token', element: <div>Note Content</div> },
-            ],
-          },
+          { path: '/changelog', element: <div>Changelog Content</div> },
+          { path: '/roadmap', element: <div>Roadmap Content</div> },
+          { path: '/shared/bookmarks/:token', element: <div>Bookmark Content</div> },
+        ],
+      },
+      {
+        element: <PublicSharedTocLayout />,
+        children: [
+          { path: '/shared/notes/:token', element: <div>Note Content</div> },
         ],
       },
     ],
@@ -50,6 +42,11 @@ function renderTree(initialPath: string): HTMLElement {
 
   const { container } = render(<RouterProvider router={router} />)
   return container
+}
+
+/** The page box the sidebar offset is applied to (chrome wrapper). */
+function pageBox(container: HTMLElement): HTMLElement {
+  return container.firstElementChild as HTMLElement
 }
 
 beforeEach(() => {
@@ -93,43 +90,88 @@ describe('PublicSharedTocLayout — content offset while the ToC is open', () =>
     [1024, false],
     [1440, false],
     [1920, true], // maximized: the collapse case the old geometry failed
-  ])('at %spx (maximized: %s) the main margin equals the effective sidebar width and content keeps the 600px floor', (viewport: number, maximized: boolean) => {
+  ])('at %spx (maximized: %s) the page offset equals the effective sidebar width', (viewport: number, maximized: boolean) => {
     setViewportWidth(viewport)
     useRightSidebarStore.setState({ activePanel: 'toc', maximized })
     const container = renderTree('/shared/notes/tok')
 
     const expected = getEffectiveSidebarWidth(400, maximized, computeMaxWidth(viewport, 0))
-    const main = container.querySelector('main')
-    expect(main?.style.marginRight).toBe(`${expected}px`)
-    // Content region = viewport − sidebar; the store's max-width math reserves
-    // MIN_CONTENT_WIDTH, so readability holds by construction.
-    expect(viewport - expected).toBeGreaterThanOrEqual(MIN_CONTENT_WIDTH)
+    expect(pageBox(container).style.marginRight).toBe(`${expected}px`)
   })
 
-  it('applies no margin below the desktop breakpoint (mobile overlay)', () => {
+  // The MIN_CONTENT_WIDTH reserve is NOT a guarantee across the whole desktop
+  // range: computeMaxWidth floors the sidebar at MIN_SIDEBAR_WIDTH, so between
+  // the 768px desktop breakpoint and 880px the content column is narrower than
+  // the reserve. Pinned explicitly rather than skipped — an earlier matrix
+  // tested only ≥1024px and read as if the floor always held.
+  it.each([
+    [768, 488],
+    [879, 599],
+    [880, 600],
+    [1024, 624],
+  ])('at %spx the remaining content column is %spx', (viewport: number, remaining: number) => {
+    setViewportWidth(viewport)
+    useRightSidebarStore.setState({ activePanel: 'toc' })
+    const container = renderTree('/shared/notes/tok')
+
+    const offset = parseInt(pageBox(container).style.marginRight, 10)
+    expect(viewport - offset).toBe(remaining)
+    // The floor holds only from 880px up.
+    expect(viewport - offset >= MIN_CONTENT_WIDTH).toBe(viewport >= 880)
+  })
+
+  it('offsets the whole page box — header and footer shrink with the content', () => {
+    // Regression guard: offsetting only <main> left the header's right-aligned
+    // actions ("Open app") underneath the sidebar. jsdom computes no layout,
+    // so assert containment — the header and footer must live inside the
+    // offset box, and <main> must not carry a competing offset of its own.
+    setViewportWidth(1440)
+    useRightSidebarStore.setState({ activePanel: 'toc' })
+    const container = renderTree('/shared/notes/tok')
+
+    const box = pageBox(container)
+    expect(box.style.marginRight).not.toBe('')
+    expect(box.contains(screen.getByLabelText('Home'))).toBe(true)
+    expect(box.contains(screen.getByRole('link', { name: 'Privacy Policy' }))).toBe(true)
+    expect(container.querySelector('main')?.style.marginRight ?? '').toBe('')
+  })
+
+  it('the offset box has no explicit width, so the offset shrinks it', () => {
+    // Regression guard for a shipped bug jsdom can't otherwise catch: with
+    // `w-full` (width: 100%) the margin pushed the element into overflow
+    // instead of shrinking it, leaving content underneath the sidebar.
+    setViewportWidth(1440)
+    useRightSidebarStore.setState({ activePanel: 'toc' })
+    const container = renderTree('/shared/notes/tok')
+
+    expect(pageBox(container).className).not.toMatch(/\bw-full\b/)
+  })
+
+  it('applies no offset below the desktop breakpoint (mobile overlay)', () => {
     setViewportWidth(500)
     useRightSidebarStore.setState({ activePanel: 'toc' })
     const container = renderTree('/shared/notes/tok')
 
-    expect(container.querySelector('main')?.style.marginRight).toBe('')
+    expect(pageBox(container).style.marginRight).toBe('')
   })
 
-  it('applies no margin when the panel is closed or is history', () => {
+  it('applies no offset when the panel is closed or is history', () => {
     setViewportWidth(1440)
     useRightSidebarStore.setState({ activePanel: 'history' })
     const container = renderTree('/shared/notes/tok')
 
-    expect(container.querySelector('main')?.style.marginRight).toBe('')
+    expect(pageBox(container).style.marginRight).toBe('')
   })
 
-  it('the standard layout never margins, even with the ToC open (bookmark route)', () => {
-    // Structural exclusion: shared bookmarks live under PublicContentLayout,
-    // which has no margin logic — nothing to flash before an effect cleans up.
+  it('the standard layout never offsets, even with the ToC open (bookmark route)', () => {
+    // Structural exclusion: shared bookmarks live under PublicPageLayout,
+    // which has no offset logic — nothing to flash before an effect cleans up.
     setViewportWidth(1440)
     useRightSidebarStore.setState({ activePanel: 'toc' })
     const container = renderTree('/shared/bookmarks/tok')
 
     expect(screen.getByText('Bookmark Content')).toBeInTheDocument()
-    expect(container.querySelector('main')?.style.marginRight).toBe('')
+    expect(pageBox(container).style.marginRight).toBe('')
+    expect(container.querySelector('main')?.style.marginRight ?? '').toBe('')
   })
 })

--- a/frontend/src/components/__tests__/PublicPageLayout.test.tsx
+++ b/frontend/src/components/__tests__/PublicPageLayout.test.tsx
@@ -1,53 +1,135 @@
-import { describe, it, expect } from 'vitest'
+/**
+ * Tests for the public layout family: chrome composition (header/footer,
+ * single-sourced across both content variants) and the ToC-capable shared
+ * layout's content geometry — the margin is applied to the full-width main
+ * BEFORE centering, so content lays out in `viewport − sidebar` (the previous
+ * inside-the-centered-column approach collapsed content to ~56px under a
+ * maximized sidebar).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
-import { PublicPageLayout } from '../PublicPageLayout'
+import {
+  PublicChromeLayout,
+  PublicContentLayout,
+  PublicSharedTocLayout,
+} from '../PublicPageLayout'
+import { useRightSidebarStore, computeMaxWidth, getEffectiveSidebarWidth, MIN_CONTENT_WIDTH } from '../../stores/rightSidebarStore'
 
-function renderWithLayout(initialPath: string): void {
+const REAL_INNER_WIDTH = window.innerWidth
+
+function setViewportWidth(width: number): void {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width })
+}
+
+function renderTree(initialPath: string): HTMLElement {
   const router = createMemoryRouter(
     [
       {
-        element: <PublicPageLayout />,
+        element: <PublicChromeLayout />,
         children: [
-          { path: '/changelog', element: <div>Changelog Content</div> },
-          { path: '/roadmap', element: <div>Roadmap Content</div> },
+          {
+            element: <PublicContentLayout />,
+            children: [
+              { path: '/changelog', element: <div>Changelog Content</div> },
+              { path: '/roadmap', element: <div>Roadmap Content</div> },
+              { path: '/shared/bookmarks/:token', element: <div>Bookmark Content</div> },
+            ],
+          },
+          {
+            element: <PublicSharedTocLayout />,
+            children: [
+              { path: '/shared/notes/:token', element: <div>Note Content</div> },
+            ],
+          },
         ],
       },
     ],
     { initialEntries: [initialPath] }
   )
 
-  render(<RouterProvider router={router} />)
+  const { container } = render(<RouterProvider router={router} />)
+  return container
 }
 
-describe('PublicPageLayout', () => {
-  it('should render header and footer with content', () => {
-    renderWithLayout('/changelog')
+beforeEach(() => {
+  useRightSidebarStore.setState({ activePanel: null, width: 400, maximized: false })
+})
 
-    // Header
+afterEach(() => {
+  setViewportWidth(REAL_INNER_WIDTH)
+})
+
+describe('public layout chrome (single-sourced across variants)', () => {
+  it('standard content pages render header, footer, and content', () => {
+    renderTree('/changelog')
+
     expect(screen.getByLabelText('Home')).toBeInTheDocument()
     // "Docs" appears in both header and footer
-    const docsLinks = screen.getAllByRole('link', { name: 'Docs' })
-    expect(docsLinks.length).toBe(2)
-
-    // Content
+    expect(screen.getAllByRole('link', { name: 'Docs' }).length).toBe(2)
     expect(screen.getByText('Changelog Content')).toBeInTheDocument()
-
-    // Footer
     expect(screen.getByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument()
   })
 
-  it('should not render docs sidebar', () => {
-    renderWithLayout('/changelog')
+  it('shared ToC pages render the same chrome', () => {
+    renderTree('/shared/notes/tok')
 
-    // No sidebar nav items like "Getting Started" or "AI Integration"
+    expect(screen.getByLabelText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Note Content')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument()
+  })
+
+  it('does not render the docs sidebar', () => {
+    renderTree('/changelog')
     expect(screen.queryByRole('link', { name: 'Getting Started' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'AI Integration' })).not.toBeInTheDocument()
   })
+})
 
-  it('should render roadmap route content', () => {
-    renderWithLayout('/roadmap')
+describe('PublicSharedTocLayout — content offset while the ToC is open', () => {
+  // No left sidebar exists on public pages, so the effective width derives
+  // from the viewport alone — deterministic per width.
+  it.each([
+    [1024, false],
+    [1440, false],
+    [1920, true], // maximized: the collapse case the old geometry failed
+  ])('at %spx (maximized: %s) the main margin equals the effective sidebar width and content keeps the 600px floor', (viewport: number, maximized: boolean) => {
+    setViewportWidth(viewport)
+    useRightSidebarStore.setState({ activePanel: 'toc', maximized })
+    const container = renderTree('/shared/notes/tok')
 
-    expect(screen.getByText('Roadmap Content')).toBeInTheDocument()
+    const expected = getEffectiveSidebarWidth(400, maximized, computeMaxWidth(viewport, 0))
+    const main = container.querySelector('main')
+    expect(main?.style.marginRight).toBe(`${expected}px`)
+    // Content region = viewport − sidebar; the store's max-width math reserves
+    // MIN_CONTENT_WIDTH, so readability holds by construction.
+    expect(viewport - expected).toBeGreaterThanOrEqual(MIN_CONTENT_WIDTH)
+  })
+
+  it('applies no margin below the desktop breakpoint (mobile overlay)', () => {
+    setViewportWidth(500)
+    useRightSidebarStore.setState({ activePanel: 'toc' })
+    const container = renderTree('/shared/notes/tok')
+
+    expect(container.querySelector('main')?.style.marginRight).toBe('')
+  })
+
+  it('applies no margin when the panel is closed or is history', () => {
+    setViewportWidth(1440)
+    useRightSidebarStore.setState({ activePanel: 'history' })
+    const container = renderTree('/shared/notes/tok')
+
+    expect(container.querySelector('main')?.style.marginRight).toBe('')
+  })
+
+  it('the standard layout never margins, even with the ToC open (bookmark route)', () => {
+    // Structural exclusion: shared bookmarks live under PublicContentLayout,
+    // which has no margin logic — nothing to flash before an effect cleans up.
+    setViewportWidth(1440)
+    useRightSidebarStore.setState({ activePanel: 'toc' })
+    const container = renderTree('/shared/bookmarks/tok')
+
+    expect(screen.getByText('Bookmark Content')).toBeInTheDocument()
+    expect(container.querySelector('main')?.style.marginRight).toBe('')
   })
 })

--- a/frontend/src/components/markdown/DocsMarkdown.test.tsx
+++ b/frontend/src/components/markdown/DocsMarkdown.test.tsx
@@ -39,6 +39,30 @@ describe('DocsMarkdown', () => {
     expect(container.querySelector('.callout-info')).toBeNull()
   })
 
+  it('accepts the shared grammar: aliases and bang-less markers collapse to docs variants', () => {
+    // Grammar lives in utils/callouts.ts (shared across all three markdown
+    // pipelines); the five canonical variants map onto the docs' three styles.
+    const danger = renderMarkdown('> [!danger]\n> Careful.').container
+    expect(danger.querySelector('.callout-warning')).not.toBeNull()
+
+    const bangless = renderMarkdown('> [note]\n> FYI.').container
+    expect(bangless.querySelector('.callout-info')).not.toBeNull()
+
+    const important = renderMarkdown('> [!IMPORTANT]\n> Big.').container
+    expect(important.querySelector('.callout-info')).not.toBeNull()
+  })
+
+  it('drops a hard line-break left behind by marker stripping', () => {
+    // `> [!tip]␣␣` (trailing spaces = hard break) parses as [text, break, ...];
+    // removing the empty marker text node must also remove the break, or the
+    // body starts with a stray blank line.
+    const { container } = renderMarkdown('> [!tip]  \n> Body.')
+    const callout = container.querySelector('.callout-tip')
+    expect(callout).not.toBeNull()
+    expect(callout?.querySelector('br')).toBeNull()
+    expect(callout?.textContent).toContain('Body.')
+  })
+
   it('renders fenced code with a copy button', () => {
     renderMarkdown('```bash\necho hello\n```')
     expect(screen.getByText('echo hello')).toBeInTheDocument()

--- a/frontend/src/components/markdown/remarkCallouts.ts
+++ b/frontend/src/components/markdown/remarkCallouts.ts
@@ -15,23 +15,28 @@
  * styling. The title, when present, is just authored bold markdown — no out-of-band
  * metadata — so it round-trips with the rest of the body.
  *
- * Variants collapse to the three the docs use: note/info/important → info,
- * tip → tip, warning/caution → warning. Unrecognized markers are left untouched
- * (rendered as a plain blockquote).
+ * The marker GRAMMAR is shared with the editor and reading-mode pipelines
+ * (utils/callouts.ts — optional `!`, case-insensitive, aliased keywords), so
+ * the three renderers can't drift on which spellings they accept. The five
+ * canonical variants then collapse onto the docs' deliberately smaller
+ * three-style palette (note/important → info, warning/caution → warning) — a
+ * docs PRESENTATION choice, kept so shipped docs pages don't change
+ * appearance. An inline Obsidian-style title after the marker is left in
+ * place as body prose (docs use the bold-line title convention instead).
  */
 import type { Root, Blockquote, Paragraph, Text } from 'mdast'
 import type { CalloutVariant } from '../../pages/docs/components/calloutStyles'
+import { matchCalloutMarker, type CalloutVariant as CanonicalVariant } from '../../utils/callouts'
 
-const VARIANT_ALIASES: Record<string, CalloutVariant> = {
+const CANONICAL_TO_DOCS: Record<CanonicalVariant, CalloutVariant> = {
   note: 'info',
-  info: 'info',
   important: 'info',
   tip: 'tip',
   warning: 'warning',
   caution: 'warning',
 }
 
-/** Strips the leading `[!variant]` marker line; returns the resolved variant. */
+/** Strips the leading `[!variant]` marker; returns the resolved docs variant. */
 function extractMarker(blockquote: Blockquote): CalloutVariant | null {
   const firstChild = blockquote.children[0]
   if (firstChild === undefined || firstChild.type !== 'paragraph') return null
@@ -40,20 +45,29 @@ function extractMarker(blockquote: Blockquote): CalloutVariant | null {
   if (firstText === undefined || firstText.type !== 'text') return null
   const text = firstText as Text
 
-  const match = /^\[!(\w+)\][ \t]*\n?/.exec(text.value)
-  if (match === null) return null
-  const variant = VARIANT_ALIASES[match[1].toLowerCase()]
-  if (variant === undefined) return null
+  const marker = matchCalloutMarker(text.value)
+  if (marker === null) return null
 
-  text.value = text.value.slice(match[0].length)
+  // Strip the marker plus trailing spaces and (at most) the newline that
+  // separated it from the body.
+  text.value = text.value.slice(marker.markerEnd).replace(/^[ \t]*\n?/, '')
   // Drop the marker's now-empty text node (and paragraph, if it held only the marker).
   if (text.value === '') {
     paragraph.children.shift()
+    // A hard line-break (trailing-spaces newline) after the marker parses as a
+    // `break` node — drop it too, or the body starts with a stray blank line.
+    if (paragraph.children[0]?.type === 'break') {
+      paragraph.children.shift()
+    }
     if (paragraph.children.length === 0) blockquote.children.shift()
   }
-  return variant
+  return CANONICAL_TO_DOCS[marker.variant]
 }
 
+// Note: this visitor recurses into nested blockquotes, so `> > [!tip]` becomes
+// a callout here — a docs-only behavior (the editor and reading-mode pipelines
+// treat nested quotes as plain). Pre-existing and harmless for curated docs
+// prose; recorded in the editor-improvements plan.
 function visit(node: { type: string; children?: unknown[] }): void {
   if (node.type === 'blockquote') {
     const variant = extractMarker(node as Blockquote)

--- a/frontend/src/content/data/changelog.json
+++ b/frontend/src/content/data/changelog.json
@@ -1,7 +1,40 @@
 [
   {
+    "month": "August 2026",
+    "theme": "A Better Reading Experience",
+    "categories": [
+      {
+        "label": "New",
+        "emoji": "🚀",
+        "entries": [
+          {
+            "title": "Callouts for notes and prompts",
+            "description": "Start a blockquote with an alert marker — `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, or `> [!CAUTION]` — and it renders as a colored callout with an icon. The syntax is forgiving: the `!` is optional, keywords are case-insensitive, common aliases like `info`, `hint`, and `danger` work, and `> [!note] Custom title` sets your own title. Content pasted from GitHub renders the same way it did there.",
+            "tag": "web"
+          }
+        ]
+      },
+      {
+        "label": "Improved",
+        "emoji": "✨",
+        "entries": [
+          {
+            "title": "Table of contents works in reading mode and on shared links",
+            "description": "The table of contents is now available while reading mode is on, so you can jump between headings in the rendered view. Shared notes and prompts get it too — visitors can open the outline and navigate a long document without an account.",
+            "tag": "web"
+          },
+          {
+            "title": "Reading mode stays on where you left it",
+            "description": "Turning on reading mode is now remembered for that note, bookmark, or prompt. Refreshing the page, navigating away and back, or loading a newer version from the server no longer drops you back into the raw markdown editor.",
+            "tag": "web"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "month": "July 2026",
-    "theme": "OAuth for AI Apps",
+    "theme": "OAuth for AI Apps & Account Control",
     "categories": [
       {
         "label": "New",
@@ -15,6 +48,11 @@
             "title": "Connect Claude and coding agents with OAuth — no tokens",
             "description": "Tiddly's MCP servers now support OAuth sign-in: paste a server URL into Claude (web, desktop, or mobile), Claude Code, or Codex, sign in with your Tiddly account in the browser, and approve — done. Claude connectors sync across all your devices automatically. Token-based setup via the CLI keeps working unchanged and remains the path for headless tools. Per-app steps: https://tiddly.me/docs/ai.",
             "tag": "ai"
+          },
+          {
+            "title": "Manage your own account — password, email, sessions, and deletion",
+            "description": "Settings → Account is now a full self-serve account page: change your password, add or update email addresses, review and sign out active sessions and devices, and permanently delete your account and all its content. None of this was available before.",
+            "tag": "web"
           }
         ]
       }

--- a/frontend/src/content/data/changelog.json
+++ b/frontend/src/content/data/changelog.json
@@ -10,6 +10,7 @@
           {
             "title": "Callouts for notes and prompts",
             "description": "Start a blockquote with an alert marker — `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, or `> [!CAUTION]` — and it renders as a colored callout with an icon. The syntax is forgiving: the `!` is optional, keywords are case-insensitive, common aliases like `info`, `hint`, and `danger` work, and `> [!note] Custom title` sets your own title. Content pasted from GitHub renders the same way it did there.",
+            "pr": 168,
             "tag": "web"
           }
         ]
@@ -21,11 +22,13 @@
           {
             "title": "Table of contents works in reading mode and on shared links",
             "description": "The table of contents is now available while reading mode is on, so you can jump between headings in the rendered view. Shared notes and prompts get it too — visitors can open the outline and navigate a long document without an account.",
+            "pr": 168,
             "tag": "web"
           },
           {
             "title": "Reading mode stays on where you left it",
             "description": "Turning on reading mode is now remembered for that note, bookmark, or prompt. Refreshing the page, navigating away and back, or loading a newer version from the server no longer drops you back into the raw markdown editor.",
+            "pr": 168,
             "tag": "web"
           }
         ]
@@ -42,16 +45,19 @@
         "entries": [
           {
             "title": "Chrome extension signs in with your web session",
-            "description": "The extension now connects automatically when you're signed in at tiddly.me in the same Chrome profile — no token to create or paste. Tokens remain supported as an optional fallback for when you're signed out, and cached drafts and tag preferences are kept separate per account. This update requests new browser permissions (to read your tiddly.me sign-in state) — approve them if Chrome prompts."
+            "description": "The extension now connects automatically when you're signed in at tiddly.me in the same Chrome profile — no token to create or paste. Tokens remain supported as an optional fallback for when you're signed out, and cached drafts and tag preferences are kept separate per account. This update requests new browser permissions (to read your tiddly.me sign-in state) — approve them if Chrome prompts.",
+            "pr": 161
           },
           {
             "title": "Connect Claude and coding agents with OAuth — no tokens",
             "description": "Tiddly's MCP servers now support OAuth sign-in: paste a server URL into Claude (web, desktop, or mobile), Claude Code, or Codex, sign in with your Tiddly account in the browser, and approve — done. Claude connectors sync across all your devices automatically. Token-based setup via the CLI keeps working unchanged and remains the path for headless tools. Per-app steps: https://tiddly.me/docs/ai.",
+            "pr": 159,
             "tag": "ai"
           },
           {
             "title": "Manage your own account — password, email, sessions, and deletion",
             "description": "Settings → Account is now a full self-serve account page: change your password, add or update email addresses, review and sign out active sessions and devices, and permanently delete your account and all its content. None of this was available before.",
+            "pr": 150,
             "tag": "web"
           }
         ]
@@ -69,11 +75,13 @@
           {
             "title": "Share bookmarks, notes, and prompts with a public link",
             "description": "Publish any item to a stable, read-only public URL that anyone can open — no account needed. Use the Share control on the item's detail page to create the link, copy it, stop sharing, or regenerate it (which invalidates the old link). Sharing never changes the item's \"last updated\" time, and your tags and relationships stay private — the public view shows only the content and its dates.",
+            "pr": 145,
             "tag": "web"
           },
           {
             "title": "Save a copy of a shared item",
             "description": "Signed in and viewing someone's shared link? Save your own independent copy to your account with one click — it lands in your library as a fresh, unshared item. Sign up straight from a shared link and your copy is waiting once you're in.",
+            "pr": 145,
             "tag": "web"
           }
         ]

--- a/frontend/src/content/data/roadmap.json
+++ b/frontend/src/content/data/roadmap.json
@@ -13,10 +13,6 @@
           "description": "Conversational interface for searching and managing content."
         },
         {
-          "title": "OAuth for MCP",
-          "description": "Connect MCP clients like ChatGPT without personal access tokens."
-        },
-        {
           "title": "Data export",
           "description": "Export all your content in standard formats."
         },
@@ -56,6 +52,14 @@
       "title": "Shipped",
       "description": "Recently launched.",
       "items": [
+        {
+          "title": "OAuth for MCP",
+          "description": "Connect MCP clients like Claude and coding agents without personal access tokens."
+        },
+        {
+          "title": "Account management",
+          "description": "Change your password, manage email addresses, and review active sessions and devices from Settings."
+        },
         {
           "title": "Antigravity MCP support",
           "description": "Connect Google Antigravity (the agy CLI and IDE) to your content via `tiddly mcp configure antigravity`.",

--- a/frontend/src/content/prose/content-types.md
+++ b/frontend/src/content/prose/content-types.md
@@ -36,6 +36,7 @@ Freeform markdown documents for capturing ideas, documentation, meeting notes, o
 - **Slash commands** — type `/` at the start of a line for headings, lists, code blocks, links, and more
 - **Command menu** — press `{{shortcut:editor.commandMenu}}` for a filterable palette of all formatting options
 - **Reading mode** — toggle with `{{shortcut:editor.toggleReadingMode}}` to see rendered markdown preview
+- **Callouts** — start a blockquote with `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, or `> [!CAUTION]` to render a colored callout; add your own title with `> [!NOTE] Custom title`
 - **Display options** — toggle word wrap, line numbers, monospace font, and table of contents sidebar
 
 See [Keyboard Shortcuts](/docs/features/shortcuts) for the full list of editor formatting shortcuts.

--- a/frontend/src/hooks/useResizableSidebar.ts
+++ b/frontend/src/hooks/useResizableSidebar.ts
@@ -4,7 +4,7 @@
  * and recompute on viewport / left-sidebar width changes.
  */
 import { useReducer, useState, useEffect, useCallback } from 'react'
-import { useRightSidebarStore, computeMaxWidth } from '../stores/rightSidebarStore'
+import { useRightSidebarStore, computeMaxWidth, getEffectiveSidebarWidth } from '../stores/rightSidebarStore'
 import { DESKTOP_SIDEBAR_ID } from '../constants/sidebar'
 
 const MD_BREAKPOINT = 768
@@ -21,19 +21,22 @@ export function measureMaxSidebarWidth(): number {
   return computeMaxWidth(window.innerWidth, leftSidebarWidth)
 }
 
-interface ResizableSidebarResult {
-  width: number
+interface EffectiveSidebarMetrics {
+  /** The sidebar's effective rendered width (clamped/maximized on desktop). */
+  effectiveWidth: number
   isDesktop: boolean
-  isDragging: boolean
-  handleMouseDown: (e: React.MouseEvent) => void
 }
 
-export function useResizableSidebar(): ResizableSidebarResult {
+/**
+ * Read-only, reactive view of the right sidebar's effective geometry: the
+ * width it actually renders at and whether we're above the desktop
+ * breakpoint. For consumers that lay content out around the sidebar (the app
+ * layout margin, the public shared-item layout) without needing drag state —
+ * useResizableSidebar composes this and adds the drag interaction.
+ */
+export function useEffectiveSidebarMetrics(): EffectiveSidebarMetrics {
   const storeWidth = useRightSidebarStore((state) => state.width)
-  const setWidth = useRightSidebarStore((state) => state.setWidth)
   const maximized = useRightSidebarStore((state) => state.maximized)
-  const setMaximized = useRightSidebarStore((state) => state.setMaximized)
-  const [isDragging, setIsDragging] = useState(false)
   const [isDesktop, setIsDesktop] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth >= MD_BREAKPOINT : true
   )
@@ -64,13 +67,26 @@ export function useResizableSidebar(): ResizableSidebarResult {
     }
   }, [])
 
-  // Effective rendered width. When maximized, follow the live max; otherwise
-  // clamp the stored width to it. Clamping here (not by mutating the store)
-  // keeps the restore target intact across viewport changes.
-  const maxWidth = measureMaxSidebarWidth()
-  const width = isDesktop
-    ? (maximized ? maxWidth : Math.min(storeWidth, maxWidth))
+  const effectiveWidth = isDesktop
+    ? getEffectiveSidebarWidth(storeWidth, maximized, measureMaxSidebarWidth())
     : storeWidth
+
+  return { effectiveWidth, isDesktop }
+}
+
+interface ResizableSidebarResult {
+  width: number
+  isDesktop: boolean
+  isDragging: boolean
+  handleMouseDown: (e: React.MouseEvent) => void
+}
+
+export function useResizableSidebar(): ResizableSidebarResult {
+  const setWidth = useRightSidebarStore((state) => state.setWidth)
+  const maximized = useRightSidebarStore((state) => state.maximized)
+  const setMaximized = useRightSidebarStore((state) => state.setMaximized)
+  const [isDragging, setIsDragging] = useState(false)
+  const { effectiveWidth: width, isDesktop } = useEffectiveSidebarMetrics()
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -457,6 +457,17 @@ body {
 }
 
 /* Headings */
+/* scroll-margin keeps ToC-navigation targets clear of the sticky toolbars
+   (app detail header / public header) when reading mode scrolls the page. */
+.milkdown-wrapper .milkdown h1,
+.milkdown-wrapper .milkdown h2,
+.milkdown-wrapper .milkdown h3,
+.milkdown-wrapper .milkdown h4,
+.milkdown-wrapper .milkdown h5,
+.milkdown-wrapper .milkdown h6 {
+  scroll-margin-top: 5rem;
+}
+
 .milkdown-wrapper .milkdown h1 {
   @apply text-2xl font-bold text-gray-900 mt-6 mb-4 first:mt-0;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -606,6 +606,111 @@ body {
   @apply border-l-4 border-indigo-500 pl-4 my-4;
 }
 
+/* Callouts (`> [!WARNING]` etc. — grammar in utils/callouts.ts, decorations in
+   MilkdownEditor's callout plugin). The raw marker span is hidden and replaced
+   by an icon plus either the variant label (no custom title) or the styled
+   custom title. Body content keeps normal blockquote text styling. */
+.milkdown-wrapper .milkdown blockquote.callout {
+  @apply rounded-r-md py-2 pr-4;
+}
+.milkdown-wrapper .milkdown blockquote.callout-note { border-color: #3b82f6; background-color: #eff6ff; }
+.milkdown-wrapper .milkdown blockquote.callout-tip { border-color: #22c55e; background-color: #f0fdf4; }
+.milkdown-wrapper .milkdown blockquote.callout-important { border-color: #a855f7; background-color: #faf5ff; }
+.milkdown-wrapper .milkdown blockquote.callout-warning { border-color: #f59e0b; background-color: #fffbeb; }
+.milkdown-wrapper .milkdown blockquote.callout-caution { border-color: #ef4444; background-color: #fef2f2; }
+
+/* Title-row text color per variant (darker shade of the border color). */
+.milkdown-wrapper .milkdown .callout-note .callout-marker-labeled::after,
+.milkdown-wrapper .milkdown .callout-note .callout-title { color: #1d4ed8; }
+.milkdown-wrapper .milkdown .callout-tip .callout-marker-labeled::after,
+.milkdown-wrapper .milkdown .callout-tip .callout-title { color: #15803d; }
+.milkdown-wrapper .milkdown .callout-important .callout-marker-labeled::after,
+.milkdown-wrapper .milkdown .callout-important .callout-title { color: #7e22ce; }
+.milkdown-wrapper .milkdown .callout-warning .callout-marker-labeled::after,
+.milkdown-wrapper .milkdown .callout-warning .callout-title { color: #b45309; }
+.milkdown-wrapper .milkdown .callout-caution .callout-marker-labeled::after,
+.milkdown-wrapper .milkdown .callout-caution .callout-title { color: #b91c1c; }
+
+/* With a custom title: the raw `[!x]` marker disappears entirely; the title
+   span becomes the heading row (icon + bold title on its own line). */
+.milkdown-wrapper .milkdown .callout .callout-marker { display: none; }
+.milkdown-wrapper .milkdown .callout .callout-title {
+  display: block;
+  font-weight: 600;
+}
+
+/* Without a custom title: the marker span itself is the title row — its text
+   is collapsed (font-size: 0; display: none would drop the pseudo-elements
+   too) and the icon (::before) + variant label (::after) render in its place.
+   Explicit rem sizes on the pseudos because 1em would inherit the 0. */
+.milkdown-wrapper .milkdown .callout .callout-marker-labeled {
+  display: block;
+  font-size: 0;
+}
+.milkdown-wrapper .milkdown .callout .callout-marker-labeled::after {
+  /* Label text comes from the decoration's data attribute (single-sourced in
+     utils/callouts.ts CALLOUT_LABELS), not hardcoded per variant here. */
+  content: attr(data-callout-label);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+/* Icon: inline SVG via mask-image so it takes the variant text color — not
+   emoji (inconsistent cross-platform rendering), not decoration widgets
+   (heavier, no benefit). Outline icons per variant below. */
+.milkdown-wrapper .milkdown .callout .callout-marker-labeled::before,
+.milkdown-wrapper .milkdown .callout .callout-title::before {
+  content: '';
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.375rem;
+  vertical-align: middle;
+  background-color: currentColor;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+}
+.milkdown-wrapper .milkdown .callout .callout-title::before {
+  width: 1.0625rem;
+  height: 1.0625rem;
+  vertical-align: -0.1875rem;
+}
+/* info circle */
+.milkdown-wrapper .milkdown .callout-note .callout-marker-labeled::before,
+.milkdown-wrapper .milkdown .callout-note .callout-title::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M12 16v-4'/%3E%3Cpath d='M12 8h.01'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M12 16v-4'/%3E%3Cpath d='M12 8h.01'/%3E%3C/svg%3E");
+}
+/* lightbulb */
+.milkdown-wrapper .milkdown .callout-tip .callout-marker-labeled::before,
+.milkdown-wrapper .milkdown .callout-tip .callout-title::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5'/%3E%3Cpath d='M9 18h6'/%3E%3Cpath d='M10 22h4'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5'/%3E%3Cpath d='M9 18h6'/%3E%3Cpath d='M10 22h4'/%3E%3C/svg%3E");
+}
+/* message-square-warning (exclamation in speech box) */
+.milkdown-wrapper .milkdown .callout-important .callout-marker-labeled::before,
+.milkdown-wrapper .milkdown .callout-important .callout-title::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/%3E%3Cpath d='M12 7v2'/%3E%3Cpath d='M12 13h.01'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/%3E%3Cpath d='M12 7v2'/%3E%3Cpath d='M12 13h.01'/%3E%3C/svg%3E");
+}
+/* alert triangle */
+.milkdown-wrapper .milkdown .callout-warning .callout-marker-labeled::before,
+.milkdown-wrapper .milkdown .callout-warning .callout-title::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+}
+/* octagon alert */
+.milkdown-wrapper .milkdown .callout-caution .callout-marker-labeled::before,
+.milkdown-wrapper .milkdown .callout-caution .callout-title::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7.9 2h8.2a2 2 0 0 1 1.4.6l4 4a2 2 0 0 1 .5 1.3v8.2a2 2 0 0 1-.6 1.4l-4 4a2 2 0 0 1-1.3.5H7.9a2 2 0 0 1-1.4-.6l-4-4a2 2 0 0 1-.5-1.3V7.9a2 2 0 0 1 .6-1.4l4-4A2 2 0 0 1 7.9 2'/%3E%3Cpath d='M12 8v4'/%3E%3Cpath d='M12 16h.01'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7.9 2h8.2a2 2 0 0 1 1.4.6l4 4a2 2 0 0 1 .5 1.3v8.2a2 2 0 0 1-.6 1.4l-4 4a2 2 0 0 1-1.3.5H7.9a2 2 0 0 1-1.4-.6l-4-4a2 2 0 0 1-.5-1.3V7.9a2 2 0 0 1 .6-1.4l4-4A2 2 0 0 1 7.9 2'/%3E%3Cpath d='M12 8v4'/%3E%3Cpath d='M12 16h.01'/%3E%3C/svg%3E");
+}
+
 /* Unordered lists */
 .milkdown-wrapper .milkdown ul {
   @apply list-disc pl-6 my-3 space-y-0.5;

--- a/frontend/src/pages/PublicBookmark.test.tsx
+++ b/frontend/src/pages/PublicBookmark.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Public bookmark page: bookmarks are deliberately excluded from the ToC
+ * (scraped content is formatting-stripped and headingless — see the
+ * editor-improvements plan), so the shell must close a stale ToC panel on
+ * mount and render no sidebar.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { PublicBookmark } from './PublicBookmark'
+import { useRightSidebarStore } from '../stores/rightSidebarStore'
+import type { PublicBookmark as PublicBookmarkType } from '../types'
+
+let mockBookmarkQuery: Partial<UseQueryResult<PublicBookmarkType>>
+vi.mock('../hooks/usePublicItem', () => ({
+  usePublicBookmark: () => mockBookmarkQuery,
+}))
+
+// Stub the heavy editors.
+vi.mock('../components/CodeMirrorEditor', () => ({
+  CodeMirrorEditor: ({ value }: { value: string }) => (
+    <textarea data-testid="content-editor" value={value} onChange={() => {}} />
+  ),
+}))
+vi.mock('../components/MilkdownEditor', () => ({
+  MilkdownEditor: ({ value }: { value: string }) => <div>{value}</div>,
+}))
+
+const activeBookmark: PublicBookmarkType = {
+  url: 'https://example.com',
+  title: 'My Bookmark',
+  description: 'A description',
+  content: 'Scraped body',
+  is_archived: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+function renderPage(): void {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/shared/bookmarks/tok']}>
+        <Routes>
+          <Route path="/shared/bookmarks/:token" element={<PublicBookmark />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('PublicBookmark page — no ToC support', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useRightSidebarStore.setState({ activePanel: null, maximized: false })
+    mockBookmarkQuery = { data: activeBookmark, isLoading: false, isError: false }
+  })
+
+  it('closes a stale ToC panel on mount and renders no sidebar or offset', () => {
+    useRightSidebarStore.setState({ activePanel: 'toc' })
+    renderPage()
+
+    expect(screen.getByText('My Bookmark')).toBeInTheDocument()
+    expect(useRightSidebarStore.getState().activePanel).toBeNull()
+    expect(screen.queryByText('Table of Contents')).toBeNull()
+    expect(document.querySelector('[style*="margin-right"]')).toBeNull()
+  })
+})

--- a/frontend/src/pages/PublicBookmark.tsx
+++ b/frontend/src/pages/PublicBookmark.tsx
@@ -1,7 +1,7 @@
 /**
  * Public read-only view of a shared bookmark.
  *
- * Route: /shared/bookmarks/:token (under PublicPageLayout, no auth required).
+ * Route: /shared/bookmarks/:token (under PublicContentLayout, no auth required).
  *
  * Thin wrapper: fetch by token via the no-auth client, adapt the locked-down
  * public payload to the shape the existing `Bookmark` render component expects,

--- a/frontend/src/pages/PublicBookmark.tsx
+++ b/frontend/src/pages/PublicBookmark.tsx
@@ -1,7 +1,7 @@
 /**
  * Public read-only view of a shared bookmark.
  *
- * Route: /shared/bookmarks/:token (under PublicContentLayout, no auth required).
+ * Route: /shared/bookmarks/:token (under PublicPageLayout, no auth required).
  *
  * Thin wrapper: fetch by token via the no-auth client, adapt the locked-down
  * public payload to the shape the existing `Bookmark` render component expects,

--- a/frontend/src/pages/PublicNote.test.tsx
+++ b/frontend/src/pages/PublicNote.test.tsx
@@ -11,6 +11,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { PublicNote } from './PublicNote'
+import { useRightSidebarStore } from '../stores/rightSidebarStore'
 import type { PublicNote as PublicNoteType } from '../types'
 
 // `mock`-prefixed so the hoisted factory may reference it.
@@ -42,9 +43,9 @@ const activeNote: PublicNoteType = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
-function renderPage(): void {
+function renderPage(): { container: HTMLElement; unmount: () => void } {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  render(
+  const { container, unmount } = render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={['/shared/notes/tok']}>
         <Routes>
@@ -53,6 +54,7 @@ function renderPage(): void {
       </MemoryRouter>
     </QueryClientProvider>
   )
+  return { container, unmount }
 }
 
 describe('PublicNote page', () => {
@@ -93,5 +95,40 @@ describe('PublicNote page', () => {
     renderPage()
     expect(screen.getByText(/isn’t available/i)).toBeInTheDocument()
     expect(screen.queryByTestId('content-editor')).toBeNull()
+  })
+
+  describe('ToC sidebar', () => {
+    beforeEach(() => {
+      useRightSidebarStore.setState({ activePanel: null, maximized: false })
+      mockNoteQuery = { data: activeNote, isLoading: false, isError: false }
+    })
+
+    it('opening the ToC renders the sidebar', () => {
+      // The content offset while the panel is open is owned by
+      // PublicSharedTocLayout (tested in PublicPageLayout.test.tsx).
+      useRightSidebarStore.setState({ activePanel: 'toc' })
+      renderPage()
+
+      expect(screen.getByText('Table of Contents')).toBeInTheDocument()
+    })
+
+    it('a persisted history panel renders no sidebar and is left alone', () => {
+      // The store restores 'history' from a prior app session; no public page
+      // can render that panel. Only 'toc' is shell-managed.
+      useRightSidebarStore.setState({ activePanel: 'history' })
+      renderPage()
+
+      expect(screen.queryByText('Table of Contents')).toBeNull()
+      expect(useRightSidebarStore.getState().activePanel).toBe('history')
+    })
+
+    it('navigating away closes the ToC (no orphaned panel on pricing/changelog)', () => {
+      useRightSidebarStore.setState({ activePanel: 'toc' })
+      const { unmount } = renderPage()
+      expect(useRightSidebarStore.getState().activePanel).toBe('toc')
+
+      unmount()
+      expect(useRightSidebarStore.getState().activePanel).toBeNull()
+    })
   })
 })

--- a/frontend/src/pages/PublicNote.tsx
+++ b/frontend/src/pages/PublicNote.tsx
@@ -1,7 +1,7 @@
 /**
  * Public read-only view of a shared note.
  *
- * Route: /shared/notes/:token (under PublicPageLayout, no auth required).
+ * Route: /shared/notes/:token (under PublicSharedTocLayout, no auth required).
  *
  * Thin wrapper: fetch by token via the no-auth client, adapt the locked-down
  * public payload to the shape the existing `Note` render component expects, and
@@ -54,6 +54,7 @@ export function PublicNote(): ReactNode {
       error={error}
       onRetry={() => { void refetch() }}
       isArchived={data?.is_archived ?? false}
+      tocEnabled
     >
       {data && (
         <NoteComponent
@@ -64,7 +65,7 @@ export function PublicNote(): ReactNode {
           readOnly
           viewState={data.is_archived ? 'archived' : 'active'}
           aiAvailable={false}
-          showTocToggle={false}
+          showTocToggle
         />
       )}
     </PublicItemShell>

--- a/frontend/src/pages/PublicPrompt.tsx
+++ b/frontend/src/pages/PublicPrompt.tsx
@@ -1,7 +1,7 @@
 /**
  * Public read-only view of a shared prompt.
  *
- * Route: /shared/prompts/:token (under PublicPageLayout, no auth required).
+ * Route: /shared/prompts/:token (under PublicSharedTocLayout, no auth required).
  *
  * Thin wrapper: fetch by token via the no-auth client, adapt the locked-down
  * public payload to the shape the existing `Prompt` render component expects,
@@ -57,6 +57,7 @@ export function PublicPrompt(): ReactNode {
       error={error}
       onRetry={() => { void refetch() }}
       isArchived={data?.is_archived ?? false}
+      tocEnabled
     >
       {data && (
         <PromptComponent
@@ -67,7 +68,7 @@ export function PublicPrompt(): ReactNode {
           readOnly
           viewState={data.is_archived ? 'archived' : 'active'}
           aiAvailable={false}
-          showTocToggle={false}
+          showTocToggle
         />
       )}
     </PublicItemShell>

--- a/frontend/src/pages/settings/SettingsAccount.tsx
+++ b/frontend/src/pages/settings/SettingsAccount.tsx
@@ -3,17 +3,17 @@
  * Account), rather than linking out to the hosted Account Portal, so users
  * stay inside the app consistent with the existing settings pattern.
  *
- * New capability, not parity (migration plan M3 step 9): password change and
- * session/device management never existed under the previous provider (Auth0), which shipped no
- * end-user account UI.
+ * New capability, not parity (migration plan M3 step 9): password change,
+ * session/device management, and self-serve deletion never existed under the
+ * previous provider (Auth0), which shipped no end-user account UI.
  *
- * GUARD RAIL: do NOT expose an account-deletion section until deletion is
- * wired end-to-end (Clerk `user.deleted` webhook → backend cascade delete,
- * plan M8) — a Clerk-side deletion without the webhook orphans all the user's
- * data in Postgres. Whether the section appears is controlled Clerk-side
- * ("Allow users to delete their accounts" in the instance's user settings);
- * the dev-instance pass verifies it is off (ledger question 12 records what
- * the component and the hosted portal expose).
+ * Account deletion is live: the section's visibility is controlled Clerk-side
+ * ("Allow users to delete their accounts"), and it was deliberately kept off
+ * until deletion was wired end-to-end — a Clerk-side deletion without the
+ * `user.deleted` webhook would orphan all of the user's data in Postgres. That
+ * path now exists (webhook → identity tombstone → cascade delete →
+ * auth-cache invalidation), so the setting is enabled in production. If the
+ * webhook is ever removed or disabled, turn the Clerk setting off with it.
  *
  * In dev mode there is no Clerk context or account to manage; the page says so
  * instead of rendering the component.

--- a/frontend/src/stores/rightSidebarStore.test.ts
+++ b/frontend/src/stores/rightSidebarStore.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   useRightSidebarStore,
   computeMaxWidth,
+  getEffectiveSidebarWidth,
   DEFAULT_SIDEBAR_WIDTH,
   MIN_SIDEBAR_WIDTH,
   MIN_CONTENT_WIDTH,
@@ -181,6 +182,17 @@ describe('rightSidebarStore', () => {
       expect(useRightSidebarStore.getState().width).toBe(500)
 
       localStorage.setItem = originalSetItem
+    })
+  })
+
+  describe('getEffectiveSidebarWidth', () => {
+    it('clamps the stored width to the max', () => {
+      expect(getEffectiveSidebarWidth(400, false, 840)).toBe(400)
+      expect(getEffectiveSidebarWidth(900, false, 840)).toBe(840)
+    })
+
+    it('follows the live max when maximized, regardless of stored width', () => {
+      expect(getEffectiveSidebarWidth(400, true, 840)).toBe(840)
     })
   })
 

--- a/frontend/src/stores/rightSidebarStore.ts
+++ b/frontend/src/stores/rightSidebarStore.ts
@@ -23,6 +23,22 @@ export function computeMaxWidth(innerWidth: number, leftSidebarWidth: number): n
   return Math.max(MIN_SIDEBAR_WIDTH, innerWidth - leftSidebarWidth - MIN_CONTENT_WIDTH)
 }
 
+/**
+ * The sidebar's effective rendered width on desktop: the live max when
+ * maximized, otherwise the stored width clamped to it. Clamping here (not by
+ * mutating the store) keeps the user's chosen width intact as the restore
+ * target across viewport changes. Single-sourced because the sidebar itself,
+ * the app layout's content margin, and the public shared-item layout must all
+ * agree on this number.
+ */
+export function getEffectiveSidebarWidth(
+  storeWidth: number,
+  maximized: boolean,
+  maxWidth: number,
+): number {
+  return maximized ? maxWidth : Math.min(storeWidth, maxWidth)
+}
+
 // Storage keys for persisting state
 const WIDTH_STORAGE_KEY = 'right-sidebar-width'
 const PANEL_STORAGE_KEY = 'right-sidebar-panel'

--- a/frontend/src/utils/callouts.test.ts
+++ b/frontend/src/utils/callouts.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the shared callout marker grammar (see callouts.ts). Exhaustive at
+ * this layer — the three consumers (CodeMirror, Milkdown, docs remark plugin)
+ * spot-check integration and rely on these for grammar coverage.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  matchCalloutMarker,
+  matchCalloutMarkerInLine,
+  resolveCalloutKeyword,
+  CALLOUT_VARIANTS,
+  type CalloutVariant,
+} from './callouts'
+
+const ALIASES: Record<CalloutVariant, string[]> = {
+  note: ['note', 'info', 'information'],
+  tip: ['tip', 'hint', 'success', 'check', 'done'],
+  important: ['important'],
+  warning: ['warning', 'attention'],
+  caution: ['caution', 'danger', 'error', 'bug', 'failure'],
+}
+
+describe('resolveCalloutKeyword', () => {
+  it('resolves every alias to its canonical variant, case-insensitively', () => {
+    for (const variant of CALLOUT_VARIANTS) {
+      for (const alias of ALIASES[variant]) {
+        expect(resolveCalloutKeyword(alias)).toBe(variant)
+        expect(resolveCalloutKeyword(alias.toUpperCase())).toBe(variant)
+        expect(resolveCalloutKeyword(alias[0].toUpperCase() + alias.slice(1))).toBe(variant)
+      }
+    }
+  })
+
+  it('returns null for unknown keywords', () => {
+    expect(resolveCalloutKeyword('foo')).toBeNull()
+    expect(resolveCalloutKeyword('warn')).toBeNull()
+    expect(resolveCalloutKeyword('')).toBeNull()
+  })
+})
+
+describe('matchCalloutMarker (post-parse text, no > prefix)', () => {
+  it('matches every alias with and without the bang', () => {
+    for (const variant of CALLOUT_VARIANTS) {
+      for (const alias of ALIASES[variant]) {
+        expect(matchCalloutMarker(`[!${alias}]`)?.variant).toBe(variant)
+        expect(matchCalloutMarker(`[${alias}]`)?.variant).toBe(variant)
+        expect(matchCalloutMarker(`[!${alias.toUpperCase()}]`)?.variant).toBe(variant)
+      }
+    }
+  })
+
+  it('reports marker offsets', () => {
+    const marker = matchCalloutMarker('[!WARNING] rest')
+    expect(marker).toMatchObject({ markerStart: 0, markerEnd: 10 })
+  })
+
+  it('captures a custom title with its span', () => {
+    const marker = matchCalloutMarker('[!note]  My Title ')
+    expect(marker?.title).toBe('My Title')
+    expect('[!note]  My Title '.slice(marker!.titleStart, marker!.titleEnd)).toBe('My Title')
+  })
+
+  it('no title → null title with a zero-length span at markerEnd', () => {
+    const marker = matchCalloutMarker('[!note]')
+    expect(marker?.title).toBeNull()
+    expect(marker?.titleStart).toBe(marker?.markerEnd)
+    expect(marker?.titleEnd).toBe(marker?.markerEnd)
+  })
+
+  it('bounds the title to the marker line (soft-break newlines in input)', () => {
+    const marker = matchCalloutMarker('[!WARNING] Title here\nBody continues')
+    expect(marker?.title).toBe('Title here')
+    expect(marker?.titleEnd).toBeLessThan('[!WARNING] Title here'.length + 1)
+  })
+
+  it('body after a newline is not a title', () => {
+    const marker = matchCalloutMarker('[!WARNING]\nBody')
+    expect(marker?.title).toBeNull()
+  })
+
+  it.each([
+    ['no brackets', 'WARNING'],
+    ['empty brackets', '[]'],
+    ['bang only', '[!]'],
+    ['non-alpha keyword', '[!123]'],
+    ['space after bang', '[! note]'],
+    ['space in brackets', '[warning ]'],
+    ['unknown keyword', '[!FOO]'],
+    ['marker not at start', 'text [!note]'],
+    ['leading whitespace', ' [!note]'],
+  ])('%s → null', (_label: string, text: string) => {
+    expect(matchCalloutMarker(text)).toBeNull()
+  })
+})
+
+describe('matchCalloutMarkerInLine (raw source with > prefix)', () => {
+  it('matches with the common prefix shapes and offsets into line coordinates', () => {
+    expect(matchCalloutMarkerInLine('> [!WARNING]')).toMatchObject({
+      variant: 'warning',
+      markerStart: 2,
+      markerEnd: 12,
+    })
+    expect(matchCalloutMarkerInLine('>[!note]')).toMatchObject({ markerStart: 1, markerEnd: 8 })
+    expect(matchCalloutMarkerInLine('>   [!tip]')?.variant).toBe('tip')
+  })
+
+  it('title span is offset into line coordinates', () => {
+    const line = '> [!note] Custom'
+    const marker = matchCalloutMarkerInLine(line)
+    expect(line.slice(marker!.titleStart, marker!.titleEnd)).toBe('Custom')
+  })
+
+  it('non-blockquote lines never match', () => {
+    expect(matchCalloutMarkerInLine('[!note]')).toBeNull()
+    expect(matchCalloutMarkerInLine('  > [!note]')).toBeNull() // indented > isn't a blockquote to the CM parser
+  })
+
+  it('a plain blockquote line is not a callout', () => {
+    expect(matchCalloutMarkerInLine('> just a quote')).toBeNull()
+    expect(matchCalloutMarkerInLine('>')).toBeNull()
+  })
+})

--- a/frontend/src/utils/callouts.ts
+++ b/frontend/src/utils/callouts.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared callout (GitHub-style alert) marker grammar — the single source of
+ * truth for what counts as a callout and which visual variant it maps to.
+ *
+ * THREE rendering pipelines consume this module and must not drift on which
+ * spellings they accept:
+ *   - the CodeMirror editor (utils/markdownStyleExtension.ts) via the
+ *     raw-source adapter `matchCalloutMarkerInLine` (its input still carries
+ *     the blockquote `>` prefix),
+ *   - the reading-mode Milkdown preview (components/MilkdownEditor.tsx) via
+ *     `matchCalloutMarker` (post-parse text, `>` already consumed),
+ *   - the docs prose pipeline (components/markdown/remarkCallouts.ts), also
+ *     post-parse (mdast text values), which maps the five canonical variants
+ *     down to its deliberately smaller three-style docs palette.
+ *
+ * Grammar is forgiving by design — content pasted from GitHub, typed from
+ * memory, or written by an agent should all render: the `!` is optional, the
+ * keyword is case-insensitive, common aliases are accepted, and an optional
+ * custom title may follow on the marker line (Obsidian-style
+ * `[!note] My title`). Unknown keywords are NOT callouts (`null`) — every
+ * consumer falls through to plain-blockquote rendering, so nothing ever
+ * breaks (fail soft).
+ */
+
+export type CalloutVariant = 'note' | 'tip' | 'important' | 'warning' | 'caution'
+
+export const CALLOUT_VARIANTS: readonly CalloutVariant[] = [
+  'note',
+  'tip',
+  'important',
+  'warning',
+  'caution',
+]
+
+/** Display labels for callouts without a custom title. */
+export const CALLOUT_LABELS: Record<CalloutVariant, string> = {
+  note: 'Note',
+  tip: 'Tip',
+  important: 'Important',
+  warning: 'Warning',
+  caution: 'Caution',
+}
+
+// Aliases collapse onto GitHub's five canonical variants. Keys must be
+// lowercase (lookups lowercase the keyword).
+const KEYWORD_TO_VARIANT: Record<string, CalloutVariant> = {
+  note: 'note',
+  info: 'note',
+  information: 'note',
+  tip: 'tip',
+  hint: 'tip',
+  success: 'tip',
+  check: 'tip',
+  done: 'tip',
+  important: 'important',
+  warning: 'warning',
+  attention: 'warning',
+  caution: 'caution',
+  danger: 'caution',
+  error: 'caution',
+  bug: 'caution',
+  failure: 'caution',
+}
+
+/** Resolve a keyword (any case) to its canonical variant, or null if unknown. */
+export function resolveCalloutKeyword(keyword: string): CalloutVariant | null {
+  return KEYWORD_TO_VARIANT[keyword.toLowerCase()] ?? null
+}
+
+export interface CalloutMarker {
+  variant: CalloutVariant
+  /** Offset of `[` within the input text (0 for the core matcher). */
+  markerStart: number
+  /** Offset just past `]`. */
+  markerEnd: number
+  /** Trimmed custom title on the marker line, or null when absent. */
+  title: string | null
+  /** Offsets of the raw title span (equal to markerEnd when no title). */
+  titleStart: number
+  titleEnd: number
+}
+
+// Marker must start the text: `[!KEYWORD]` or `[KEYWORD]`, letters only, no
+// space after the bang (matching GitHub's grammar).
+const MARKER_RE = /^\[!?([A-Za-z]+)\]/
+
+/**
+ * Match a callout marker at the START of post-parse text (no blockquote `>`).
+ * The input may contain the rest of the paragraph (soft-break newlines
+ * included) — the custom title is bounded to the marker's own line.
+ */
+export function matchCalloutMarker(text: string): CalloutMarker | null {
+  const match = MARKER_RE.exec(text)
+  if (match === null) return null
+  const variant = resolveCalloutKeyword(match[1])
+  if (variant === null) return null
+
+  const markerEnd = match[0].length
+  const newlineIdx = text.indexOf('\n', markerEnd)
+  const lineEnd = newlineIdx === -1 ? text.length : newlineIdx
+  const rawTitle = text.slice(markerEnd, lineEnd)
+  const title = rawTitle.trim()
+  if (title === '') {
+    return { variant, markerStart: 0, markerEnd, title: null, titleStart: markerEnd, titleEnd: markerEnd }
+  }
+  const titleStart = markerEnd + (rawTitle.length - rawTitle.trimStart().length)
+  return { variant, markerStart: 0, markerEnd, title, titleStart, titleEnd: titleStart + title.length }
+}
+
+// Blockquote prefix as the CodeMirror line parser recognizes it: `>` at line
+// start (markdownStyleExtension's parseLine does not treat indented `>` as a
+// blockquote, so neither does this adapter — keeping the two in agreement).
+const BLOCKQUOTE_PREFIX_RE = /^>[ \t]*/
+
+/**
+ * Raw-source adapter: match a callout marker on a blockquote SOURCE line
+ * (`> [!WARNING] ...`). Returned offsets are in line coordinates, ready for
+ * CodeMirror inline decorations.
+ */
+export function matchCalloutMarkerInLine(lineText: string): CalloutMarker | null {
+  const prefix = BLOCKQUOTE_PREFIX_RE.exec(lineText)
+  if (prefix === null) return null
+  const offset = prefix[0].length
+  const marker = matchCalloutMarker(lineText.slice(offset))
+  if (marker === null) return null
+  return {
+    ...marker,
+    markerStart: marker.markerStart + offset,
+    markerEnd: marker.markerEnd + offset,
+    titleStart: marker.titleStart + offset,
+    titleEnd: marker.titleEnd + offset,
+  }
+}

--- a/frontend/src/utils/headingNavigation.test.ts
+++ b/frontend/src/utils/headingNavigation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for reading-mode heading resolution (see headingNavigation.ts).
+ *
+ * The rendered DOM is constructed directly (the real Milkdown output shape:
+ * block elements as children of a root, nested headings inside
+ * blockquote/li) so the parity, verification, and fallback layers can each be
+ * exercised — including adversarial cases where the source parser and the
+ * renderer disagree about which headings exist.
+ */
+import { describe, it, expect } from 'vitest'
+import { findRenderedHeading } from './headingNavigation'
+
+function dom(html: string): HTMLElement {
+  const root = document.createElement('div')
+  root.innerHTML = html
+  return root
+}
+
+describe('findRenderedHeading', () => {
+  it('resolves headings by ordinal in the common case', () => {
+    const markdown = '# Alpha\n\ntext\n\n## Beta\n\n# Gamma'
+    const root = dom('<h1>Alpha</h1><p>text</p><h2>Beta</h2><h1>Gamma</h1>')
+
+    expect(findRenderedHeading(root, markdown, 5)?.textContent).toBe('Beta')
+    expect(findRenderedHeading(root, markdown, 7)?.textContent).toBe('Gamma')
+  })
+
+  it('excludes blockquote-nested headings from the candidate set (parity)', () => {
+    // `# Usage` / `> # Usage` / `# Usage`: the source parser reports two
+    // root-level headings; the DOM renders three h1 elements. Without the
+    // nesting filter, "the 2nd parsed Usage" would resolve to the blockquote's
+    // copy.
+    const markdown = '# Usage\n\n> # Usage\n\n# Usage'
+    const root = dom('<h1>Usage</h1><blockquote><h1>Usage</h1></blockquote><h1>Usage</h1>')
+
+    const resolved = findRenderedHeading(root, markdown, 5)
+    expect(resolved).not.toBeNull()
+    expect(resolved?.parentElement?.tagName).not.toBe('BLOCKQUOTE')
+    expect(resolved).toBe(root.children[2])
+  })
+
+  it('excludes list-nested headings from the candidate set (parity)', () => {
+    const markdown = '# First\n\n- item\n\n# Second'
+    const root = dom('<h1>First</h1><ul><li><h1>In list</h1></li></ul><h1>Second</h1>')
+
+    expect(findRenderedHeading(root, markdown, 5)?.textContent).toBe('Second')
+  })
+
+  it('duplicate headings straddling a setext heading resolve correctly', () => {
+    const markdown = '# Usage\n\nMiddle\n===\n\n# Usage'
+    const root = dom('<h1>Usage</h1><h1>Middle</h1><h1>Usage</h1>')
+
+    expect(findRenderedHeading(root, markdown, 6)).toBe(root.children[2])
+  })
+
+  it('verifies by text after link normalization', () => {
+    const markdown = '# See [the docs](https://example.com)'
+    const root = dom('<h1>See <a href="https://example.com">the docs</a></h1>')
+
+    expect(findRenderedHeading(root, markdown, 1)).toBe(root.children[0])
+  })
+
+  it('multi-line setext headings match exactly against the full rendered text', () => {
+    // The AST parser reports the whole promoted paragraph as heading text
+    // (anchored to its first line), matching the DOM — no suffix tolerance
+    // needed or applied.
+    const markdown = 'First line\nsecond line\n===\n'
+    const root = dom('<h1>First line second line</h1>')
+
+    expect(findRenderedHeading(root, markdown, 1)).toBe(root.children[0])
+  })
+
+  it('falls back to occurrence matching when an unparsed heading skews ordinals', () => {
+    // Raw HTML headings in markdown render as real elements but are invisible
+    // to any markdown AST — residual skew the verification layer must catch.
+    const markdown = '# Usage\n\n<h1>Injected</h1>\n\n# Usage'
+    const root = dom('<h1>Usage</h1><h1>Injected</h1><h1>Usage</h1>')
+
+    // Ordinal for the 2nd parsed Usage points at "Injected" — text verification
+    // rejects it, and occurrence matching (2nd "Usage" h1) recovers.
+    expect(findRenderedHeading(root, markdown, 5)).toBe(root.children[2])
+  })
+
+  it('does not bind to a superstring when verification fails', () => {
+    // "Usage" must not resolve to "Advanced Usage" — a dead click is safer
+    // than a wrong jump.
+    const markdown = '# Usage\n\n<h1>Injected</h1>'
+    const root = dom('<h1>Advanced Usage</h1><h1>Injected</h1>')
+
+    expect(findRenderedHeading(root, markdown, 1)).toBeNull()
+  })
+
+  it('rejects an ordinal whose level does not match', () => {
+    const markdown = '## Title'
+    const root = dom('<h1>Title</h1>')
+
+    expect(findRenderedHeading(root, markdown, 1)).toBeNull()
+  })
+
+  it('returns null for a line with no parsed heading (safe no-op)', () => {
+    const markdown = '# Alpha\n\ntext'
+    const root = dom('<h1>Alpha</h1><p>text</p>')
+
+    expect(findRenderedHeading(root, markdown, 3)).toBeNull()
+    expect(findRenderedHeading(root, markdown, 99)).toBeNull()
+  })
+
+  it('empty headings resolve by ordinal but never by text fallback', () => {
+    const markdown = '# \n\n# ' // two empty headings
+    const root = dom('<h1></h1><h1></h1>')
+
+    expect(findRenderedHeading(root, markdown, 3)).toBe(root.children[1])
+  })
+})

--- a/frontend/src/utils/headingNavigation.ts
+++ b/frontend/src/utils/headingNavigation.ts
@@ -1,0 +1,65 @@
+/**
+ * Resolves a markdown heading (identified by source line) to its element in
+ * the rendered (Milkdown/ProseMirror) reading view, for ToC click navigation.
+ *
+ * Strategy: candidate-set parity, then ordinal matching, with verification.
+ * Both sides of the match come from the same grammar — markdownHeadings.ts
+ * parses with remark, the engine the renderer itself uses — so ordinals agree
+ * by construction for everything markdown-native. The DOM candidate set
+ * excludes headings nested in blockquotes/list items (the source side reports
+ * root-level headings only — e.g. `# Usage` / `> # Usage` / `# Usage` would
+ * otherwise make "the 2nd parsed Usage" resolve to the blockquote's copy).
+ * Residual skew is still possible from constructs no markdown AST sees (raw
+ * HTML `<h1>` blocks render as real headings); text+level verification catches
+ * it, with an occurrence-counting fallback. If that fails too, callers no-op —
+ * a dead click is safer than silently scrolling to the wrong section.
+ */
+import { parseMarkdownHeadings } from './markdownHeadings'
+
+/** Collapse whitespace so parsed text compares against DOM textContent. */
+function normalize(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+export function findRenderedHeading(
+  root: Element,
+  markdown: string,
+  targetLine: number,
+): HTMLElement | null {
+  const headings = parseMarkdownHeadings(markdown)
+  const targetIdx = headings.findIndex((h) => h.line === targetLine)
+  if (targetIdx === -1) return null
+  const target = headings[targetIdx]
+  const targetText = normalize(target.text)
+  const targetTag = `H${target.level}`
+
+  const candidates = Array.from(
+    root.querySelectorAll<HTMLElement>('h1, h2, h3, h4, h5, h6'),
+  ).filter((el) => {
+    const nested = el.closest('blockquote, li')
+    return nested === null || !root.contains(nested)
+  })
+
+  const ordinal = candidates[targetIdx]
+  if (
+    ordinal !== undefined &&
+    ordinal.tagName === targetTag &&
+    normalize(ordinal.textContent ?? '') === targetText
+  ) {
+    return ordinal
+  }
+
+  // Fallback: the Nth same-text-same-level rendered heading, where N is this
+  // heading's occurrence index among the parsed headings. Exact text only —
+  // any tolerance here could bind "Usage" to "Advanced Usage".
+  let occurrence = 0
+  for (let i = 0; i < targetIdx; i++) {
+    if (headings[i].level === target.level && normalize(headings[i].text) === targetText) {
+      occurrence++
+    }
+  }
+  const sameHeadings = candidates.filter(
+    (el) => el.tagName === targetTag && normalize(el.textContent ?? '') === targetText,
+  )
+  return sameHeadings[occurrence] ?? null
+}

--- a/frontend/src/utils/markdownHeadings.test.ts
+++ b/frontend/src/utils/markdownHeadings.test.ts
@@ -149,11 +149,14 @@ describe('parseMarkdownHeadings', () => {
   })
 
   it('test__parseMarkdownHeadings__hash_alone_on_line', () => {
-    // `#` followed by end of line (no space) — not a heading per ATX spec
-    // But `# ` (hash then space) is a heading with empty text
+    // Per CommonMark, the opening # sequence may be followed by spaces/tabs OR
+    // by end of line — so a bare `#` IS a valid empty heading. (A previous
+    // hand-rolled parser asserted the opposite; the renderer emits an h1 for
+    // it, so ordinal parity requires reporting it.)
     const text = '#\n# '
     const result = parseMarkdownHeadings(text)
     expect(result).toEqual([
+      { level: 1, text: '', line: 1 },
       { level: 1, text: '', line: 2 },
     ])
   })
@@ -226,11 +229,13 @@ describe('parseMarkdownHeadings', () => {
     ])
   })
 
-  it('test__parseMarkdownHeadings__preserves_asterisks_in_word_context', () => {
+  it('test__parseMarkdownHeadings__intraword_asterisks_are_emphasis_like_the_renderer', () => {
+    // CommonMark allows intraword emphasis with * (unlike _): 2*3*4 renders
+    // as 2<em>3</em>4, so the parsed text must match the rendered textContent.
     const text = '## 2*3*4'
     const result = parseMarkdownHeadings(text)
     expect(result).toEqual([
-      { level: 2, text: '2*3*4', line: 1 },
+      { level: 2, text: '234', line: 1 },
     ])
   })
 
@@ -281,6 +286,131 @@ describe('parseMarkdownHeadings', () => {
       { level: 1, text: 'Introduction', line: 1 },
       { level: 2, text: 'Details', line: 8 },
       { level: 3, text: 'Conclusion', line: 16 },
+    ])
+  })
+
+  // ---------------------------------------------------------------------------
+  // Setext headings (Text / === or ---) — rendered as h1/h2 by remark, so the
+  // parser must report them for reading-mode ordinal parity.
+  // ---------------------------------------------------------------------------
+
+  it('test__parseMarkdownHeadings__setext_h1_and_h2_anchor_to_the_text_line', () => {
+    const text = 'Title\n===\n\nSection\n---'
+    expect(parseMarkdownHeadings(text)).toEqual([
+      { level: 1, text: 'Title', line: 1 },
+      { level: 2, text: 'Section', line: 4 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__single_char_setext_underline_counts', () => {
+    expect(parseMarkdownHeadings('Title\n=')).toEqual([{ level: 1, text: 'Title', line: 1 }])
+    expect(parseMarkdownHeadings('Title\n-')).toEqual([{ level: 2, text: 'Title', line: 1 }])
+  })
+
+  it('test__parseMarkdownHeadings__setext_underline_indented_up_to_three_spaces', () => {
+    expect(parseMarkdownHeadings('Title\n   ===')).toEqual([{ level: 1, text: 'Title', line: 1 }])
+  })
+
+  it('test__parseMarkdownHeadings__setext_text_is_cleaned_of_inline_formatting', () => {
+    expect(parseMarkdownHeadings('**Bold** title\n===')).toEqual([
+      { level: 1, text: 'Bold title', line: 1 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__dashes_after_blank_line_are_not_a_heading', () => {
+    // A `---` with no paragraph above is a thematic break, not an underline.
+    expect(parseMarkdownHeadings('Paragraph\n\n---')).toEqual([])
+  })
+
+  it('test__parseMarkdownHeadings__dashes_after_list_blockquote_or_atx_are_not_a_heading', () => {
+    expect(parseMarkdownHeadings('- item\n---')).toEqual([])
+    expect(parseMarkdownHeadings('> quote\n---')).toEqual([])
+    // After an ATX heading, --- is a thematic break (the heading still parses).
+    expect(parseMarkdownHeadings('# Heading\n---')).toEqual([
+      { level: 1, text: 'Heading', line: 1 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__dashes_after_a_thematic_break_are_not_a_heading', () => {
+    expect(parseMarkdownHeadings('Text\n---\n---')).toEqual([
+      { level: 2, text: 'Text', line: 1 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__setext_inside_code_fence_is_ignored', () => {
+    expect(parseMarkdownHeadings('```\nTitle\n===\n```')).toEqual([])
+  })
+
+  // ---------------------------------------------------------------------------
+  // Indented ATX headings — CommonMark allows up to 3 leading spaces.
+  // ---------------------------------------------------------------------------
+
+  it('test__parseMarkdownHeadings__atx_indented_up_to_three_spaces', () => {
+    const text = ' # One\n  ## Two\n   ### Three'
+    expect(parseMarkdownHeadings(text)).toEqual([
+      { level: 1, text: 'One', line: 1 },
+      { level: 2, text: 'Two', line: 2 },
+      { level: 3, text: 'Three', line: 3 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__atx_indented_four_spaces_is_code_not_heading', () => {
+    expect(parseMarkdownHeadings('    # Not a heading')).toEqual([])
+  })
+
+  // ---------------------------------------------------------------------------
+  // Link/image normalization — the rendered DOM shows only the text, and the
+  // ToC panel should too.
+  // ---------------------------------------------------------------------------
+
+  it('test__parseMarkdownHeadings__reduces_links_to_their_text', () => {
+    expect(parseMarkdownHeadings('# See [the docs](https://example.com) here')).toEqual([
+      { level: 1, text: 'See the docs here', line: 1 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__images_contribute_nothing_like_dom_textContent', () => {
+    // An <img> contributes nothing to textContent, and reading-mode
+    // verification compares parsed text against textContent — so alt text is
+    // deliberately excluded (this is why the parser doesn't use
+    // mdast-util-to-string, which would include it).
+    expect(parseMarkdownHeadings('# Logo ![alt text](img.png) end')).toEqual([
+      { level: 1, text: 'Logo end', line: 1 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__link_with_bold_text_fully_cleaned', () => {
+    expect(parseMarkdownHeadings('# [**Bold link**](url)')).toEqual([
+      { level: 1, text: 'Bold link', line: 1 },
+    ])
+  })
+
+  // ---------------------------------------------------------------------------
+  // CommonMark forms the renderer emits that a hand-rolled parser missed —
+  // each of these shifts reading-mode ordinals if skipped or mis-texted.
+  // ---------------------------------------------------------------------------
+
+  it('test__parseMarkdownHeadings__closing_sequence_is_stripped', () => {
+    // ATX closing sequences: `# Title #` renders as "Title".
+    expect(parseMarkdownHeadings('# Title #\n## Sub ##')).toEqual([
+      { level: 1, text: 'Title', line: 1 },
+      { level: 2, text: 'Sub', line: 2 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__tab_after_hashes_is_a_heading', () => {
+    expect(parseMarkdownHeadings('#\tTitle')).toEqual([
+      { level: 1, text: 'Title', line: 1 },
+    ])
+  })
+
+  it('test__parseMarkdownHeadings__multiline_setext_reports_full_text_anchored_to_first_line', () => {
+    // A multi-line paragraph promoted by an underline is ALL heading text, and
+    // the heading anchors to the paragraph's FIRST line (navigation should
+    // land at the heading's start). Both differ from the previous hand-rolled
+    // parser, which reported only the last line — deliberate behavior change.
+    expect(parseMarkdownHeadings('First line\nsecond line\n===')).toEqual([
+      { level: 1, text: 'First line second line', line: 1 },
     ])
   })
 })

--- a/frontend/src/utils/markdownHeadings.ts
+++ b/frontend/src/utils/markdownHeadings.ts
@@ -1,70 +1,85 @@
+/**
+ * Extracts top-level headings from markdown source for the ToC sidebar and
+ * reading-mode navigation.
+ *
+ * Parses with the REAL markdown parser (remark) rather than approximating the
+ * grammar by hand. This matters beyond convenience: reading-mode navigation
+ * resolves headings by ordinal against the rendered DOM, so the set of
+ * headings this module reports must match what the renderer emits — and the
+ * renderer (Milkdown) parses through the same remark/mdast engine with the
+ * same GFM extension (`@milkdown/kit/preset/gfm` is remark-gfm-backed). Using
+ * remark here makes that parity true by construction: setext headings, closing
+ * sequences (`# Title #`), bare `#` (a valid empty heading), indentation
+ * rules, and inline normalization all agree with the renderer for free.
+ *
+ * Only ROOT-LEVEL headings are reported — headings nested in blockquotes or
+ * list items are excluded, matching the candidate-set filter in
+ * headingNavigation.ts.
+ */
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import type { Heading, PhrasingContent } from 'mdast'
+
 export interface MarkdownHeading {
   level: number // 1-6
-  text: string // cleaned heading text (no #s, no inline markers)
-  line: number // 1-based line number in the document
+  text: string // heading text as the rendered DOM would show it (no markers)
+  /**
+   * 1-based source line the heading starts on. For setext headings this is the
+   * FIRST line of the promoted paragraph (a multi-line paragraph is all
+   * heading text) — navigation should land at the heading's start.
+   */
+  line: number
 }
 
-const HEADING_RE = /^(#{1,6}) /
-const FENCE_OPEN_RE = /^(\s*)((`{3,})|(~{3,}))/
+// Module-scope processor: `parse()` runs only the syntax layer (no
+// transformers), and remark-gfm participates at that layer via its micromark
+// extensions, so one frozen processor serves every call.
+const processor = unified().use(remarkParse).use(remarkGfm)
 
 /**
- * Strip common inline markdown markers from heading text.
- * Handles wrapping pairs: **bold**, *italic*, __bold__, _italic_,
- * `code`, ~~strikethrough~~, ==highlight==
+ * Flatten a heading's inline nodes the way DOM textContent would.
+ * Deliberately NOT mdast-util-to-string: that includes image alt text, which
+ * an <img> does not contribute to textContent — and reading-mode verification
+ * compares this output against textContent. Images and raw inline HTML
+ * contribute nothing; everything else contributes its literal value or its
+ * children's flattening.
  */
-function cleanInlineFormatting(text: string): string {
-  // Order matters: longer markers first to avoid partial matches
-  return text
-    .replace(/\*\*(.+?)\*\*/g, '$1')
-    .replace(/~~(.+?)~~/g, '$1')
-    .replace(/==(.+?)==/g, '$1')
-    .replace(/__(.+?)__/g, '$1')
-    .replace(/(?<!\w)\*(.+?)\*(?!\w)/g, '$1')
-    .replace(/(?<!\w)_(.+?)_(?!\w)/g, '$1')
-    .replace(/`(.+?)`/g, '$1')
+function flattenInlineText(nodes: PhrasingContent[]): string {
+  let out = ''
+  for (const node of nodes) {
+    if (node.type === 'image' || node.type === 'imageReference' || node.type === 'html') continue
+    if ('value' in node) {
+      out += node.value
+    } else if ('children' in node) {
+      out += flattenInlineText(node.children as PhrasingContent[])
+    }
+  }
+  return out
+}
+
+/**
+ * Strip Milkdown's non-GFM inline extensions so parsed text matches what its
+ * renderer shows. Milkdown's commonmark preset includes remarkMarker
+ * (==highlight== → <mark>), which plain remark-gfm leaves as literal text.
+ */
+function stripNonStandardMarks(text: string): string {
+  return text.replace(/==(.+?)==/g, '$1')
 }
 
 export function parseMarkdownHeadings(text: string): MarkdownHeading[] {
-  const lines = text.split('\n')
+  const root = processor.parse(text)
   const headings: MarkdownHeading[] = []
-
-  let inCodeFence = false
-  let fenceChar = ''
-  let fenceLength = 0
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
-
-    // Check for code fence boundaries
-    const fenceMatch = line.match(FENCE_OPEN_RE)
-    if (fenceMatch) {
-      const char = fenceMatch[2][0] // '`' or '~'
-      const len = (char === '`' ? fenceMatch[3] : fenceMatch[4]).length
-
-      if (!inCodeFence) {
-        inCodeFence = true
-        fenceChar = char
-        fenceLength = len
-      } else if (char === fenceChar && len >= fenceLength) {
-        // Closing fence: same char, at least as many chars, nothing else after (allow trailing whitespace)
-        const afterFence = line.slice(fenceMatch[0].length)
-        if (afterFence.trim() === '') {
-          inCodeFence = false
-        }
-      }
-      continue
-    }
-
-    if (inCodeFence) continue
-
-    const headingMatch = line.match(HEADING_RE)
-    if (headingMatch) {
-      const level = headingMatch[1].length
-      const rawText = line.slice(headingMatch[0].length)
-      const cleaned = cleanInlineFormatting(rawText.trim())
-      headings.push({ level, text: cleaned, line: i + 1 })
-    }
+  for (const node of root.children) {
+    if (node.type !== 'heading') continue
+    const heading = node as Heading
+    const line = heading.position?.start.line
+    if (line === undefined) continue
+    headings.push({
+      level: heading.depth,
+      text: stripNonStandardMarks(flattenInlineText(heading.children)).replace(/\s+/g, ' ').trim(),
+      line,
+    })
   }
-
   return headings
 }

--- a/frontend/src/utils/markdownStyleExtension.test.ts
+++ b/frontend/src/utils/markdownStyleExtension.test.ts
@@ -1061,3 +1061,106 @@ describe('link dom event handlers', () => {
     })
   })
 })
+
+describe('callouts (CodeMirror editor)', () => {
+  // DOM-level assertions against a real EditorView so the full path
+  // (parseLine → buildDecorations threading → line classes) is exercised.
+  const views: EditorView[] = []
+  afterEach(() => {
+    views.forEach((v) => v.destroy())
+    views.length = 0
+  })
+  function mount(doc: string): HTMLElement {
+    const parent = document.createElement('div')
+    document.body.appendChild(parent)
+    const view = new EditorView({
+      state: EditorState.create({ doc, extensions: [markdownStyleExtension] }),
+      parent,
+    })
+    views.push(view)
+    return view.dom
+  }
+  function lineClasses(dom: HTMLElement): string[] {
+    return Array.from(dom.querySelectorAll('.cm-line')).map((el) => el.className)
+  }
+
+  it('marker line gets the variant class and the marker span is dimmed', () => {
+    const dom = mount('> [!WARNING] heads up')
+    expect(dom.querySelector('.cm-md-callout-warning')).not.toBeNull()
+    const marker = dom.querySelector('.cm-md-callout-marker')
+    expect(marker?.textContent).toBe('[!WARNING]')
+  })
+
+  it('continuation lines inherit the variant; the blockquote end resets it', () => {
+    const dom = mount('> [!note]\n> body line\n\nplain text')
+    const classes = lineClasses(dom)
+    expect(classes[0]).toContain('cm-md-callout-note')
+    expect(classes[1]).toContain('cm-md-callout-note')
+    expect(classes[2] ?? '').not.toContain('cm-md-callout')
+    expect(classes[3] ?? '').not.toContain('cm-md-callout')
+  })
+
+  it('a plain quote before a marker does not inherit; a marker mid-document starts fresh', () => {
+    const dom = mount('> plain quote\n\n> [!tip]\n> tip body')
+    const classes = lineClasses(dom)
+    expect(classes[0]).not.toContain('cm-md-callout')
+    expect(classes[2]).toContain('cm-md-callout-tip')
+    expect(classes[3]).toContain('cm-md-callout-tip')
+  })
+
+  it('blank-line-separated callouts are both recognized (opener-gate overcorrection guard)', () => {
+    // Two callouts separated by a blank unquoted line are two blockquotes —
+    // both markers sit on quote-opening lines and both must be honored.
+    const dom = mount('> [!warning] a\n\n> [!tip] b')
+    const classes = lineClasses(dom)
+    expect(classes[0]).toContain('cm-md-callout-warning')
+    expect(classes[0]).not.toContain('cm-md-callout-tip')
+    expect(classes[2]).toContain('cm-md-callout-tip')
+    expect(classes[2]).not.toContain('cm-md-callout-warning')
+  })
+
+  it('a marker-shaped line inside an open quote is body text (parity with rendered pipelines)', () => {
+    // `> [!note]` / `> [!caution]` / `> body` with no blank line is ONE
+    // blockquote; the rendered pipelines read only its opening, so the second
+    // marker is literal body text there. The editor must agree: one note
+    // callout throughout, no caution restart, no dim-marker on line 2.
+    const dom = mount('> [!note]\n> [!caution]\n> body')
+    const classes = lineClasses(dom)
+    expect(classes[0]).toContain('cm-md-callout-note')
+    expect(classes[1]).toContain('cm-md-callout-note')
+    expect(classes[2]).toContain('cm-md-callout-note')
+    expect(dom.querySelector('[class*="cm-md-callout-caution"]')).toBeNull()
+    const markers = dom.querySelectorAll('.cm-md-callout-marker')
+    expect(markers).toHaveLength(1)
+    expect(markers[0].textContent).toBe('[!note]')
+  })
+
+  it('a marker after a plain quote line is body text, not a callout', () => {
+    // The case that distinguishes the quote-opener gate from a naive
+    // "no active callout" check: `> plain` / `> [!note]` is one blockquote
+    // whose opening has no marker — the rendered pipelines show a plain
+    // quote, so the editor must too.
+    const dom = mount('> plain\n> [!note] later')
+    expect(dom.querySelector('[class*="cm-md-callout"]')).toBeNull()
+  })
+
+  it('unknown keywords render as a plain blockquote', () => {
+    const dom = mount('> [!FOO] nope')
+    expect(lineClasses(dom)[0]).toContain('cm-md-blockquote')
+    expect(dom.querySelector('[class*="cm-md-callout"]')).toBeNull()
+  })
+
+  it('markers inside fenced code blocks are ignored', () => {
+    const dom = mount('```\n> [!warning] not a callout\n```')
+    expect(dom.querySelector('[class*="cm-md-callout"]')).toBeNull()
+  })
+
+  it('parseLine surfaces the variant and marker span for blockquote lines', () => {
+    expect(parseLine('> [!Danger] x', false)).toMatchObject({
+      type: 'blockquote',
+      callout: 'caution',
+      calloutMarker: { from: 2, to: 11 },
+    })
+    expect(parseLine('> quote', false)).toEqual({ type: 'blockquote' })
+  })
+})

--- a/frontend/src/utils/markdownStyleExtension.test.ts
+++ b/frontend/src/utils/markdownStyleExtension.test.ts
@@ -1155,6 +1155,36 @@ describe('callouts (CodeMirror editor)', () => {
     expect(dom.querySelector('[class*="cm-md-callout"]')).toBeNull()
   })
 
+  it('first/last callout lines get the vertical-spacing classes', () => {
+    const dom = mount('> [!note]\n> middle\n> end\n\ntext')
+    const classes = lineClasses(dom)
+    expect(classes[0]).toContain('cm-md-callout-first')
+    expect(classes[0]).not.toContain('cm-md-callout-last')
+    expect(classes[1]).not.toContain('cm-md-callout-first')
+    expect(classes[1]).not.toContain('cm-md-callout-last')
+    expect(classes[2]).toContain('cm-md-callout-last')
+    expect(classes[2]).not.toContain('cm-md-callout-first')
+  })
+
+  it('a code fence directly after a callout terminates it (lookahead fence state)', () => {
+    // The last-line lookahead re-parses line i+1 with the fence state as of
+    // line i. A blockquote line can't change that state (parseLine checks
+    // fences first), so a fence opener on i+1 is classified 'code-start' and
+    // correctly ends the callout — the exact assumption the lookahead rests on.
+    const dom = mount('> [!note]\n> body\n```\ncode\n```')
+    const classes = lineClasses(dom)
+    expect(classes[1]).toContain('cm-md-callout-last')
+    expect(classes[2]).not.toContain('cm-md-callout')
+    expect(classes[3]).not.toContain('cm-md-callout')
+  })
+
+  it('a single-line callout is both first and last', () => {
+    const dom = mount('> [!tip] compact')
+    const classes = lineClasses(dom)
+    expect(classes[0]).toContain('cm-md-callout-first')
+    expect(classes[0]).toContain('cm-md-callout-last')
+  })
+
   it('parseLine surfaces the variant and marker span for blockquote lines', () => {
     expect(parseLine('> [!Danger] x', false)).toMatchObject({
       type: 'blockquote',

--- a/frontend/src/utils/markdownStyleExtension.ts
+++ b/frontend/src/utils/markdownStyleExtension.ts
@@ -21,6 +21,7 @@ import {
 } from '@codemirror/view'
 import type { DecorationSet, ViewUpdate } from '@codemirror/view'
 import { RangeSetBuilder } from '@codemirror/state'
+import { matchCalloutMarkerInLine, type CalloutVariant } from './callouts'
 
 // Shared styles for dimmed markdown syntax (brackets, #, >, etc.)
 const SYNTAX_COLOR = '#c0c5cc'
@@ -37,6 +38,11 @@ interface LineInfo {
   // the start of the line through the marker's trailing space. Used for
   // hanging-indent so wrapped lines align with the content start (KAN-111).
   prefixLen?: number
+  // Blockquote lines whose first line is a callout marker (`> [!WARNING]`):
+  // the resolved variant plus the marker's span for dim styling. The variant
+  // is carried across the quote's continuation lines by buildDecorations.
+  callout?: CalloutVariant
+  calloutMarker?: { from: number; to: number }
 }
 
 function parseLine(text: string, inCodeBlock: boolean): LineInfo | null {
@@ -77,8 +83,18 @@ function parseLine(text: string, inCodeBlock: boolean): LineInfo | null {
   const numberedMatch = text.match(/^\s*\d+\.\s/)
   if (numberedMatch) return { type: 'numbered', prefixLen: numberedMatch[0].length }
 
-  // Blockquotes
-  if (text.startsWith('>')) return { type: 'blockquote' }
+  // Blockquotes — a first-line callout marker upgrades the quote to a callout
+  if (text.startsWith('>')) {
+    const marker = matchCalloutMarkerInLine(text)
+    if (marker) {
+      return {
+        type: 'blockquote',
+        callout: marker.variant,
+        calloutMarker: { from: marker.markerStart, to: marker.markerEnd },
+      }
+    }
+    return { type: 'blockquote' }
+  }
 
   // Horizontal rules (---, ***, ___)
   if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(text)) return { type: 'hr' }
@@ -421,6 +437,11 @@ const headerSyntaxMark = Decoration.mark({ class: 'cm-md-header-syntax' })
 // Decoration for blockquote syntax
 const blockquoteSyntaxMark = Decoration.mark({ class: 'cm-md-blockquote-syntax' })
 
+// Decoration for a callout marker (`[!WARNING]`). Styled dim but kept visible
+// and editable — this is a live editor, and hiding the marker behind a replace
+// decoration would fight the cursor. The rendered views hide it instead.
+const calloutMarkerMark = Decoration.mark({ class: 'cm-md-callout-marker' })
+
 /**
  * Find checklist syntax in a line (e.g., "- [ ] " or "- [x] ").
  * Returns the range to gray out, or null if not a checklist line.
@@ -646,6 +667,11 @@ function buildDecorations(
 ): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>()
   let inCodeBlock = false
+  // Callout state, threaded line-by-line like inCodeBlock: an OPENING marker
+  // line starts a callout whose variant applies to the quote's continuation
+  // lines until the blockquote ends (any non-blockquote line, including blank).
+  let currentCallout: CalloutVariant | null = null
+  let prevLineWasBlockquote = false
 
   for (let i = 1; i <= view.state.doc.lines; i++) {
     const line = view.state.doc.line(i)
@@ -658,12 +684,32 @@ function buildDecorations(
       inCodeBlock = false
     }
 
+    // A marker is honored only on a line that OPENS a quote in the line model
+    // (the previous line wasn't a `>` line) — matching the rendered pipelines,
+    // which read only a blockquote's opening. A marker-shaped line deeper
+    // inside an open quote is plain body text there, so here it must neither
+    // (re)set the variant nor receive marker styling. Note "opens" is
+    // line-model scoped (contiguous explicitly-quoted lines), not AST-level —
+    // see the callout parity comment at the theme section.
+    const opensLineBlockquote = info?.type === 'blockquote' && !prevLineWasBlockquote
+    if (info?.type === 'blockquote') {
+      if (opensLineBlockquote && info.callout !== undefined) {
+        currentCallout = info.callout
+      }
+    } else {
+      currentCallout = null
+    }
+    prevLineWasBlockquote = info?.type === 'blockquote'
+
     // Add line decoration if we have line-level styling
     if (info) {
       let lineClass = `cm-md-${info.type}`
       // Add checked class for completed checklist items
       if (info.type === 'checklist' && info.checked) {
         lineClass += ' cm-md-checklist-checked'
+      }
+      if (info.type === 'blockquote' && currentCallout !== null) {
+        lineClass += ` cm-md-callout-${currentCallout}`
       }
       const spec: Parameters<typeof Decoration.line>[0] = { class: lineClass }
       if (info.prefixLen !== undefined) {
@@ -723,6 +769,16 @@ function buildDecorations(
       const blockquoteSyntax = findBlockquoteSyntax(line.text)
       if (blockquoteSyntax) {
         inlineDecorations.push({ from: line.from + blockquoteSyntax.from, to: line.from + blockquoteSyntax.to, decoration: blockquoteSyntaxMark })
+      }
+
+      // Callout marker (`[!WARNING]`) — dim, visible, editable. Only on the
+      // quote-opening line; a marker-shaped continuation line is body text.
+      if (opensLineBlockquote && info?.calloutMarker !== undefined) {
+        inlineDecorations.push({
+          from: line.from + info.calloutMarker.from,
+          to: line.from + info.calloutMarker.to,
+          decoration: calloutMarkerMark,
+        })
       }
 
       // Bold - must be processed before italic to handle ** vs *
@@ -1064,6 +1120,26 @@ const markdownBaseTheme = EditorView.theme({
   '.cm-md-blockquote': {
     borderLeft: '3px solid #6366f1',
     paddingLeft: '1em',
+  },
+
+  // Callouts (`> [!WARNING]` etc.) — variant-tinted left rule + background.
+  // Compound selectors so they override the base blockquote border. The marker
+  // text stays visible/editable in the editor (dim, below); the rendered views
+  // do the icon-and-title treatment.
+  //
+  // Parity boundary: callout detection follows this extension's LINE-BASED
+  // blockquote model (unindented `>`, backtick fences only, no lazy
+  // continuation) — deliberately no more structurally accurate than the quote
+  // styling it extends. The rendered pipelines (real markdown ASTs) are ground
+  // truth; residual differences are recorded in the editor-improvements plan.
+  '.cm-md-blockquote.cm-md-callout-note': { borderLeftColor: '#3b82f6', backgroundColor: '#eff6ff' },
+  '.cm-md-blockquote.cm-md-callout-tip': { borderLeftColor: '#22c55e', backgroundColor: '#f0fdf4' },
+  '.cm-md-blockquote.cm-md-callout-important': { borderLeftColor: '#a855f7', backgroundColor: '#faf5ff' },
+  '.cm-md-blockquote.cm-md-callout-warning': { borderLeftColor: '#f59e0b', backgroundColor: '#fffbeb' },
+  '.cm-md-blockquote.cm-md-callout-caution': { borderLeftColor: '#ef4444', backgroundColor: '#fef2f2' },
+  '.cm-md-callout-marker, .cm-md-callout-marker *': {
+    color: `${SYNTAX_COLOR} !important`,
+    fontSize: SYNTAX_FONT_SIZE,
   },
 
   // Code blocks - light gray background, monospace font

--- a/frontend/src/utils/markdownStyleExtension.ts
+++ b/frontend/src/utils/markdownStyleExtension.ts
@@ -710,6 +710,17 @@ function buildDecorations(
       }
       if (info.type === 'blockquote' && currentCallout !== null) {
         lineClass += ` cm-md-callout-${currentCallout}`
+        // First/last lines of the callout block get vertical spacing (see the
+        // theme). Last = the quote ends after this line; a fence opener like
+        // `\`\`\`` isn't a blockquote line, so it correctly terminates too.
+        if (opensLineBlockquote) {
+          lineClass += ' cm-md-callout-first'
+        }
+        const isLastLine = i === view.state.doc.lines ||
+          parseLine(view.state.doc.line(i + 1).text, inCodeBlock)?.type !== 'blockquote'
+        if (isLastLine) {
+          lineClass += ' cm-md-callout-last'
+        }
       }
       const spec: Parameters<typeof Decoration.line>[0] = { class: lineClass }
       if (info.prefixLen !== undefined) {
@@ -1140,6 +1151,21 @@ const markdownBaseTheme = EditorView.theme({
   '.cm-md-callout-marker, .cm-md-callout-marker *': {
     color: `${SYNTAX_COLOR} !important`,
     fontSize: SYNTAX_FONT_SIZE,
+  },
+  // Vertical breathing room for callout blocks. Padding grows the tinted area
+  // inside the block; the TRANSPARENT border creates the gap between the tint
+  // and surrounding text — deliberately not margin, which CodeMirror excludes
+  // from line-height measurement (cursor/scroll geometry would drift).
+  // backgroundClip keeps the tint from painting under the transparent border.
+  '.cm-md-callout-first': {
+    borderTop: '0.4em solid transparent',
+    paddingTop: '0.3em',
+    backgroundClip: 'padding-box',
+  },
+  '.cm-md-callout-last': {
+    borderBottom: '0.4em solid transparent',
+    paddingBottom: '0.3em',
+    backgroundClip: 'padding-box',
   },
 
   // Code blocks - light gray background, monospace font

--- a/frontend/src/utils/readingModeCache.test.ts
+++ b/frontend/src/utils/readingModeCache.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the per-item reading-mode LRU (see readingModeCache.ts).
+ *
+ * The LRU semantics matter here: reads must refresh recency (an item opened
+ * daily but toggled once must not age out), and only reading-mode-ON entries
+ * are stored (off = the miss-default, so it carries no information).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  readReadingMode,
+  touchReadingMode,
+  writeReadingMode,
+  clearReadingModeCache,
+} from './readingModeCache'
+
+const STORAGE_KEY = 'tiddly:reading-mode'
+
+/** Advance the mocked clock so every write gets a strictly increasing timestamp. */
+let clock = 1_000
+function tick(): void {
+  clock += 1_000
+  vi.spyOn(Date, 'now').mockReturnValue(clock)
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  clock = 1_000
+  tick()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('readingModeCache — basic behavior', () => {
+  it('miss reads as false; write(true) → hit; write(false) deletes the entry', () => {
+    expect(readReadingMode('a')).toBe(false)
+
+    writeReadingMode('a', true)
+    expect(readReadingMode('a')).toBe(true)
+
+    writeReadingMode('a', false)
+    expect(readReadingMode('a')).toBe(false)
+    // Off is not stored — the map has no entry at all, not a `false` value.
+    expect(localStorage.getItem(STORAGE_KEY)).not.toContain('"a"')
+  })
+
+  it('write(false) on a miss is a no-op (does not create storage)', () => {
+    writeReadingMode('never-seen', false)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('touch on a miss does not create an entry', () => {
+    touchReadingMode('never-toggled')
+    expect(readReadingMode('never-toggled')).toBe(false)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('clearReadingModeCache removes everything', () => {
+    writeReadingMode('a', true)
+    writeReadingMode('b', true)
+    clearReadingModeCache()
+    expect(readReadingMode('a')).toBe(false)
+    expect(readReadingMode('b')).toBe(false)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})
+
+describe('readingModeCache — corrupted or foreign stored data', () => {
+  it.each([
+    ['unparseable JSON', 'not-json{{{'],
+    ['a JSON array', '[1,2,3]'],
+    ['a JSON scalar', '42'],
+    ['null', 'null'],
+  ])('treats %s as empty and stays writable', (_label: string, raw: string) => {
+    localStorage.setItem(STORAGE_KEY, raw)
+    expect(readReadingMode('a')).toBe(false)
+
+    writeReadingMode('a', true)
+    expect(readReadingMode('a')).toBe(true)
+  })
+
+  it('drops non-numeric entry values but keeps valid ones', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ good: 5, bad: 'x', worse: null }))
+    expect(readReadingMode('good')).toBe(true)
+    expect(readReadingMode('bad')).toBe(false)
+    expect(readReadingMode('worse')).toBe(false)
+  })
+
+  it('swallows storage write errors', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    expect(() => writeReadingMode('a', true)).not.toThrow()
+    expect(() => touchReadingMode('a')).not.toThrow()
+  })
+
+  it('swallows storage read errors', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage blocked')
+    })
+    expect(readReadingMode('a')).toBe(false)
+    expect(() => writeReadingMode('a', true)).not.toThrow()
+  })
+})
+
+describe('readingModeCache — LRU eviction', () => {
+  function fill(prefix: string, count: number): void {
+    for (let i = 0; i < count; i++) {
+      tick()
+      writeReadingMode(`${prefix}${i}`, true)
+    }
+  }
+
+  it('caps at 100 entries', () => {
+    fill('item-', 150)
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, number>
+    expect(Object.keys(stored)).toHaveLength(100)
+    // The newest 100 survive; the oldest 50 were evicted.
+    expect(readReadingMode('item-149')).toBe(true)
+    expect(readReadingMode('item-49')).toBe(false)
+    expect(readReadingMode('item-50')).toBe(true)
+  })
+
+  it('a read-refreshed entry survives; the oldest untouched entry is evicted', () => {
+    // The decisive LRU sequence: fill with A plus 99 others (at cap), refresh A
+    // by touching it, insert ONE new entry → A survives and the oldest
+    // UNTOUCHED entry (other-0) is evicted. (Note: "touch A then insert 100
+    // more" would correctly evict A — that is not a valid survival test.)
+    tick()
+    writeReadingMode('A', true)
+    fill('other-', 99)
+
+    tick()
+    touchReadingMode('A')
+    tick()
+    writeReadingMode('new-entry', true)
+
+    expect(readReadingMode('A')).toBe(true)
+    expect(readReadingMode('new-entry')).toBe(true)
+    expect(readReadingMode('other-0')).toBe(false)
+    expect(readReadingMode('other-1')).toBe(true)
+  })
+
+  it('without the read refresh, the same sequence evicts A (recency is real, not insertion order)', () => {
+    tick()
+    writeReadingMode('A', true)
+    fill('other-', 99)
+
+    tick()
+    writeReadingMode('new-entry', true)
+
+    expect(readReadingMode('A')).toBe(false)
+    expect(readReadingMode('other-0')).toBe(true)
+  })
+
+  it('re-writing an existing entry refreshes it without evicting anyone', () => {
+    tick()
+    writeReadingMode('A', true)
+    fill('other-', 99) // at cap: A + 99
+
+    tick()
+    writeReadingMode('A', true) // already present — refresh, no eviction needed
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, number>
+    expect(Object.keys(stored)).toHaveLength(100)
+    expect(readReadingMode('A')).toBe(true)
+    expect(readReadingMode('other-0')).toBe(true)
+  })
+
+  it('toggle-off then re-toggle-on reinserts with fresh recency', () => {
+    tick()
+    writeReadingMode('A', true)
+    tick()
+    writeReadingMode('A', false)
+    expect(readReadingMode('A')).toBe(false)
+
+    tick()
+    writeReadingMode('A', true)
+    expect(readReadingMode('A')).toBe(true)
+  })
+})

--- a/frontend/src/utils/readingModeCache.ts
+++ b/frontend/src/utils/readingModeCache.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-item reading-mode memory — a small localStorage-backed LRU.
+ *
+ * Reading mode used to be transient component state, silently reset by any
+ * editor remount (page refresh, conflict refresh, version restore, bookmark
+ * content fetch). It is deliberately NOT a global preference like wrap/line
+ * numbers/mono font: a global would leak one item's mode to all items (opening
+ * the create view as a blank read-only preview) and would regress prompts,
+ * which intentionally default to raw source. So: remembered per item.
+ *
+ * Storage shape — one key holding `{ [itemId]: lastUsedMs }`:
+ * - Only items with reading mode ON are stored. "Off" is indistinguishable from
+ *   the miss-default (markdown), so storing it would carry no information; the
+ *   cap therefore bounds only meaningful overrides.
+ * - The timestamp doubles as LRU recency. Both reads (opening an item in
+ *   reading mode) and writes refresh it — read-refresh matters because an item
+ *   the user *opens* daily but toggled only once must not age out.
+ * - The cap (100) is a runaway guard, not a UX mechanism: it's sized so
+ *   eviction effectively never fires in normal use, because an eviction here is
+ *   a visible behavior change ("this note used to open rendered") with an
+ *   invisible cause. ~50 bytes/entry makes the cap generosity, not necessity.
+ *
+ * Like the draft keys (see drafts.ts), entries are not namespaced by user;
+ * account deletion clears the whole cache via clearReadingModeCache(), invoked
+ * as a discrete teardown step in AuthProvider (NOT via clearAllDrafts, which is
+ * prefix-scoped to draft keys).
+ */
+
+const STORAGE_KEY = 'tiddly:reading-mode'
+
+const MAX_ENTRIES = 100
+
+type CacheMap = Record<string, number>
+
+/** Load the map, treating missing/corrupted/foreign-shaped data as empty. */
+function loadMap(): CacheMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    const map: CacheMap = {}
+    for (const [id, ts] of Object.entries(parsed)) {
+      if (typeof ts === 'number' && Number.isFinite(ts)) {
+        map[id] = ts
+      }
+    }
+    return map
+  } catch {
+    return {}
+  }
+}
+
+function saveMap(map: CacheMap): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Storage unavailable/full — reading-mode memory is best-effort.
+  }
+}
+
+/** Whether the item was last left in reading mode. Pure read (no recency touch). */
+export function readReadingMode(itemId: string): boolean {
+  return loadMap()[itemId] !== undefined
+}
+
+/**
+ * Refresh an existing entry's recency (no-op on miss — a touch must never
+ * *create* an entry, or every opened item would count as reading-mode-on).
+ */
+export function touchReadingMode(itemId: string): void {
+  const map = loadMap()
+  if (map[itemId] === undefined) return
+  map[itemId] = Date.now()
+  saveMap(map)
+}
+
+/** Persist a toggle: on → insert/refresh (evicting LRU past the cap), off → delete. */
+export function writeReadingMode(itemId: string, on: boolean): void {
+  const map = loadMap()
+  if (!on) {
+    if (map[itemId] === undefined) return
+    delete map[itemId]
+    saveMap(map)
+    return
+  }
+  if (map[itemId] === undefined) {
+    const ids = Object.keys(map)
+    if (ids.length >= MAX_ENTRIES) {
+      ids.sort((a, b) => map[a] - map[b])
+      for (const evict of ids.slice(0, ids.length - (MAX_ENTRIES - 1))) {
+        delete map[evict]
+      }
+    }
+  }
+  map[itemId] = Date.now()
+  saveMap(map)
+}
+
+/** Remove the whole cache. Account-deletion teardown (see AuthProvider). */
+export function clearReadingModeCache(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Best-effort, mirroring clearAllDrafts — must never throw out of teardown.
+  }
+}


### PR DESCRIPTION
## Summary

Three editor improvements, shipped together because they all land in the same subsystem (`ContentEditor` → `CodeMirrorEditor` and the read-only Milkdown preview it hosts in reading mode): reading mode is remembered per item, the table of contents works in reading mode and on public share pages, and GitHub-style callouts render across all three markdown pipelines.

Design and rationale: [`docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md`](docs/implementation_plans/2026-08-05-editor-reading-mode-toc-callouts.md), which also records the limitations knowingly left in place.

## Changes

**Reading mode persists per item.** It was transient component state, silently reset by any editor remount — page refresh, conflict refresh, version restore, bookmark content fetch. Now backed by a localStorage LRU (cap 100, stores only "on" entries) keyed by item ID, seeded at state initialization rather than by a live effect so the create→edit transition can't flip the mode mid-session. A mode toggled while creating is migrated on save, gated by an explicit create-provenance prop: an in-place `undefined → id` transition alone does not prove a create, since navigating from `/new` to an existing item delivers that item's id one render before the corrective remount. Public share views neither read nor write the cache.

**Table of contents in reading mode and on public pages.** Heading clicks previously targeted the hidden CodeMirror view; they now resolve against the rendered DOM via candidate-set parity (top-level headings only), ordinal matching with text verification, and an occurrence-counting fallback that no-ops rather than jumping to the wrong section. Heading extraction moved from a hand-rolled regex parser to `remark-parse` + `remark-gfm` — the same mdast engine the renderer uses — making source/render agreement true by construction and fixing real divergences (bare `#`, closing sequences, setext, intraword emphasis, link text). Public note and prompt pages gained the sidebar; shared bookmarks deliberately did not, since scraped bookmark content is formatting-stripped and headingless.

**Callouts.** `> [!WARNING]` and friends render in the editor, in reading mode, and on docs pages. One shared module owns the grammar so the three pipelines cannot drift on accepted spellings — optional `!`, case-insensitive, aliases (`info`, `hint`, `danger`, …), optional inline titles, unknown keywords failing soft to a plain blockquote. The docs pipeline adopts that grammar while keeping its existing three-style palette, so shipped docs pages are visually unchanged. A marker is honored only on a blockquote's opening line, matching what the AST-based renderers do.

**Public share page layout.** The ToC sidebar overlapped shared content. The offset now applies to the outer page box so header, content, and footer shrink together, and the footer sizes its layout from its own width via container queries rather than the viewport — it previously kept a fixed-height single-row layout while its links wrapped, clipping them.

**Content and docs.** Changelog entries for August (this work) and July (account management, which shipped in July but was never announced); `OAuth for MCP` moved from roadmap Backlog to Shipped, where it belonged since July; callout syntax documented in the notes prose and `llms-app-usage.txt`; a stale comment claiming account deletion must not be exposed corrected.

## Testing

`make frontend-verify` — 3,695 tests across 193 files, lint and typecheck clean. Frontend-only; no backend, auth, or API surface touched, so the deployed security suite is unaffected.

Manual verification covered the areas automated tests cannot see, and found four defects now fixed: callout block spacing, a blank band above custom callout titles, sidebar/content overlap, and the clipped footer. Worth noting for reviewers: the layout defects all passed a fully green suite, since jsdom computes no layout — the added guards assert containment and the absence of specific class patterns, which is the honest limit of what unit tests can pin here.

## Impact

No breaking changes. Two new direct dependencies, `remark-parse` and `unified`, both already present transitively via Milkdown — measured main-bundle delta is zero.

The footer change is shared, so the app and docs footers also switch to container-based sizing. This is intended: an app settings page at ~1024px with the left sidebar expanded gives the footer a ~736px box, which previously forced a one-row layout into a space too small for it.

Known limitations, recorded in the plan rather than fixed: the editor's line-based markdown model still diverges from the renderers on indented blockquotes, tilde fences, and lazy continuation (pre-existing, affects every construct it styles); the sidebar's 600px content reserve only holds from ~880px viewport up (shared with the app's own layout); and a reading-mode toggle made while *creating a bookmark* is not persisted, since bookmark creation navigates away rather than transitioning in place.
