### PR TITLE
Publish scopes_supported in MCP OAuth protected-resource metadata

### DIFF
--- a/backend/src/shared/mcp_oauth.py
+++ b/backend/src/shared/mcp_oauth.py
@@ -5,8 +5,9 @@ MCP servers (the server side of the MCP authorization spec).
 Three pieces, used identically by both MCP servers:
 
 1. **Protected-resource metadata** (RFC 9728): each server advertises its own
-   canonical MCP endpoint URL as the OAuth ``resource`` and points at Clerk as the
-   authorization server, so an OAuth-capable client can discover where to sign in.
+   canonical MCP endpoint URL as the OAuth ``resource``, points at Clerk as the
+   authorization server, and publishes the scopes to request, so an OAuth-capable
+   client can discover where and how to sign in.
 2. **A presence-only 401 gate**: a request to the MCP endpoint with no
    ``Authorization: Bearer`` header is rejected *before* MCP dispatch with a
    ``WWW-Authenticate`` pointer to the metadata (RFC 9728 §5.1) — the signal that
@@ -56,6 +57,24 @@ MCP_PATH = "/mcp"
 # served too as a compatibility fallback for less-strict clients.
 WELL_KNOWN_PATH = "/.well-known/oauth-protected-resource"
 WELL_KNOWN_PATH_SUFFIXED = f"{WELL_KNOWN_PATH}{MCP_PATH}"
+
+# Scopes a client should request (RFC 9728 ``scopes_supported``), published so a
+# spec-conforming OAuth client can derive both its DCR registration and its authorize
+# request from discovery instead of guessing. This is not a permission matrix: the
+# backend has no per-scope permission model (`decode_clerk_jwt` never reads
+# ``scope``; identity is ``sub``) and accepts a valid token whatever scopes it
+# carries. These scopes govern the client's credential lifecycle and interop, and
+# both servers share one list. ``offline_access``: without it Clerk issues no
+# refresh token, so authorization cannot outlive the 24h access token (lifetime
+# recorded in `decode_clerk_jwt`'s docstring) — once it expires, only a fresh
+# browser sign-in gets a new one. ``openid`` keeps a DCR client's registered scopes
+# aligned with the OIDC-shaped authorize requests most clients send (the mismatch
+# behind the known ChatGPT connector issue). ``profile``/``email`` are deliberately
+# absent: observed Clerk ``at+jwt`` access tokens carry no email/profile claims
+# regardless of scope — consistent with standard OIDC, where those scopes shape ID
+# tokens and userinfo, neither of which the backend reads — and JIT user creation
+# accepts a null email.
+SCOPES_SUPPORTED = ("openid", "offline_access")
 
 # CORS for browser-based connectors. A cross-origin request that sets Authorization
 # is a "non-simple" request and preflights; the preflight (OPTIONS) never carries the
@@ -286,6 +305,7 @@ def build_protected_resource_metadata(config: OAuthConfig) -> dict[str, Any]:
         "resource": config.resource_url,
         "authorization_servers": [config.authorization_server],
         "bearer_methods_supported": ["header"],
+        "scopes_supported": list(SCOPES_SUPPORTED),
     }
 
 

--- a/backend/tests/mcp_server/test_oauth_discovery.py
+++ b/backend/tests/mcp_server/test_oauth_discovery.py
@@ -54,6 +54,7 @@ async def test__protected_resource_metadata__served_with_cors(path: str) -> None
     assert body["resource"] == EXPECTED_RESOURCE
     assert body["authorization_servers"] == [EXPECTED_AUTH_SERVER]
     assert body["bearer_methods_supported"] == ["header"]
+    assert body["scopes_supported"] == ["openid", "offline_access"]
     assert response.headers["access-control-allow-origin"] == "*"
 
 

--- a/backend/tests/prompt_mcp_server/test_oauth_discovery.py
+++ b/backend/tests/prompt_mcp_server/test_oauth_discovery.py
@@ -60,6 +60,7 @@ async def test__protected_resource_metadata__served_at_suffixed_path() -> None:
     assert body["resource"] == EXPECTED_RESOURCE
     assert body["authorization_servers"] == [EXPECTED_AUTH_SERVER]
     assert body["bearer_methods_supported"] == ["header"]
+    assert body["scopes_supported"] == ["openid", "offline_access"]
 
 
 async def test__protected_resource_metadata__served_at_root_compat_path() -> None:

--- a/backend/tests/security/test_mcp_oauth_surface.py
+++ b/backend/tests/security/test_mcp_oauth_surface.py
@@ -30,7 +30,7 @@ WELL_KNOWN = [
     "/.well-known/oauth-protected-resource/mcp",
     "/.well-known/oauth-protected-resource",
 ]
-_SPEC_FIELDS = {"resource", "authorization_servers", "bearer_methods_supported"}
+_SPEC_FIELDS = {"resource", "authorization_servers", "bearer_methods_supported", "scopes_supported"}
 
 
 @pytest.mark.parametrize("app", APPS)

--- a/backend/tests/shared/test_mcp_oauth.py
+++ b/backend/tests/shared/test_mcp_oauth.py
@@ -287,6 +287,7 @@ def test__build_protected_resource_metadata__has_spec_fields() -> None:
         "resource": RESOURCE_URL,
         "authorization_servers": ["https://clerk.example.com"],
         "bearer_methods_supported": ["header"],
+        "scopes_supported": ["openid", "offline_access"],
     }
 
 
@@ -319,6 +320,7 @@ async def test__metadata_endpoint__get_returns_metadata(path: str) -> None:
         "resource": RESOURCE_URL,
         "authorization_servers": ["https://clerk.example.com"],
         "bearer_methods_supported": ["header"],
+        "scopes_supported": ["openid", "offline_access"],
     }
     assert response.headers["access-control-allow-origin"] == "*"
 


### PR DESCRIPTION
## Summary

Both MCP servers now advertise which OAuth scopes a client should request (`openid`, `offline_access`) in their RFC 9728 protected-resource metadata. Spec-conforming OAuth clients derive both their dynamic-client-registration scopes and their authorize-request scopes from this field; without it, a generic client either omits scopes (Clerk then issues no refresh token, forcing a browser re-sign-in after every ~24h access-token expiry) or falls back to the authorization server's full scope list (over-asking for `private_metadata`/`public_metadata`). This unblocks Switchboard's OAuth prompt-provider integration and may resolve the known ChatGPT-connector registration/authorize scope mismatch.

## Changes

- `backend/src/shared/mcp_oauth.py`: new `SCOPES_SUPPORTED` constant (immutable tuple; the builder emits a fresh list per call) added to `build_protected_resource_metadata`, which both servers share. The comment records the scope rationale — notably why `profile`/`email` are excluded: the backend has no per-scope permission model, `at+jwt` access tokens carry no email/profile claims regardless of scope, and JIT user creation accepts a null email.
- Test updates in lockstep: exact-equality assertions in `tests/shared/test_mcp_oauth.py`, the exact key-set (no-leakage) check in `tests/security/test_mcp_oauth_surface.py`, and one field assertion in each server's `test_oauth_discovery.py`.

## Impact

**No breaking changes for existing state**: already-registered OAuth clients and issued tokens are unaffected; the metadata document remains public and unauthenticated by design, and the new field contains no sensitive data.

**Deployment considerations — required post-deploy verification.** The mechanism that may fix ChatGPT can also break currently-working connectors: a client that derives its *registration* from this (narrower) list but hardcodes a wider *authorize* request will hit Clerk's scope-mismatch rejection. Because DCR registers one OAuth application per connection attempt, the exposure is **new and re-established connections** — including a user removing and re-adding a connector. Therefore, immediately after deploy, verify by **adding tiddly as a fresh connection** in each client (Claude web/Desktop, Claude Code, Codex, MCP Inspector, ChatGPT) — re-testing an existing connector proves nothing, since its registration predates this change.

- **ChatGPT check**: a negative result has a specific known mode — its registration aligns with the new list but its authorize request still hardcodes `email profile`, so the mismatch persists with different scopes. If negative, the next documented lever is carrying `scope` in the 401 `WWW-Authenticate` challenge (generated from the same constant), deliberately not included here pending evidence it's needed.
- **Rollback** is self-healing: drop the `scopes_supported` key and redeploy — no data migration, no effect on issued tokens. Users who hit a failed connection during the window simply reconnect afterward; the stale narrow registration becomes an inert unused app, consistent with existing per-attempt DCR behavior.
